### PR TITLE
MUMUP-1175 Hide the "rate" link in Marketplace entries for now.

### DIFF
--- a/partials/marketplace-portlet.html
+++ b/partials/marketplace-portlet.html
@@ -11,7 +11,7 @@
     <a class="btn btn-default btn-launch" href="{{portlet.maxUrl}}"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
   </div><br>
   <rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
-   | <a href="">rate</a>
+   <!-- | <a href="">rate</a> -->
   <p>{{portlet.description}}</p>
   <div class="category-list" ng-click="showDetails = !showDetails">
     <a ng-repeat="category in portlet.categories" href="#" class="category-links">{{category}}</a>


### PR DESCRIPTION
Hide the "| rate" link in Marketplace entries because UI for users to set ratings is not yet available.

Left in as a comment so design can easily be restored when that feature is added.

In the meantime, hiding it helps keep the code more real.  Sets truer expectations in demoing and testing.

Retains display of existing rating since that much _is_ working right now: to the extent that there's rating data in the database, it's reflected in the JSON and those ratings are reflected in star display.

Before:

![with_rate_link](https://cloud.githubusercontent.com/assets/952283/4470117/e2ae5b9c-491f-11e4-99d0-91608a767884.png)

After:

![without_rate_link](https://cloud.githubusercontent.com/assets/952283/4470119/e8d4f936-491f-11e4-9d62-376c04772b1d.png)
