### PR TITLE
MUMUP-1152 : minor issue with overlap on short screens

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -8209,8 +8209,8 @@ button:focus {
   font-weight: 200;
 }
 .page-content {
-  position: relative;
-  top: 48px;
+  padding-top: 48px;
+  padding-bottom: 17px;
 }
 .portlet-title div {
   position: relative;

--- a/css/buckyless/cards.less
+++ b/css/buckyless/cards.less
@@ -232,8 +232,8 @@
   font-weight: 200;
 }
 .page-content {
-  position: relative;
-  top: 48px;
+  padding-top: 48px;
+  padding-bottom: 17px;
 }
 .portlet-title div {
   position: relative;

--- a/css/buckyless/deleted-styles.less
+++ b/css/buckyless/deleted-styles.less
@@ -153,10 +153,7 @@ li a:hover {
   background: #b70101;
   padding-bottom: 30px;
 }
-.page-content {
-  position: relative;
-  top: 55px;
-}
+
 .portlet-title span:hover {
   opacity: 1.0;
   cursor: pointer;


### PR DESCRIPTION
### Before

![image](https://cloud.githubusercontent.com/assets/3534544/4508152/1eef2baa-4b13-11e4-9ec3-5db5265f8c3f.png)
### After

![image](https://cloud.githubusercontent.com/assets/3534544/4508160/2e370f56-4b13-11e4-902f-de10d4dd7042.png)

Knowledge : overflow of divs can be an issue if you use relative.
