### PR TITLE
MUMUP-1177 : Redirect on unauthenticated sessions

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,7 @@
 <script type="text/javascript" src="js/main/main-service.js"></script>
 <script type="text/javascript" src="js/main/main-directives.js"></script>
 <script type="text/javascript" src="js/controllers.js"></script>
+<script type="text/javascript" src="js/services.js"></script>
 <script type="text/javascript" src="js/notifications/notification-controllers.js"></script>
 <script type="text/javascript" src="js/directives.js"></script>
 <script type="text/javascript" src="js/marketplace/marketplace-service.js"></script>

--- a/js/angular-page.js
+++ b/js/angular-page.js
@@ -4,6 +4,7 @@
     'ui.bootstrap',
     'portal.misc.controllers',
     'portal.misc.directives',
+    'portal.misc.service',
     'portal.main.controllers',
     'portal.main.service',
     'portal.main.directives',

--- a/js/main/main-controllers.js
+++ b/js/main/main-controllers.js
@@ -3,12 +3,17 @@
 (function() {
   var app = angular.module('portal.main.controllers', []);
 
-  app.controller('MainController', [ '$http', function($http) {
+  app.controller('MainController', [ '$http', 'errorService', function($http, errorService) {
     var store = this;
     store.data = [];
-    $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').success(function(data) {
-      store.data = data;
-    });
+    $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').then(
+      function(result) {
+        store.data = result.data;
+      } ,
+      function(reason){
+       errorService.redirectUser(reason.status, 'layoutDoc call');
+      }
+    );
     this.directToPortlet = function directToPortlet(url) {
       $location.path(url);
     }
@@ -24,7 +29,7 @@
                   $('#portlet-id-'+ nodeId).parent().remove();
                 },
                 error: function(request, text, error) {
-                  //$('#up-notification').noty({text: request.response, type: 'error'});
+                  
                 }
             });
       };
@@ -37,9 +42,8 @@
   app.controller('SessionCheckController', [ 'mainService', function(mainService) {
     var that = this;
     that.user = [];
-    mainService.getUser().then(function(data){
-      that.user = data;
-      console.log(data);
+    mainService.getUser().then(function(result){
+      that.user = result.data.person;
     });
   }]);
 

--- a/js/main/main-service.js
+++ b/js/main/main-service.js
@@ -3,20 +3,16 @@
 (function() {
 var app = angular.module('portal.main.service', []);
 
-app.factory('mainService', function($http) {
+app.factory('mainService', function($http, errorService) {
   var prom = $http.get('/portal/api/session.json');
 
   var getUser = function() {
-  	return prom.then(function(result) {
-  		var data = result.data;
-		if(data === null || data.person.userName === "guest") {
-			//redirecting to login screen
-      $('body').append("<form id='redirectForm' action='/portal/Login'></form>");
-      $('#redirectForm').submit();
-		} else {
-			return data.person;
-		}
-	});
+  	return prom.success(
+      function(data, status) { //success function
+    		return data.person;
+	  }).error(function(data, status) { // failure function
+      errorService.redirectUser(status, "Get User Info");
+    });
   }
 
   return {

--- a/js/marketplace/marketplace-service.js
+++ b/js/marketplace/marketplace-service.js
@@ -3,7 +3,7 @@
 (function() {
 var app = angular.module('portal.marketplace.service', []);
 
-app.factory('marketplaceService', function($http) {
+app.factory('marketplaceService', function($http, errorService) {
 
   var filter = "";
 
@@ -15,9 +15,14 @@ app.factory('marketplaceService', function($http) {
       return filter;
   };
   var getPortlets = function () {
-    return $http.get('/portal/api/marketplace/entries.json').then(function(result) {
-      return result.data;
-    });
+    return $http.get('/portal/api/marketplace/entries.json', {cache : true}).then(
+      function(result) {
+        return result.data;
+      }, 
+      function(reason){
+        errorService.redirectUser(reason.status, "Marketplace entries fetch");
+      }
+    );
   };
 
   var getPortlet = function() {

--- a/js/services.js
+++ b/js/services.js
@@ -1,0 +1,26 @@
+'use strict';
+
+(function() {
+var app = angular.module('portal.misc.service', []);
+
+app.factory('errorService', function($http, $modal) {
+  
+  var redirectUser = function(status, caller) {
+  	if(status === 0 || status === 302) {
+  		//got a redirect call from shib due to session timeout or /web direct hit
+  		console.log("redirect happening");
+    	console.log(status);
+    	$('body').append("<form id='redirectForm' action='/portal/Login'><input type='hidden' name='profile' value='bucky'/></form>");
+    	$('#redirectForm').submit();
+    } else {
+    	conosole.warn("Strange behavior from " + caller +". Returned status code : " + status);
+    }
+  }
+
+  return {
+    redirectUser: redirectUser
+  }
+
+});
+
+})();


### PR DESCRIPTION
If we try to hit /portal/api/\* on a shib protected it throws a 302 for shib. This then runs the error function for the promise.  We are handling this by redirecting to /portal/Login (for 302's only). If there is another error, it logs a warn to the console with who through it.

Eventually I think it would be neat to have a modal shib login or something, but this will do for beta 1.
