### PR TITLE
MUMPO-209 rm empty-src placeholder img tag on Click to add more! invite.

### DIFF
--- a/partials/marketplace-light.html
+++ b/partials/marketplace-light.html
@@ -1,7 +1,7 @@
 <div class="portlet-div">
     <a href="#/marketplace">
         <div class="portlet-title text-center">
-            <h1><img src="">Click to add more!</h1>
+            <h1>Click to add more!</h1>
                 <div>
                     <i class="fa fa-times portlet-options" ng-click="mainCtrl.removePortlet($index,mainCtrl.data.layout)"></i>
                 </div>


### PR DESCRIPTION
The "Marketplace light" representation on the landing page is a virtual Favorite that is an invitation to click to add more.

That virtual favorite had an empty-src image tag, causing a broken image under Firefox e.g.  This changeset drops that src-less image.  It can of course be re-added when there's an image to display there.

Before:

![broken_image_under_firefox_before](https://cloud.githubusercontent.com/assets/952283/4526971/fd9abe30-4d63-11e4-8c43-b6ba7eb431bb.png)

After:

![no_image_at_all_after](https://cloud.githubusercontent.com/assets/952283/4526973/01605b1a-4d64-11e4-939c-2eaaaeca8e5a.png)
