### PR TITLE
MUMPO-250: In vertical orientation on iPad, header cut off

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -8237,7 +8237,7 @@ div.table {
   width: 100%;
   height: 100%;
 }
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   div.table {
     margin-top: 20px;
   }
@@ -8813,7 +8813,7 @@ span:focus {
     display: none;
   }
 }
-@media (max-width: 769px) {
+@media (max-width: 767px) {
   .beta-sidebar {
     display: none;
   }
@@ -8998,7 +8998,7 @@ span:focus {
   border: 1px solid #ccc;
   margin-left: 10px;
 }
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .text {
     display: table;
     height: 50px;
@@ -9015,7 +9015,7 @@ span:focus {
     font-size: 0.85em;
   }
 }
-@media (min-width: 769px) {
+@media (min-width: 768px) {
   .beta-announcement .text {
     padding-left: 60px;
     padding-top: 5px;

--- a/css/buckyless/beta-header.less
+++ b/css/buckyless/beta-header.less
@@ -42,7 +42,7 @@
 }
 
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   .text {
     display:table;
     height:50px;
@@ -62,7 +62,7 @@
   }
 }
 
-@media (min-width: 769px) {
+@media (min-width: 768px) {
   .beta-announcement .text {
   	padding-left : 60px;
   	padding-top: 5px;

--- a/css/buckyless/cards.less
+++ b/css/buckyless/cards.less
@@ -259,17 +259,17 @@
 
 div.table {
   display : table;
-  width: 100%; 
+  width: 100%;
   height : 100%;
 }
 
-@media (max-width: 768px) {
+@media (max-width: 767px) {
   div.table {
     margin-top : 20px;
   }
 }
 
 div.table-cell {
-  display : table-cell; 
+  display : table-cell;
   vertical-align : middle;
 }

--- a/css/buckyless/responsive.less
+++ b/css/buckyless/responsive.less
@@ -6,7 +6,7 @@
     display:none;
   }
 }
-@media (max-width:769px) {
+@media (max-width:767px) {
   .beta-sidebar {
     display:none;
   }

--- a/partials/beta-header.html
+++ b/partials/beta-header.html
@@ -13,7 +13,7 @@
 		      		Feedback
 		      	</span>
 		      </a>
-		      <a class='btn btn-default' href="/portal/Login?profile=default">Back to classic <span class="hidden-xs">MyUW</span></a>
+		      <a class='btn btn-default' href="/portal/Login?profile=default">Back to classic <span class="hidden-xs hidden-sm">MyUW</span></a>
 	  	  </span>
 	    </div>
 


### PR DESCRIPTION
Fixed the formatting of the beta switcher on iPad.

At 768px: 
![image](https://cloud.githubusercontent.com/assets/1919535/4619835/be41fa9e-5319-11e4-9209-2cd8ebae31c0.png)
