### PR TITLE
MUMUP-1209: Suppress Add to Home and Launch buttons when user doesn't have access

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -7993,9 +7993,9 @@ button:focus {
   outline: none !important;
 }
 .btn-default:focus {
-  color: #bbb;
-  background-color: #fff;
-  border-color: #bbb;
+  color: #adadad;
+  background-color: #ffffff;
+  border-color: #adadad;
 }
 /* Card UI Styling */
 .page-content {
@@ -8630,14 +8630,14 @@ li.read:hover {
   color: #ffffff;
 }
 .cant-add {
-  background-color: #fff;
-  border: 1px solid #bbb;
-  color: #bbb;
+  background-color: #ffffff;
+  border: 1px solid #adadad;
+  color: #adadad;
 }
 .cant-add:hover {
-  background-color: #fff;
-  border: 1px solid #bbb;
-  color: #bbb;
+  background-color: #ffffff;
+  border: 1px solid #adadad;
+  color: #adadad;
   cursor: default;
 }
 .category-links {

--- a/css/buckyless/general.less
+++ b/css/buckyless/general.less
@@ -57,7 +57,7 @@ button:focus {
     outline: none !important;
 }
 .btn-default:focus {
-  color:#bbb;
-  background-color:#fff;
-  border-color:#bbb;
+  color:@grayscale5;
+  background-color:@white;
+  border-color:@grayscale5;
 }

--- a/css/buckyless/marketplace.less
+++ b/css/buckyless/marketplace.less
@@ -41,14 +41,14 @@
   color:@white;
 }
 .cant-add {
-  background-color:#fff;
-  border:1px solid #bbb;
-  color:#bbb;
+  background-color:@white;
+  border:1px solid @grayscale5;
+  color:@grayscale5;
 }
 .cant-add:hover {
-  background-color:#fff;
-  border:1px solid #bbb;
-  color:#bbb;
+  background-color:@white;
+  border:1px solid @grayscale5;
+  color:@grayscale5;
   cursor:default;
 }
 .category-links {

--- a/partials/marketplace-portlet.html
+++ b/partials/marketplace-portlet.html
@@ -7,20 +7,20 @@
   <div class="action-buttons" ng-click="showDetails = !showDetails">
 
     <!-- Add to Home button with access -->
-    <button class="btn btn-default btn-add fname-{{portlet.fname}}" ng-click="marketplaceCtrl.addToHome($index , portlet)" ng-show="portlet.canAdd === true">
+    <button class="btn btn-default btn-add fname-{{portlet.fname}}" ng-click="marketplaceCtrl.addToHome($index , portlet)" ng-show="portlet.canAdd">
       <span class="fa fa-plus"></span>Add to Home
     </button>
 
     <!-- Add to Home button without access -->
-    <button class="btn btn-default btn-add cant-add" ng-show="portlet.canAdd === false" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500">
+    <button class="btn btn-default btn-add cant-add" ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500">
       <span class="fa fa-plus"></span>Add to Home
     </button>
 
     <!-- Launch button with access -->
-    <a class="btn btn-default btn-launch" href="{{portlet.maxUrl}}" ng-show="portlet.canAdd === true"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
+    <a class="btn btn-default btn-launch" href="{{portlet.maxUrl}}" ng-show="portlet.canAdd"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
 
     <!-- Launch button without access -->
-    <a class="btn btn-default btn-launch cant-add" href ng-show="portlet.canAdd === false" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
+    <a class="btn btn-default btn-launch cant-add" href ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
 
   </div><br>
   <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
@@ -34,20 +34,20 @@
   <div class="action-buttons-mobile" ng-click="showDetails = !showDetails">
 
     <!-- Add to Home button with access on mobile-->
-    <button class="btn btn-default btn-add fname-{{portlet.fname}}" ng-click="marketplaceCtrl.addToHome($index , portlet)" ng-show="portlet.canAdd === true">
+    <button class="btn btn-default btn-add fname-{{portlet.fname}}" ng-click="marketplaceCtrl.addToHome($index , portlet)" ng-show="portlet.canAdd">
       <span class="fa fa-plus"></span>Add to Home
     </button>
 
     <!-- Add to Home button without access on mobile-->
-    <button class="btn btn-default btn-add cant-add" ng-show="portlet.canAdd === false" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500">
+    <button class="btn btn-default btn-add cant-add" ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500">
       <span class="fa fa-plus"></span>Add to Home
     </button>
 
     <!-- Launch button with access on mobile-->
-    <a class="btn btn-default btn-launch" href="{{portlet.maxUrl}}" ng-show="portlet.canAdd === true"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
+    <a class="btn btn-default btn-launch" href="{{portlet.maxUrl}}" ng-show="portlet.canAdd"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
 
     <!-- Launch button without access on mobile-->
-    <a class="btn btn-default btn-launch cant-add" href ng-show="portlet.canAdd === false" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
+    <a class="btn btn-default btn-launch cant-add" href ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
   </div>
 
   <div class="portlet-details">


### PR DESCRIPTION
A number of things added to improve the user experience:
- When you don't have access, the buttons are grayed out and the cursor changes to a default cursor
- The buttons are no longer functioning links, and won't go anywhere when the user doesn't have access
- A popover appears if the user hovers over the button for more than a half second, saying "You do not have access to this app" (suggestions for better text welcome)

ex.
![image](https://cloud.githubusercontent.com/assets/1919535/4652134/2f803c82-54a2-11e4-9e75-21ad267b9454.png)

Everything still the same when you do have access, as expected:

![image](https://cloud.githubusercontent.com/assets/1919535/4652176/b063ef24-54a2-11e4-8b1c-4bd94bf24a88.png)
