### PR TITLE
Explicitly declare marketplaceService dependencies.

### DIFF
--- a/js/marketplace/marketplace-service.js
+++ b/js/marketplace/marketplace-service.js
@@ -3,7 +3,7 @@
 (function() {
 var app = angular.module('portal.marketplace.service', []);
 
-app.factory('marketplaceService', function($http, miscService) {
+app.factory('marketplaceService', ['$http', 'miscService', function($http, miscService) {
 
   var filter = "";
 
@@ -40,6 +40,6 @@ app.factory('marketplaceService', function($http, miscService) {
     getPortlet: getPortlet
   }
 
-});
+}]);
 
 })();


### PR DESCRIPTION
Defense against mangling by eventual JS minimization.

For context see:
- https://docs.angularjs.org/tutorial/step_05 (A Note on Minification).
- https://docs.angularjs.org/guide/di

This is an improvement I inadvertently implemented in coding #34 , and while not needed for that and indeed not needed at all until we get to a minifying build, wanted to capture the good practice change.

There's a `$inject` alternative to this array syntax for proofing dependency injection against minification, but I read somewhere that this array syntax is the preferred approach.  Having trouble finding that reference as I write this pull request description; if it's important can doubtless dredge it up again.
