### PR TITLE
MUMMNG-963, MUMUP-1223: Make wrapping titles look better, and fix overlap of anchors

### DIFF
--- a/css/angular.css
+++ b/css/angular.css
@@ -8660,9 +8660,9 @@ button:focus {
   font-size: 0.85em;
 }
 .card-remove {
-  top: 8px;
+  top: 0px;
   position: absolute;
-  right: -3px;
+  right: 0px;
 }
 .add-more {
   padding: 15px;
@@ -8673,16 +8673,17 @@ button:focus {
 .add-more:hover {
   padding-left: 10px;
 }
-.portlet-title h1 img {
-  margin: 6px;
-  min-height: 1.5em;
+.portlet-title img {
+  position: relative;
+  width: 25px;
+  top: -4px;
+  margin-right: 10px;
 }
 .portlet-div {
   position: relative;
-  height: 130px;
+  height: 150px;
   background-color: #ffffff;
-  padding-bottom: 10px;
-  padding-left: 5px;
+  padding: 5px;
   border-bottom: 1px solid #ddd !important;
   border-right: 1px solid #ddd !important;
   box-model: border-box;
@@ -8703,31 +8704,35 @@ button:focus {
 .portlet-div .portlet-options {
   color: #aaa;
   font-size: 1.3em;
-  padding: 6px 8px;
+  padding: 8px 10px;
 }
 .portlet-div .portlet-options:hover {
   color: #333;
 }
 .portlet-content {
   padding: 0px 12px 0px 12px;
-  height: 100%;
+  height: 80px;
 }
 .portlet-title {
   margin: 0px;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
+  padding: 6px 30px 5px 12px;
 }
-.portlet-title h1 {
-  font-size: 1.6em;
+.portlet-title h1,
+.portlet-title i.fa {
+  font-size: 1.5em;
   color: #600;
   width: 100%;
   font-weight: 200;
   display: inline;
-  margin: 0px;
-  padding: 0px;
-  padding-top: 5px;
 }
-.portlet-title h1 span.fa {
+.portlet-title i,
+.portlet-title img {
+  margin-right: 10px;
+  font-size: 1.7em;
+}
+.portlet-title span.fa {
   width: 38px;
   height: 38px;
   font-size: 0.8em;

--- a/css/buckyless/cards.less
+++ b/css/buckyless/cards.less
@@ -146,9 +146,9 @@
 }
 
 .card-remove {
-  top: 8px;
+  top: 0px;
   position: absolute;
-  right: -3px;
+  right:0px;
 }
 
 .add-more {
@@ -160,16 +160,17 @@
 .add-more:hover {
   padding-left:10px;
 }
-.portlet-title h1 img {
-  margin: 6px;
-  min-height : 1.5em;
+.portlet-title img {
+  position:relative;
+  width:25px;
+  top:-4px;
+  margin-right:10px;
 }
 .portlet-div {
   position:relative;
-  height:130px;
+  height:150px;
   background-color: @white;
-  padding-bottom:10px;
-  padding-left:5px;
+  padding:5px;
   border-bottom: 1px solid #ddd !important;
   border-right:1px solid #ddd !important;
   box-model: border-box;
@@ -191,31 +192,37 @@
 .portlet-div .portlet-options {
   color:#aaa;
   font-size:1.3em;
-  padding:6px 8px;
+  padding:8px 10px;
 }
 .portlet-div .portlet-options:hover {
   color:#333;
 }
 .portlet-content {
   padding:0px 12px 0px 12px;
-  height:100%;
+  height:80px;
 }
 .portlet-title {
   margin: 0px;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
+  padding:6px 30px 5px 12px;
+
 }
-.portlet-title h1 {
-  font-size: 1.6em;
+.portlet-title h1, .portlet-title i.fa {
+  font-size: 1.5em;
   color: #600;
   width: 100%;
   font-weight: 200;
   display: inline;
-  margin: 0px;
-  padding:0px;
-  padding-top:5px;
 }
-.portlet-title h1 span.fa {
+.portlet-title i, .portlet-title img {
+  margin-right:10px;
+  font-size:1.7em;
+}
+.portlet-title img {
+
+}
+.portlet-title span.fa {
   width: 38px;
   height: 38px;
   font-size: 0.8em;

--- a/js/marketplace/marketplace-controller.js
+++ b/js/marketplace/marketplace-controller.js
@@ -99,8 +99,8 @@
       for(var p in $scope.portlets) {
         if ($scope.portlets[p].fname == $routeParams.fname) {
           $scope.portlet = $scope.portlets[p];
-        };
-      };
+        }
+      }
     });
 
 
@@ -111,7 +111,7 @@
 
     if($routeParams.fname !== null) {
       $scope.showDetails = true;
-    };
+    } 
 
 
 

--- a/partials/main.html
+++ b/partials/main.html
@@ -26,7 +26,7 @@
 
         <a href="{{portlet.url}}">
           <div class="portlet-title">
-              <h1><img src="{{portlet.iconUrl}}" ng-show="portlet.faIcon === null"><i class="fa {{portlet.faIcon}}" ng-show="portlet.faIcon != null"></i>  {{ portlet.title }}</h1>
+              <img src="{{portlet.iconUrl}}" ng-show="portlet.faIcon === null"><i class="fa {{portlet.faIcon}}" ng-show="portlet.faIcon != null"></i><h1>{{ portlet.title }}</h1>
           </div>
         </a>
         <div class='card-remove'>


### PR DESCRIPTION
Some marginal improvements in the styling of the wrapping titles. Looks a little cleaner. I still think all the text on the page makes it look a little cluttered, so I will return to the thought of hiding the description and showing it on hover when I have some time, possibly later this week. 

![image](https://cloud.githubusercontent.com/assets/1919535/4888208/5b16ee2a-638b-11e4-900f-c8691cb55da6.png)

Before:
![image](https://cloud.githubusercontent.com/assets/1919535/4888284/e12815ac-638b-11e4-9c99-b89dc3a1d396.png)
