### PR TITLE
MUMPO-362: Marketplace Details and Add to Home overlapping

### DIFF
--- a/src/main/webapp/css/buckyless/marketplace.less
+++ b/src/main/webapp/css/buckyless/marketplace.less
@@ -159,7 +159,7 @@
 .portlet-details {
   position:relative;
   float:right;
-  top:-20px;
+  top:0px;
   right:10px;
 }
 .portlet-details-div {

--- a/src/main/webapp/css/buckyless/responsive.less
+++ b/src/main/webapp/css/buckyless/responsive.less
@@ -59,9 +59,9 @@
     display:none;
   }
   .action-buttons-mobile {
-    margin:20px 0px 0px;
+    margin:30px 0px 0px;
     display:block;
-    text-align:right;
+    text-align:center;
   }
   .portlet-div {
     margin:0px 0px 0px 0px;
@@ -128,9 +128,9 @@
     height:40px;
   }
   .portlet-details {
-    float:left;
+    float:right;
     padding:0px 0px 0px 15px;
-    top:-20px;
+    top:10px;
   }
   .portlet-title {
     font-size:1em;

--- a/src/main/webapp/partials/marketplace-portlet.html
+++ b/src/main/webapp/partials/marketplace-portlet.html
@@ -38,13 +38,18 @@
 
   </div><br>
   <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
-    ( {{:: portlet.userRated }} rating<span ng-if="portlet.userRated !== 1">s</span> )
+    ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
   </span>
   <span> | <button ng-click="openRating('sm',portlet.fname, portlet.title)" class="btn btn-default">Rate</button></span>
   <p>{{::portlet.description}}</p>
   <div class="category-list" ng-click="showDetails = !showDetails">
     <a ng-repeat="category in portlet.categories" href="" ng-click="selectFilter('category',category)" class="category-links">{{::category}}</a>
+    <div class="portlet-details">
+      <a href="">Details <i class="fa fa-angle-down" ng-show="!showDetails"></i><i class="fa fa-angle-up" ng-show="showDetails"></i></a>
+    </div>
   </div>
+  
+  
 
   <!-- Action buttons for mobile -->
   <div class="action-buttons-mobile" ng-click="showDetails = !showDetails">
@@ -66,9 +71,7 @@
     <a class="btn btn-default btn-launch disabled" href ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
   </div>
 
-  <div class="portlet-details">
-    <a href="">Details <i class="fa fa-angle-down" ng-show="!showDetails"></i><i class="fa fa-angle-up" ng-show="showDetails"></i></a>
-  </div>
+  
 
   <!-- Portlet Details (hidden by default) -->
   <div ng-if="showDetails" class="row portlet-details-div">


### PR DESCRIPTION
Fixing the issue where on mobile, the Details link overlaps the Add to Home button.

Before:
![image](https://cloud.githubusercontent.com/assets/1919535/5570843/aaa34950-8f4d-11e4-82b6-d0f805e2d513.png)

After:
![image](https://cloud.githubusercontent.com/assets/1919535/5570847/bbaa1800-8f4d-11e4-996d-9a718de8a601.png)
