### PR TITLE
LUNCH : bring back notification demo in beta settings

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -4,7 +4,7 @@
   var app = angular.module('portal.main.controllers', []);
 
   app.controller('MainController', ['$localStorage','$scope', function($localStorage, $scope) {
-    $scope.$storage = $localStorage.$default( {showSidebar: true, sidebarQuicklinks: false, homeImg : "img/square.jpg"} );
+    $scope.$storage = $localStorage.$default( {showSidebar: true, sidebarQuicklinks: false, homeImg : "img/square.jpg", notificationsDemo : false} );
   } ]);
 
   /* Username */

--- a/angularjs-portal-frame/src/main/webapp/partials/header.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/header.html
@@ -26,15 +26,13 @@
              </ul>
              <ul class="nav navbar-nav hidden-xs bucky-nav-large">
                  <li>
-                   <!--
-                    <h3  ng-controller="NotificationController as notificationIconCtrl">
+                    <h3  ng-controller="NotificationController as notificationIconCtrl" ng-show="{{$storage.notificationsDemo}}">
                         <a title="click to view notifications" href="{{notificationIconCtrl.notificationUrl}}">
                             <div  class='notification-badge'>
                                 <span class="number-of-nots">{{notificationIconCtrl.count}}</span>
                             </div>
                         </a>
                     </h3>
-                  -->
                  </li>
                  <li>
                     <search></search>

--- a/angularjs-portal-home/src/main/webapp/js/angular-page.js
+++ b/angularjs-portal-home/src/main/webapp/js/angular-page.js
@@ -17,16 +17,16 @@
     'portal.main.directives',
     'portal.marketplace.controller',
     'portal.marketplace.service',
-    'portal.marketplace.directives'
-    /* 'portal.notification.controller',
-     * 'portal.notification.directives*/
+    'portal.marketplace.directives',
+    'portal.notification.controller',
+    'portal.notification.directives'
      ]);
  app.config(['$routeProvider',function($routeProvider, $locationProvider) {
 	 $routeProvider.
       when('/apps', {templateUrl: 'partials/marketplace.html'}).
       when('/features', {templateUrl: 'partials/features.html'}).
       when('/settings', {templateUrl: 'partials/settings.html'}).
-   /* when('/notifications', {templateUrl: 'partials/notifications-full.html'}). */
+      when('/notifications', {templateUrl: 'partials/notifications-full.html'}). 
       when('/apps/details/:fname', {templateUrl: 'partials/marketplace-details.html', controller:'MarketplaceDetailsController'}).
       when('/apps/search/:initFilter', {templateUrl: 'partials/marketplace.html'}).
       otherwise({templateUrl: 'partials/layout.html'});

--- a/angularjs-portal-home/src/main/webapp/js/notifications/notification-controllers.js
+++ b/angularjs-portal-home/src/main/webapp/js/notifications/notification-controllers.js
@@ -9,7 +9,8 @@
     store.notifications_full = [];
     store.count = 0;
     store.notificationUrl = '/portal/p/notification/';
-    store.fetchUrl = '/portal/p/notification/normal/GET-NOTIFICATIONS-UNCATEGORIZED.resource.uP';
+    //store.fetchUrl = '/portal/p/notification/normal/GET-NOTIFICATIONS-UNCATEGORIZED.resource.uP';
+    store.fetchUrl = '/web/samples/sample_notification.json';
 
     $http.get(store.fetchUrl)
     		.success(function(data) {

--- a/angularjs-portal-home/src/main/webapp/partials/layout.html
+++ b/angularjs-portal-home/src/main/webapp/partials/layout.html
@@ -9,24 +9,18 @@
     </div>
     <div ng-controller="NewStuffController as newStuffCtrl">
       <div ng-repeat="stuff in newStuffArray">
-      <div ng-if='newStuffCtrl.show(stuff)'  class="header-opaque">
-      <div><p class="new">New</p></div>
-      <div><h3>{{::stuff.title}}</h3></div>
-      <div class="description"><p>{{::stuff.shortDesc}}<a ng-if="stuff.link !== null" href="{{::stuff.link}}">Find out more.</a></p></div>
-      <!--<div class="remove"><i class="fa fa-remove" ng-click="mainCtrl.showNewStuff = false"></i></div>-->
+          <div ng-if='newStuffCtrl.show(stuff)'  class="header-opaque">
+              <div><p class="new">New</p></div>
+              <div><h3>{{::stuff.title}}</h3></div>
+              <div class="description"><p>{{::stuff.shortDesc}}<a ng-if="stuff.link !== null" href="{{::stuff.link}}">Find out more.</a></p></div>
+          </div>
       </div>
-      </div>
-      <!--<p class="news-section-title">News</p>
-      <h3 class="news-article-title">Initial Impression</h3>
-      <p class="news-article-description">First-year students take to the turf for W Project. <a href="https://www.youtube.com/watch?v=-I_Ia6wNwkA&feature=youtu.be">Read more <i class="fa fa-angle-right"></i></a></p>-->
     </div>
   </div>
-  <!--
-  <div class="col-xs-12 notification-section">
+  <div class="col-xs-12 notification-section" ng-show="{{$storage.notificationsDemo}}">
     <h3 class="home-section-header">Notifications</h3>
     <notifications></notifications>
   </div>
-  -->
   <div class="col-xs-12 no-padding portlet-section" ng-controller="LayoutController as layoutCtrl">
     <h3 class="home-section-header portlet-section-header">
         Your Favorites <span class='small-font-plus'>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -31,6 +31,17 @@
            <small>Shows the settings button to get to this page easier</small>
            
        </li>
+       <li class="portlet-container-home beta-card-style">
+           <h4>
+               <span class="btn-group">
+                   <label class="btn" ng-class="{'btn-success' : $storage.notificationsDemo, 'btn-danger' : !$storage.notificationsDemo }" ng-model="$storage.notificationsDemo" btn-radio="true">On</label>
+                   <label class="btn" ng-class="{'btn-success' : $storage.notificationsDemo, 'btn-danger' : !$storage.notificationsDemo }" ng-model="$storage.notificationsDemo" btn-radio="false">Off</label>
+               </span>
+               Notification Demo
+           </h4>
+           <small>Shows a demo of what the notifications could look like on the home page</small>
+           
+       </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>
         <li class="no-padding portlet-container-home  beta-card-style" style='text-align : center;'>


### PR DESCRIPTION
Remember that one time we had downtime and we started working on notifications, but then hid it because it wasn't ready for beta 1?  Lets un-hide this work with a beta flag.

![image](https://cloud.githubusercontent.com/assets/3534544/5668298/6f538600-9734-11e4-97a4-e90c3294e329.png)

![image](https://cloud.githubusercontent.com/assets/3534544/5668328/76fb31dc-9734-11e4-817e-7796344d8068.png)

![image](https://cloud.githubusercontent.com/assets/3534544/5668330/80821090-9734-11e4-9f25-2917c8308f89.png)
