### PR TITLE
MUMUP-1437: Prof pic to fix long name

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
@@ -112,15 +112,6 @@ a#myuw-header img {
   min-width: 2em;
 }
 
-.user-name-header {
-  color: @white;
-  min-width: 20em;
-  text-align: right;
-  padding:12px 30px 0px 0px;
-  font-size:1.2em;
-  font-weight:400;
-  letter-spacing:0.06em;
-}
 
 .portlet-title h1 i {
   margin: 6px;

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/responsive.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/responsive.less
@@ -167,6 +167,9 @@
   .mp-header {
     height:320px;
   }
+  .hide-sidebar-div, .profile-pic, .side-bar-nav hr {
+    display:none;
+  }
 
 
 }

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/sidebar.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/sidebar.less
@@ -14,7 +14,6 @@
   left:15px;
   ul.sidebar {
     margin-top:11px;
-    padding-top:25px;
     width:12em;
     box-shadow:none;
     width:100%;
@@ -63,14 +62,17 @@
   }
 }
 
-.hide-sidebar {
-  float:right;
-  color:@grayscale6;
-  cursor:pointer;
-  padding-right:10px;
-  font-size:20px;
-  &:hover {
-    color:@grayscale5;
+.hide-sidebar-div {
+  height:35px;
+  .hide-sidebar {
+    float:right;
+    color:@grayscale6;
+    cursor:pointer;
+    padding:5px;
+    font-size:20px;
+    &:hover {
+      color:@grayscale5;
+    }
   }
 }
 .section-divider {
@@ -98,6 +100,31 @@
     transition:0.2s ease-in-out;
   }
 }
+
+.profile-pic {
+  display:block;
+  width:100%;
+  text-align:center;
+  padding:0px 10px;
+  img {
+    width:70px;
+    height:70px;
+    overflow:hidden;
+    border-radius:50%;
+    border:2px solid #ccc;
+    margin:10px 0px;
+  }
+  p {
+    color:@grayscale3;
+    margin:5px 0px;
+    font-size:1.1em;
+  }
+}
+.side-bar-nav hr {
+  width:70%;
+  border-top:1px solid @grayscale7;
+}
+
 
 /* Beta to Classic Transition */
 

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -4,7 +4,8 @@
   var app = angular.module('portal.main.controllers', []);
 
   app.controller('MainController', ['$localStorage','$scope', function($localStorage, $scope) {
-    $scope.$storage = $localStorage.$default( {showSidebar: true, sidebarQuicklinks: false, homeImg : "img/square.jpg", notificationsDemo : false} );
+    
+    $scope.$storage = $localStorage.$default( {showSidebar: true, sidebarQuicklinks: false, homeImg : "img/square.jpg", sidebarShowProfile: false, profileImg: "img/terrace.jpg", notificationsDemo : false } );
   } ]);
 
   /* Username */

--- a/angularjs-portal-frame/src/main/webapp/partials/header.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/header.html
@@ -33,9 +33,6 @@
                  </li>
              </ul>
              <ul class="nav navbar-nav navbar-right hidden-xs">
-                <li>
-                    <username></username>
-                </li>
              </ul>
          </div>
      </div>

--- a/angularjs-portal-frame/src/main/webapp/partials/sidebar-left.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/sidebar-left.html
@@ -4,7 +4,7 @@
       <span class="fa fa-arrow-left hide-sidebar" ng-click="$storage.showSidebar = false" popover="Minimize sidebar" popover-placement="left" popover-trigger="mouseenter" popover-popup-delay="600"></span>
     </div>
     <div class="profile-pic">
-      <img src="img/jared.jpeg">
+      <img src="img/terrace.jpg">
       <username></username>
     </div>
     <hr>

--- a/angularjs-portal-frame/src/main/webapp/partials/sidebar-left.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/sidebar-left.html
@@ -4,7 +4,7 @@
       <span class="fa fa-arrow-left hide-sidebar" ng-click="$storage.showSidebar = false" popover="Minimize sidebar" popover-placement="left" popover-trigger="mouseenter" popover-popup-delay="600"></span>
     </div>
     <div class="profile-pic">
-      <img src="img/terrace.jpg">
+      <img src="{{$storage.profileImg}}" ng-if="$storage.sidebarShowProfile">
       <username></username>
     </div>
     <hr>

--- a/angularjs-portal-frame/src/main/webapp/partials/sidebar-left.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/sidebar-left.html
@@ -1,6 +1,13 @@
 <div>
   <nav class="side-bar-nav">
-    <span class="fa fa-arrow-left hide-sidebar" ng-click="$storage.showSidebar = false" popover="Minimize sidebar" popover-placement="left" popover-trigger="mouseenter" popover-popup-delay="600"></span>
+    <div class="hide-sidebar-div">
+      <span class="fa fa-arrow-left hide-sidebar" ng-click="$storage.showSidebar = false" popover="Minimize sidebar" popover-placement="left" popover-trigger="mouseenter" popover-popup-delay="600"></span>
+    </div>
+    <div class="profile-pic">
+      <img src="img/jared.jpeg">
+      <username></username>
+    </div>
+    <hr>
     <ul class="list-group sidebar">
       <li class="list-group-item"><a href="#/" ng-click="navbarCollapsed = true"><span class="fa fa-home fa-fw"></span> Home</a></li>
       <li class="list-group-item"><a href='/web/#/apps' ng-click="navbarCollapsed = true"><span class="fa fa-star fa-fw"></span> Apps</a></li>

--- a/angularjs-portal-frame/src/main/webapp/partials/username.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/username.html
@@ -1,3 +1,3 @@
-<div ng-controller="SessionCheckController as sessionCtrl" class='user-name-header'>
-	Hello, {{sessionCtrl.user.displayName}}
+<div ng-controller="SessionCheckController as sessionCtrl">
+	<p>{{sessionCtrl.user.displayName}}</p>
 </div>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -12,8 +12,8 @@
        <li class="portlet-container-home beta-card-style">
            <h4>
                <span class="btn-group">
-                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarQuicklinks, 'btn-danger' : !$storage.sidebarQuicklinks, }" ng-model="$storage.sidebarQuicklinks" btn-radio="true">On</label>
-                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarQuicklinks, 'btn-danger' : !$storage.sidebarQuicklinks, }" ng-model="$storage.sidebarQuicklinks" btn-radio="false">Off</label>
+                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarQuicklinks, 'btn-default' : !$storage.sidebarQuicklinks, }" ng-model="$storage.sidebarQuicklinks" btn-radio="true">On</label>
+                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarQuicklinks, 'btn-default' : !$storage.sidebarQuicklinks, }" ng-model="$storage.sidebarQuicklinks" btn-radio="false">Off</label>
                </span>
                Sidebar Quicklinks
            </h4>
@@ -23,8 +23,8 @@
        <li class="portlet-container-home beta-card-style">
            <h4>
                <span class="btn-group">
-                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarShowSettings, 'btn-danger' : !$storage.sidebarShowSettings }" ng-model="$storage.sidebarShowSettings" btn-radio="true">On</label>
-                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarShowSettings, 'btn-danger' : !$storage.sidebarShowSettings }" ng-model="$storage.sidebarShowSettings" btn-radio="false">Off</label>
+                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarShowSettings, 'btn-default' : !$storage.sidebarShowSettings }" ng-model="$storage.sidebarShowSettings" btn-radio="true">On</label>
+                   <label class="btn" ng-class="{'btn-success' : $storage.sidebarShowSettings, 'btn-default' : !$storage.sidebarShowSettings }" ng-model="$storage.sidebarShowSettings" btn-radio="false">Off</label>
                </span>
                Sidebar Settings 
            </h4>
@@ -32,15 +32,25 @@
            
        </li>
        <li class="portlet-container-home beta-card-style">
-           <h4>
-               <span class="btn-group">
-                   <label class="btn" ng-class="{'btn-success' : $storage.notificationsDemo, 'btn-danger' : !$storage.notificationsDemo }" ng-model="$storage.notificationsDemo" btn-radio="true">On</label>
-                   <label class="btn" ng-class="{'btn-success' : $storage.notificationsDemo, 'btn-danger' : !$storage.notificationsDemo }" ng-model="$storage.notificationsDemo" btn-radio="false">Off</label>
-               </span>
-               Notification Demo
-           </h4>
-           <small>Shows a demo of what the notifications could look like on the home page</small>
-           
+         <h4>
+           <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.sidebarShowProfile, 'btn-default' : !$storage.sidebarShowProfile }" ng-model="$storage.sidebarShowProfile" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.sidebarShowProfile, 'btn-default' : !$storage.sidebarShowProfile }" ng-model="$storage.sidebarShowProfile" btn-radio="false">Off</label>
+           </span>
+           Profile picture 
+         </h4>
+         <small>Shows the profile picture in the sidebar</small>
+         
+       </li>
+       <li>
+         <h4>
+           <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.notificationsDemo, 'btn-danger' : !$storage.notificationsDemo }" ng-model="$storage.notificationsDemo" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.notificationsDemo, 'btn-danger' : !$storage.notificationsDemo }" ng-model="$storage.notificationsDemo" btn-radio="false">Off</label>
+           </span>
+           Notification Demo
+         </h4>
+         <small>Shows a demo of what the notifications could look like on the home page</small>
        </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>
@@ -55,6 +65,18 @@
             <label class="btn btn-primary" ng-model="$storage.homeImg" btn-radio="'img/square.jpg'">333 East Campus</label>
             
           </div>
+       </li>
+       <li class="no-padding portlet-container-home  beta-card-style" style='text-align : center;'>
+         <h4>Home Profile Image &nbsp;</h4>
+         <small>Pick a different profile image for MyUW Home</small>
+         <div style='text-align: center;'>
+           <div style='padding: 1em;'>
+             <img ng-src="{{$storage.profileImg}}" height='100px'>
+           </div>
+           <label class="btn btn-primary" ng-model="$storage.profileImg" btn-radio="'img/terrace.jpg'">Chairs at the Union Terrace</label>
+           <label class="btn btn-primary" ng-model="$storage.profileImg" btn-radio="'img/square.jpg'">333 East Campus</label>
+           
+         </div>
        </li>
     </ul>
   </div>


### PR DESCRIPTION
So, I don't like doing things twice. So given the choices in the JIRA for MUMUP-1437 between fixing the long name in the header and then redoing that fix again if/when we put it in the sidebar, I propose we just put it in the sidebar AND put in a small profile picture like we've talked about in the past.

Here's how it would look:
![image](https://cloud.githubusercontent.com/assets/1919535/5687297/f36f2778-9810-11e4-89c5-d40d38fa7f7e.png)

Until we get the back-end in place to allow actual profile pics uploaded by users (if that's something we want to do), we could just put in a placeholder image or Bucky, like so:
![image](https://cloud.githubusercontent.com/assets/1919535/5687382/b53452e8-9811-11e4-9631-43d2e85695a3.png)


And, this fixes the name issue, even for atypically long names :)
![image](https://cloud.githubusercontent.com/assets/1919535/5687401/ef9ef4b0-9811-11e4-829e-12c5a9f886e4.png)


