### PR TITLE
MUMUP-1379 Add Beta setting for using static content card template.

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -11,7 +11,8 @@
       homeImg : "img/square.jpg", 
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 
-      notificationsDemo : false } );
+      notificationsDemo : false, 
+      staticContentOnHome : false } );
   } ]);
 
   /* Username */

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -5,7 +5,13 @@
 
   app.controller('MainController', ['$localStorage','$scope', function($localStorage, $scope) {
     
-    $scope.$storage = $localStorage.$default( {showSidebar: true, sidebarQuicklinks: false, homeImg : "img/square.jpg", sidebarShowProfile: false, profileImg: "img/terrace.jpg", notificationsDemo : false } );
+    $scope.$storage = $localStorage.$default( {
+      showSidebar: true, 
+      sidebarQuicklinks: false, 
+      homeImg : "img/square.jpg", 
+      sidebarShowProfile: false, 
+      profileImg: "img/terrace.jpg", 
+      notificationsDemo : false } );
   } ]);
 
   /* Username */

--- a/angularjs-portal-home/src/main/webapp/partials/layout.html
+++ b/angularjs-portal-home/src/main/webapp/partials/layout.html
@@ -36,8 +36,14 @@
     <div data-loading class='loading-gif'><img src="img/ajax-loader.gif" alt="Loading content, please wait"></div>
     <ul ui-sortable="sortableOptions" ng-model="layout" id="cards-sortable">
        <li class="col-xs-12 col-sm-6 col-md-6 col-lg-4 no-padding portlet-container-home" ng-repeat="portlet in layout">
-          <default-card></default-card>
-          <!-- <static-content-card ng-if="portlet.staticContent != null"></static-content-card> -->
+          <default-card 
+            ng-if="!$storage.staticContentOnHome || 
+                    portlet.staticContent == null">
+          </default-card>
+          <static-content-card 
+            ng-if="$storage.staticContentOnHome &&
+                    portlet.staticContent != null">
+          </static-content-card>
         </li>
     </ul>
     <marketplace-light class="col-xs-12 col-sm-6 col-md-6 col-lg-4 no-padding" ></marketplace-light>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -41,6 +41,16 @@
          </h4>
          <small>Shows a demo of what the notifications could look like on the home page</small>
        </li>
+       <li class="portlet-container-home beta-card-style">
+         <h4>
+           <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.staticContentOnHome, 'btn-default' : !$storage.staticContentOnHome }" ng-model="$storage.staticContentOnHome" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.staticContentOnHome, 'btn-default' : !$storage.staticContentOnHome }" ng-model="$storage.staticContentOnHome" btn-radio="false">Off</label>
+           </span>
+           Static content cards
+         </h4>
+         <small>Shows static content cards rather than default cards for portlets with associated static content.</small>
+       </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>
         <li class="no-padding portlet-container-home  beta-card-style" style='text-align : center;'>


### PR DESCRIPTION
Adds a Beta setting for turning on using the static content card template rather than the default card template for portlets with associated static content.

![static-content-cards-beta-setting](https://cloud.githubusercontent.com/assets/952283/5766127/a1f6e6a2-9cc4-11e4-9794-67ee5c7fde7d.png)
