### PR TITLE
Use UW-UI-Toolkit in /web, including Bootstrap

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/angular.less
+++ b/angularjs-portal-frame/src/main/webapp/css/angular.less
@@ -1,6 +1,6 @@
 @import "../bower_components/normalize-less/normalize.less";
 @import "../bower_components/font-awesome/css/font-awesome.css";
-@import "../bower_components/bootstrap/less/bootstrap.less";
+@import "../bower_components/uw-ui-toolkit/src/less/uw-ui-toolkit.less";
 //@import "common.less";
 @import "variables.less";
 @import "buckyless/general.less";


### PR DESCRIPTION
Not sure we need Bootstrap in Bower, now that UW UI Toolkit includes it. But leaving there for now.