### PR TITLE
MUMUP-1500 Only use sessionStorage Marketplace data from same portal session

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-service.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-service.js
@@ -4,7 +4,7 @@
 var app = angular.module('portal.main.service', []);
 
 app.factory('mainService', function($http, miscService) {
-  var prom = $http.get('/portal/api/session.json');
+  var prom = $http.get('/portal/api/session.json', { cache: true});
   var sidebarPromise = $http.get('/web/samples/sidebar.json');
 
   var getUser = function() {

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -3,7 +3,7 @@
 (function() {
   var app = angular.module('portal.marketplace.controller', []);
 
-  app.controller('MarketplaceController', [ '$sessionStorage', '$modal', '$timeout', '$rootScope',  '$window', '$http', '$scope','$location','$routeParams','marketplaceService','miscService', function($sessionStorage,$modal,$timeout, $rootScope, $window, $http, $scope, $location, $routeParams, marketplaceService, miscService) {
+  app.controller('MarketplaceController', [ '$sessionStorage', '$modal', '$timeout', '$rootScope',  '$window', '$http', '$scope','$location','$routeParams','marketplaceService','miscService', 'mainService', function($sessionStorage,$modal,$timeout, $rootScope, $window, $http, $scope, $location, $routeParams, marketplaceService, miscService, mainService) {
 
     $scope.$storage = $sessionStorage;
     //init variables

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -3,7 +3,13 @@
 (function() {
   var app = angular.module('portal.marketplace.controller', []);
 
-  app.controller('MarketplaceController', [ '$sessionStorage', '$modal', '$timeout', '$rootScope',  '$window', '$http', '$scope','$location','$routeParams','marketplaceService','miscService', 'mainService', function($sessionStorage,$modal,$timeout, $rootScope, $window, $http, $scope, $location, $routeParams, marketplaceService, miscService, mainService) {
+  app.controller('MarketplaceController', 
+    [ '$sessionStorage', '$modal', '$timeout', '$rootScope', '$window', 
+    '$http', '$scope', '$location', '$routeParams', 'marketplaceService',
+    'miscService', 'mainService', 
+    function($sessionStorage, $modal, $timeout, $rootScope, $window, 
+      $http, $scope, $location, $routeParams, marketplaceService, 
+      miscService, mainService) {
 
     $scope.$storage = $sessionStorage;
     //init variables

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -10,21 +10,33 @@
     var store = this;
     store.portlets = [];
     store.count = 0;
+    store.user = [];
+    mainService.getUser().then(function(result){
+      store.user = result.data.person;
 
-    //get marketplace portlets
-    if($sessionStorage.marketplace != null) {
-        store.portlets = $sessionStorage.marketplace;
-        $scope.categories = $sessionStorage.categories;
-    } else {
-        marketplaceService.getPortlets().then(function(data) {
-          store.portlets = data.portlets;
-          $scope.categories = data.categories;
-          $scope.layout = data.layout;
+      //get marketplace portlets
+      if($sessionStorage.sessionKey == store.user.sessionKey
+        && $sessionStorage.marketplace != null
+        && $sessionStorage.categories != null) {
+
+          store.portlets = $sessionStorage.marketplace;
+          $scope.categories = $sessionStorage.categories;
           
-          $sessionStorage.marketplace = data.portlets;
-          $sessionStorage.categories = data.categories;
-        });
-    }
+      } else {
+          marketplaceService.getPortlets().then(function(data) {
+            store.portlets = data.portlets;
+            $scope.categories = data.categories;
+            $scope.layout = data.layout;
+            
+            $sessionStorage.marketplace = data.portlets;
+            $sessionStorage.categories = data.categories;
+            $sessionStorage.sessionKey = store.user.sessionKey;
+          });
+      }
+      
+    });
+    
+    
 
     //setup search term
     var tempFilterText = '', filterTextTimeout;


### PR DESCRIPTION
[MUMUP-1500](https://jira.doit.wisc.edu/jira/browse/MUMUP-1500).

## What this change does

Without this change, when you
1) Log in and exercise `/web/apps` as `staff`
2) Log out
3) Log in and exercise `/web/apps` as `admin`

`admin` sees only the Marketplace data visible to `staff` because from the browser's perspective it's the same local browsing session and so `sessionStorage` persisted across these logins.

With this change, when you do those steps, `admin` gets a fresh load of Marketplace data into `sessionStorage`.

## This isn't really a security fix, it's just a fix

This isn't really a security fix, since sharing browser sessions breaks the security model of the Internet, really, and there's only so much as can do about that, but this is really a functionality fix, in that users getting cached Marketplace data that isn't tailored to them was some kind of bug.

## This makes development more pleasant
More to the point, this change makes it a lot easier to naively develop and test Marketplace functionality without remembering just when to manually zap `sessionStorage`.

## How the solution works

The solution stores the **stats** session key into `sessionStorage`.  `MarketplaceController` compares the stored session key against a fresh read of the session key from the server. If the session keys do not match, `MarketplaceController` refreshes the `sessionStorage` cached data.

That's the **stats** session key, not the `JSESSIONID`.  You can't grab the session key from `sessionStorage` and use it to resurrect an abandoned but not yet server-side-expired portal session.  However, if you have access to `sessionStorage` to try, you probably have access to the cookie that contains that value, so maybe that nuance matters little.  Still, the point is, this solution doesn't make the security worse.