### PR TITLE
Add commented-out example of MacOS notification and sound on build.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,3 +7,7 @@ popd
 pushd angularjs-portal-home
 mvn -Djava.awt.headless=true tomcat7:redeploy
 popd
+
+# On MacOS this will display a notification.
+# osascript -e 'display notification "angularJSportal build.sh finished" with title "Angular portal deployed" sound name "Hero"'
+# See http://apple.stackexchange.com/questions/57412/


### PR DESCRIPTION
Adds documentation to end of `build.sh` with a command that can be un-commented to get a MacOS notification and sound upon `build.sh` completion.

Using this locally so I notice when the build finishes and am reminded to get back to testing whatever it was that built.