### PR TITLE
MUMUP-1379 Show pithy content on home (take 2)

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -12,7 +12,8 @@
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 
       notificationsDemo : false, 
-      staticContentOnHome : false } );
+      staticContentOnHome : false,
+      pithyContentOnHome : false } );
   } ]);
 
   /* Username */

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -16,6 +16,14 @@
           templateUrl : 'partials/static-content-card.html'
       }
   });
+  
+  app.directive('pithyContentCard', function(){
+      return {
+          restrict : 'E',
+          templateUrl : 'partials/pithy-content-card.html'
+      }
+  });
+
 
    app.directive('marketplaceLight', function(){
       return{

--- a/angularjs-portal-home/src/main/webapp/partials/layout.html
+++ b/angularjs-portal-home/src/main/webapp/partials/layout.html
@@ -37,13 +37,23 @@
     <ul ui-sortable="sortableOptions" ng-model="layout" id="cards-sortable">
        <li class="col-xs-12 col-sm-6 col-md-6 col-lg-4 no-padding portlet-container-home" ng-repeat="portlet in layout">
           <default-card 
-            ng-if="!$storage.staticContentOnHome || 
-                    portlet.staticContent == null">
+            ng-if="(!$storage.staticContentOnHome || 
+                    portlet.staticContent == null)
+                    &&
+                    (!$storage.pithyContentOnHome || 
+                     portlet.pithyStaticContent == null)">
           </default-card>
           <static-content-card 
             ng-if="$storage.staticContentOnHome &&
                     portlet.staticContent != null">
           </static-content-card>
+          <pithy-content-card 
+            ng-if="(!$storage.staticContentOnHome || 
+                    portlet.staticContent == null)
+                    &&
+                    ($storage.pithyContentOnHome &&
+                    portlet.pithyStaticContent != null)">
+          </pithy-content-card>
         </li>
     </ul>
     <marketplace-light class="col-xs-12 col-sm-6 col-md-6 col-lg-4 no-padding" ></marketplace-light>

--- a/angularjs-portal-home/src/main/webapp/partials/pithy-content-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/pithy-content-card.html
@@ -1,7 +1,10 @@
 <div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}">
+  
+  <a href="{{::portlet.url}}" target="{{::portlet.target}}" >
   <div class="portlet-title">
       <img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i><h1>{{ ::portlet.title }}</h1>
   </div>
+  </a>
   
   <div class='card-remove'>
      <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>

--- a/angularjs-portal-home/src/main/webapp/partials/pithy-content-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/pithy-content-card.html
@@ -1,0 +1,14 @@
+<div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}" ng-click="layoutCtrl.toggleDiv(portlet.nodeId);">
+  <div class="portlet-title">
+      <img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i><h1>{{ ::portlet.title }}</h1>
+  </div>
+  
+  <div class='card-remove'>
+     <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
+  </div>
+  <div class="portlet-content">
+    {{:: portlet.description | truncate:160}}
+  </div>
+  <div ng-bind-html="portlet.staticContent" class="hidden up-portlet-content-wrapper" id="content-{{::portlet.nodeId}}">
+  </div>
+</div>

--- a/angularjs-portal-home/src/main/webapp/partials/pithy-content-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/pithy-content-card.html
@@ -1,4 +1,4 @@
-<div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}" ng-click="layoutCtrl.toggleDiv(portlet.nodeId);">
+<div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}">
   <div class="portlet-title">
       <img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i><h1>{{ ::portlet.title }}</h1>
   </div>
@@ -7,8 +7,6 @@
      <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
   </div>
   <div class="portlet-content">
-    {{:: portlet.description | truncate:160}}
-  </div>
-  <div ng-bind-html="portlet.staticContent" class="hidden up-portlet-content-wrapper" id="content-{{::portlet.nodeId}}">
+     <div ng-bind-html="portlet.pithyStaticContent"></div>
   </div>
 </div>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -49,7 +49,7 @@
            </span>
            Static content cards
          </h4>
-         <small>Shows static content cards rather than default cards for portlets with associated static content.</small>
+         <small>Shows static content cards rather than default cards for portlets with associated static content.  Static content cards are the cards that expand to show the static content right on the home.</small>
        </li>
        <li class="portlet-container-home beta-card-style">
          <h4>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -51,6 +51,16 @@
          </h4>
          <small>Shows static content cards rather than default cards for portlets with associated static content.</small>
        </li>
+       <li class="portlet-container-home beta-card-style">
+         <h4>
+           <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.pithyContentOnHome, 'btn-default' : !$storage.pithyContentOnHome }" ng-model="$storage.pithyContentOnHome" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.pithyContentOnHome, 'btn-default' : !$storage.pithyContentOnHome }" ng-model="$storage.pithyContentOnHome" btn-radio="false">Off</label>
+           </span>
+           Pithy content cards
+         </h4>
+         <small>Shows pithy content cards rather than default cards for portlets with associated pithy static content.  Pithy content cards are the cards show some portlet-specific markup right on the face of the card.</small>
+       </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>
         <li class="no-padding portlet-container-home  beta-card-style" style='text-align : center;'>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -60,6 +60,14 @@
            Pithy content cards
          </h4>
          <small>Shows pithy content cards rather than default cards for portlets with associated pithy static content.  Pithy content cards are the cards show some portlet-specific markup right on the face of the card.</small>
+         <div class="alert alert-info" role="alert"
+           ng-show="$storage.pithyContentOnHome 
+                    && $storage.staticContentOnHome">
+          The static card feature takes precedence over pithy content, 
+          so for portlets with both static and pithy content associated 
+          with them, the Static content card will display and 
+          the Pithy content card will not.
+         </div>
        </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>


### PR DESCRIPTION
[MUMUP-1379](https://jira.doit.wisc.edu/jira/browse/MUMUP-1379).

Replaces #98, this time retaining the parallel static content feature that was restored to service in #99.

Adds `pithy-content-card` feature parallel to `static-content-card`.  Pithy cards display pithy content, which is per-portlet markup right on the face of the card.

![pithy-cards-when-available](https://cloud.githubusercontent.com/assets/952283/5772012/7f197a50-9d0f-11e4-9272-0f75626e001f.png)

Adds the feature to the Beta settings.

![new_beta_setting](https://cloud.githubusercontent.com/assets/952283/5781806/4b7e6a9a-9d7b-11e4-836c-c00d60d74580.png)

The Static cards feature takes precedence over the Pithy cards feature, and the Beta settings tells you so when it matters.

![static_and_pithy](https://cloud.githubusercontent.com/assets/952283/5781823/6031feac-9d7b-11e4-8a02-e5a1a001bd26.png)