### PR TITLE
Add `to_trusted` filter.

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/filters.js
+++ b/angularjs-portal-frame/src/main/webapp/js/filters.js
@@ -51,4 +51,19 @@
         return filtered;
       };
     });
+    
+    /* WARNING: THIS FILTER IS DANGEROUS.
+       You should only filter to trusted status HTML that you are
+       absolutely sure you can trust 
+       (i.e., it definitely did not come from end user input, 
+       it only is from a trusted source.)
+       
+       If you don't understand what this filter does, no worries,
+       but then you really shouldn't be using it! :)
+     */
+    app.filter('to_trusted', ['$sce', function($sce){
+      return function(text) {
+          return $sce.trustAsHtml(text);
+      };
+    }]);
 } ());


### PR DESCRIPTION
Adds a `to_trusted` filter which makes it (dangerously) easy to mark content as "trusted" from AngularJS's perspective.

## How to use

Here's how you'd use this in say the `pithy-card.html` template so that the HTML from the entity files can include `JavaScript`.

```
<div ng-bind-html="portlet.pithyStaticContent | to_trusted"></div>
```

Without piping through `to_trusted`, the pithy content can only be static `HTML` that doesn't include `JavaScript`.  Safety.