### PR TITLE
MUMUP-1424 : Bug: MyUW title underlining

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
@@ -9,7 +9,8 @@ a#myuw-header {
    font-weight: 200;
 }
 
-a#myuw-header:hover {
+a#myuw-header:link, a#myuw-header:visited, a#myuw-header:hover,
+a#myuw-header:focus, a#myuw-header:active {
    text-decoration: none;
 }
 


### PR DESCRIPTION
https://jira.doit.wisc.edu/jira/browse/MUMUP-1424

The MyUW Beta link on the top left that takes the user to the MyUW Home was underlining, so I disabled that under every condition and now the link should never underline.

Before (link underlined):

![underl](https://cloud.githubusercontent.com/assets/7268126/5845933/8fe00014-a185-11e4-934f-303a08f096ce.png)

After (link not underlined):

![notunderl](https://cloud.githubusercontent.com/assets/7268126/5845850/fee4d6b6-a184-11e4-9b99-57bd3e9f7ae4.png)
