### PR TITLE
Add optional parameters to build and add in mac/linux notifications

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,9 +1,21 @@
 #!/bin/bash
+if [ "$#" = "0" ]; then
+ mvn -Djava.awt.headless=true clean package
+else 
+ mvn -Djava.awt.headless=true $@
+fi
 
-mvn -Djava.awt.headless=true clean package
 pushd angularjs-portal-frame
 mvn -Djava.awt.headless=true tomcat7:redeploy
 popd
 pushd angularjs-portal-home
 mvn -Djava.awt.headless=true tomcat7:redeploy
 popd
+
+unamestr=`uname`
+if [[ "$unamestr" == 'Linux' ]]; then
+ notify-send "build complete for angular" 
+elif [[ "$unamestr" == 'Darwin' ]]; then
+ osascript -e 'display notification "angularJSportal build.sh finished" with title "Angular portal deployed" sound name "Hero"'
+fi
+

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 if [ "$#" = "0" ]; then
- mvn -Djava.awt.headless=true clean package
+ mvn -Djava.awt.headless=true clean install
 else 
  mvn -Djava.awt.headless=true $@
 fi


### PR DESCRIPTION
You can now do `./build.sh` just like before that calls `mvn clean package` OR you can now pass in what build steps you want it to do, for example `./build.sh clean install` will call `mvn clean install`.

I also added in notifications for mac and linux. The idea spawned from @apetro 's pull #97.