### PR TITLE
Add mvn install to build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ mvn -Djava.awt.headless=true clean package
 pushd angularjs-portal-frame
 mvn -Djava.awt.headless=true tomcat7:redeploy
 popd
+mvn install
 pushd angularjs-portal-home
 mvn -Djava.awt.headless=true tomcat7:redeploy
 popd


### PR DESCRIPTION
Should we add `mvn install` to the build.sh file? I'm a maven newb but I consistently can't get styles to transfer from frame to home when developing without running `mvn install`.