### PR TITLE
Static content max angular view

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -11,7 +11,8 @@
       homeImg : "img/square.jpg", 
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 
-      notificationsDemo : false, 
+      notificationsDemo : false,
+      staticContentMax : false,
       staticContentOnHome : false,
       pithyContentOnHome : false } );
   } ]);

--- a/angularjs-portal-home/src/main/webapp/js/angular-page.js
+++ b/angularjs-portal-home/src/main/webapp/js/angular-page.js
@@ -29,6 +29,7 @@
       when('/notifications', {templateUrl: 'partials/notifications-full.html'}). 
       when('/apps/details/:fname', {templateUrl: 'partials/marketplace-details.html', controller:'MarketplaceDetailsController'}).
       when('/apps/search/:initFilter', {templateUrl: 'partials/marketplace.html'}).
+      when('/static/:fname', {templateUrl: 'partials/static-content-max.html'}).
       otherwise({templateUrl: 'partials/layout.html'});
       }
  	]);

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -83,6 +83,20 @@
       };
       
   } ]);
+  
+  app.controller('StaticContentController', ['$routeParams', '$scope', 'layoutService', function ($routeParams, $scope, layoutService){
+	  $scope.portlet = [];
+	  layoutService.getLayout().then(function(data){
+		  $scope.portlets = data.layout;
+		  //TODO: make this better
+	      for(var p in $scope.portlets) {
+	        if ($scope.portlets[p].fname == $routeParams.fname) {
+	            $scope.portlet = $scope.portlets[p];
+	            break;
+	        };
+	      };
+      });
+  }]);
 
   
   app.controller('NewStuffController', ['$scope', 'layoutService', function ($scope, layoutService){

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -17,6 +17,13 @@
       }
   });
   
+  app.directive('staticContentCardMax', function(){
+      return {
+          restrict : 'E',
+          templateUrl : 'partials/static-content-card-max.html'
+      }
+  });
+  
   app.directive('pithyContentCard', function(){
       return {
           restrict : 'E',

--- a/angularjs-portal-home/src/main/webapp/partials/layout.html
+++ b/angularjs-portal-home/src/main/webapp/partials/layout.html
@@ -41,14 +41,23 @@
                     portlet.staticContent == null)
                     &&
                     (!$storage.pithyContentOnHome || 
-                     portlet.pithyStaticContent == null)">
+                     portlet.pithyStaticContent == null)
+                    &&
+                    (!$storage.staticContentMax || 
+                    portlet.staticContent == null)">
           </default-card>
-          <static-content-card 
-            ng-if="$storage.staticContentOnHome &&
+          <static-content-card-max 
+            ng-if="$storage.staticContentMax &&
                     portlet.staticContent != null">
+          </static-content-card-max>
+          <static-content-card 
+            ng-if="$storage.staticContentOnHome   &&
+                    portlet.staticContent != null &&
+                    !$storage.staticContentMax">
           </static-content-card>
           <pithy-content-card 
-            ng-if="(!$storage.staticContentOnHome || 
+            ng-if="((!$storage.staticContentOnHome &&
+                    !$storage.staticContentMax) ||
                     portlet.staticContent == null)
                     &&
                     ($storage.pithyContentOnHome &&

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -44,12 +44,29 @@
        <li class="portlet-container-home beta-card-style">
          <h4>
            <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.staticContentMax, 'btn-default' : !$storage.staticContentMax }" ng-model="$storage.staticContentMax" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.staticContentMax, 'btn-default' : !$storage.staticContentMax }" ng-model="$storage.staticContentMax" btn-radio="false">Off</label>
+           </span>
+           Static content on an Angular max page
+         </h4>
+         <small>Just changes the ng-view to /static/fname. This will save a server trip and 2 xslt transformatios.</small>
+       </li>
+       <li class="portlet-container-home beta-card-style">
+         <h4>
+           <span class="btn-group">
              <label class="btn" ng-class="{'btn-success' : $storage.staticContentOnHome, 'btn-default' : !$storage.staticContentOnHome }" ng-model="$storage.staticContentOnHome" btn-radio="true">On</label>
              <label class="btn" ng-class="{'btn-success' : $storage.staticContentOnHome, 'btn-default' : !$storage.staticContentOnHome }" ng-model="$storage.staticContentOnHome" btn-radio="false">Off</label>
            </span>
-           Static content cards
+           Static Content Cards
          </h4>
          <small>Shows static content cards rather than default cards for portlets with associated static content.  Static content cards are the cards that expand to show the static content right on the home.</small>
+         <div class="alert alert-info" role="alert"
+           ng-show="$storage.staticContentMax 
+                    && $storage.staticContentOnHome">
+          The "Static content on an Angular max page" feature takes precedence over 
+          "Static Content Cards", so for portlets with static content associated 
+          with them, the Static content max will display on click.
+         </div>
        </li>
        <li class="portlet-container-home beta-card-style">
          <h4>
@@ -62,10 +79,11 @@
          <small>Shows pithy content cards rather than default cards for portlets with associated pithy static content.  Pithy content cards are the cards show some portlet-specific markup right on the face of the card.</small>
          <div class="alert alert-info" role="alert"
            ng-show="$storage.pithyContentOnHome 
-                    && $storage.staticContentOnHome">
-          The static card feature takes precedence over pithy content, 
+                    && ($storage.staticContentOnHome ||
+                        $storage.staticContentMax)">
+          The static content features take precedence over pithy content, 
           so for portlets with both static and pithy content associated 
-          with them, the Static content card will display and 
+          with them, the Static content will display and 
           the Pithy content card will not.
          </div>
        </li>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -49,7 +49,7 @@
            </span>
            Static content on an Angular max page
          </h4>
-         <small>Just changes the ng-view to /static/fname. This will save a server trip and 2 xslt transformatios.</small>
+         <small>Just changes the ng-view to /static/fname. This will save a server trip and 2 XSLT transformations.</small>
        </li>
        <li class="portlet-container-home beta-card-style">
          <h4>

--- a/angularjs-portal-home/src/main/webapp/partials/static-content-card-max.html
+++ b/angularjs-portal-home/src/main/webapp/partials/static-content-card-max.html
@@ -1,0 +1,16 @@
+<div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}">
+
+  <a href="#/static/{{::portlet.fname}}">
+    <div class="portlet-title">
+        <img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i><h1>{{ ::portlet.title }}</h1>
+    </div>
+  </a>
+  <div class='card-remove'>
+     <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
+  </div>
+  <a href="#/static/{{::portlet.fname}}" >
+    <div class="portlet-content">
+      {{:: portlet.description | truncate:160}}
+    </div>
+  </a>
+</div>

--- a/angularjs-portal-home/src/main/webapp/partials/static-content-max.html
+++ b/angularjs-portal-home/src/main/webapp/partials/static-content-max.html
@@ -1,0 +1,12 @@
+<div class="row card"  ng-controller="StaticContentController as staticContentCtrl">
+  <div class="card-header">
+    <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
+    <div class="card-header-text">
+      <h1><img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i> {{ ::portlet.title }}</h1>
+    </div>
+  </div>
+  <div class="col-xs-12 no-padding portlet-section">
+	  <div ng-bind-html="portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{::portlet.nodeId}}">
+	  </div>
+  </div>
+</div>


### PR DESCRIPTION
In chats with the team we thought it would be an interesting idea to have static content on an angular page (I think we can credit @vertein with the original idea). This is a beta-setting level view on that.

![screen shot 2015-01-27 at 11 13 28 pm](https://cloud.githubusercontent.com/assets/3534544/5932777/247edf12-a67a-11e4-8804-38702ad81626.png)

Please note this takes precedence over both static content on home and pithy content.

When you click on a card when new setting is enabled you are redirected to `/web/#/static/:fname`. This then loads another view.

![screen shot 2015-01-27 at 11 08 47 pm](https://cloud.githubusercontent.com/assets/3534544/5932736/77556f40-a679-11e4-91aa-4033b4501130.png)

### Bottom line
+ This feature saves a server hit and 2 xslt transformations
+ The only real difference the user will see is speed improvement
+ #incrementalImprovement