### PR TITLE
Make the new simple content on angular faster by removing server side hit

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -3,13 +3,18 @@
 (function() {
   var app = angular.module('portal.layout.controllers', []);
 
-  app.controller('LayoutController', [ '$sessionStorage', '$scope', 'layoutService', 'miscService', function($sessionStorage, $scope, layoutService, miscService) {
+  app.controller('LayoutController', [ '$location', '$sessionStorage', '$scope', 'layoutService', 'miscService', 'sharedPortlet', function($location, $sessionStorage, $scope, layoutService, miscService, sharedPortlet) {
     miscService.pushPageview();
     $scope.layout = [];
 
     layoutService.getLayout().then(function(data){
       $scope.layout = data.layout;
     });
+    
+    this.maxStaticPortlet = function gotoMaxStaticPortlet(url, portlet) {
+    	sharedPortlet.setProperty(portlet);
+    	$location.path(url);
+    }
 
     this.directToPortlet = function directToPortlet(url) {
       $location.path(url);
@@ -84,20 +89,19 @@
       
   } ]);
   
-  app.controller('StaticContentController', ['$routeParams', '$scope', 'layoutService', function ($routeParams, $scope, layoutService){
-	  $scope.portlet = [];
-	  layoutService.getLayout().then(function(data){
-		  $scope.portlets = data.layout;
-		  //TODO: make this better
-	      for(var p in $scope.portlets) {
-	        if ($scope.portlets[p].fname == $routeParams.fname) {
-	            $scope.portlet = $scope.portlets[p];
+  app.controller('StaticContentController', ['$routeParams', '$scope', 'layoutService', 'sharedPortlet', function ($routeParams, $scope, layoutService, sharedPortlet){
+	  $scope.portlet = sharedPortlet.getProperty() || {};
+	  if (typeof $scope.portlet.fname === 'undefined' || $scope.portlet.fname !== $routeParams.fname) {
+	      layoutService.getLayout().then(function(data){
+	        for(var p in data.layout) {
+	          if (data.layout[p].fname == $routeParams.fname) {
+	            $scope.portlet = data.layout[p];
 	            break;
+	          }
 	        };
-	      };
-      });
+	      });
+       }
   }]);
-
   
   app.controller('NewStuffController', ['$scope', 'layoutService', function ($scope, layoutService){
       $scope.newStuffArray = [];

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -3,13 +3,16 @@
 (function() {
   var app = angular.module('portal.layout.controllers', []);
 
-  app.controller('LayoutController', [ '$location', '$sessionStorage', '$scope', 'layoutService', 'miscService', 'sharedPortletService', function($location, $sessionStorage, $scope, layoutService, miscService, sharedPortletService) {
+  app.controller('LayoutController', [ '$location', '$sessionStorage', '$scope', '$rootScope', 'layoutService', 'miscService', 'sharedPortletService', function($location, $sessionStorage, $scope, $rootScope, layoutService, miscService, sharedPortletService) {
     miscService.pushPageview();
-    $scope.layout = [];
-
-    layoutService.getLayout().then(function(data){
-      $scope.layout = data.layout;
-    });
+    if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
+      
+      $rootScope.layout = [];
+    
+      layoutService.getLayout().then(function(data){
+        $rootScope.layout = data.layout;
+      });
+    }
     
     this.maxStaticPortlet = function gotoMaxStaticPortlet(url, portlet) {
     	sharedPortletService.setProperty(portlet);
@@ -89,7 +92,7 @@
       
   } ]);
   
-  app.controller('StaticContentController', ['$routeParams', '$scope', 'layoutService', 'sharedPortletService', function ($routeParams, $scope, layoutService, sharedPortletService){
+  app.controller('StaticContentController', ['$routeParams', '$rootScope','$scope', 'layoutService', 'sharedPortletService', function ($routeParams, $rootScope, $scope, layoutService, sharedPortletService){
 	  $scope.portlet = sharedPortletService.getProperty() || {};
 	  var that = this;
 	  that.getPortlet = function(fname, portlets ) {
@@ -103,12 +106,16 @@
 	  }
 	  
 	  if (typeof $scope.portlet.fname === 'undefined' || $scope.portlet.fname !== $routeParams.fname) {
-		  if($scope.layout != null) {
-			  $scope.portlet = that.getPortlet($routeParams.fname, $scope.portlets);
+		  
+		  if(typeof $rootScope.layout !== 'undefined' && $rootScope.layout != null) {
+			  $scope.portlet = that.getPortlet($routeParams.fname, $rootScope.layout);
+		  } else {
+			  layoutService.getLayout().then(function(data){
+			      $rootScope.layout = data.layout;
+			      $scope.portlet = that.getPortlet($routeParams.fname, $rootScope.layout);
+			  });
 		  }
-	      layoutService.getLayout().then(function(data){
-	        $scope.portlet = that.getPortlet($routeParams.fname, data.layout);
-	      });
+	      
        }
   }]);
   

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -14,9 +14,9 @@
       });
     }
     
-    this.maxStaticPortlet = function gotoMaxStaticPortlet(url, portlet) {
+    this.maxStaticPortlet = function gotoMaxStaticPortlet(portlet) {
     	sharedPortletService.setProperty(portlet);
-    	$location.path(url);
+    	$location.path('/static/'+portlet.fname);
     }
 
     this.directToPortlet = function directToPortlet(url) {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -92,7 +92,7 @@
       
   } ]);
   
-  app.controller('StaticContentController', ['$routeParams', '$rootScope','$scope', 'layoutService', 'sharedPortletService', function ($routeParams, $rootScope, $scope, layoutService, sharedPortletService){
+  app.controller('StaticContentController', ['$location', '$routeParams', '$rootScope','$scope', 'layoutService', 'sharedPortletService', function ($location, $routeParams, $rootScope, $scope, layoutService, sharedPortletService){
 	  $scope.portlet = sharedPortletService.getProperty() || {};
 	  var that = this;
 	  that.getPortlet = function(fname, portlets ) {
@@ -109,10 +109,16 @@
 		  
 		  if(typeof $rootScope.layout !== 'undefined' && $rootScope.layout != null) {
 			  $scope.portlet = that.getPortlet($routeParams.fname, $rootScope.layout);
+			  if(typeof $scope.portlet.fname === 'undefined') {
+				  $location.path('/');
+			  }
 		  } else {
 			  layoutService.getLayout().then(function(data){
 			      $rootScope.layout = data.layout;
 			      $scope.portlet = that.getPortlet($routeParams.fname, $rootScope.layout);
+			      if(typeof $scope.portlet.fname === 'undefined') {
+			    	  $location.path('/');
+			      }
 			  });
 		  }
 	      

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -3,7 +3,7 @@
 (function() {
   var app = angular.module('portal.layout.controllers', []);
 
-  app.controller('LayoutController', [ '$location', '$sessionStorage', '$scope', 'layoutService', 'miscService', 'sharedPortlet', function($location, $sessionStorage, $scope, layoutService, miscService, sharedPortlet) {
+  app.controller('LayoutController', [ '$location', '$sessionStorage', '$scope', 'layoutService', 'miscService', 'sharedPortletService', function($location, $sessionStorage, $scope, layoutService, miscService, sharedPortletService) {
     miscService.pushPageview();
     $scope.layout = [];
 
@@ -12,7 +12,7 @@
     });
     
     this.maxStaticPortlet = function gotoMaxStaticPortlet(url, portlet) {
-    	sharedPortlet.setProperty(portlet);
+    	sharedPortletService.setProperty(portlet);
     	$location.path(url);
     }
 
@@ -89,16 +89,25 @@
       
   } ]);
   
-  app.controller('StaticContentController', ['$routeParams', '$scope', 'layoutService', 'sharedPortlet', function ($routeParams, $scope, layoutService, sharedPortlet){
-	  $scope.portlet = sharedPortlet.getProperty() || {};
+  app.controller('StaticContentController', ['$routeParams', '$scope', 'layoutService', 'sharedPortletService', function ($routeParams, $scope, layoutService, sharedPortletService){
+	  $scope.portlet = sharedPortletService.getProperty() || {};
+	  var that = this;
+	  that.getPortlet = function(fname, portlets ) {
+	    for(var p in portlets) {
+	      if (portlets[p].fname == fname) {
+	        return portlets[p];
+	        break;
+	      }
+	    };
+	    return {};
+	  }
+	  
 	  if (typeof $scope.portlet.fname === 'undefined' || $scope.portlet.fname !== $routeParams.fname) {
+		  if($scope.layout != null) {
+			  $scope.portlet = that.getPortlet($routeParams.fname, $scope.portlets);
+		  }
 	      layoutService.getLayout().then(function(data){
-	        for(var p in data.layout) {
-	          if (data.layout[p].fname == $routeParams.fname) {
-	            $scope.portlet = data.layout[p];
-	            break;
-	          }
-	        };
+	        $scope.portlet = that.getPortlet($routeParams.fname, data.layout);
 	      });
        }
   }]);

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -3,6 +3,19 @@
 (function() {
 var app = angular.module('portal.layout.service', []);
 
+app.service('sharedPortlet', function () {
+    var property = {};
+
+    return {
+        getProperty: function () {
+            return property;
+        },
+        setProperty: function(value) {
+            property = value;
+        }
+    };
+});
+
 app.factory('layoutService', function($http, miscService) {
 
     var getLayout = function() {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -3,7 +3,7 @@
 (function() {
 var app = angular.module('portal.layout.service', []);
 
-app.service('sharedPortlet', function () {
+app.factory('sharedPortletService', function () {
     var property = {};
 
     return {

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -81,6 +81,7 @@
                     if(marketplaceEntries.length > 0) {
                         marketplaceEntries[0].hasInLayout = true;
                     }
+                    $rootScope.layout = null; //reset layout due to modifications
                 });
               },
               error: function(request, text, error) {

--- a/angularjs-portal-home/src/main/webapp/partials/static-content-card-max.html
+++ b/angularjs-portal-home/src/main/webapp/partials/static-content-card-max.html
@@ -1,16 +1,16 @@
 <div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}">
 
-  <a href="#/static/{{::portlet.fname}}">
+  <div ng-click="layoutCtrl.maxStaticPortlet('/static/'+ portlet.fname,portlet)">
     <div class="portlet-title">
         <img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i><h1>{{ ::portlet.title }}</h1>
     </div>
-  </a>
+  </div>
   <div class='card-remove'>
      <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
   </div>
-  <a href="#/static/{{::portlet.fname}}" >
+  <div ng-click="layoutCtrl.maxStaticPortlet('/static/'+ portlet.fname,portlet)">
     <div class="portlet-content">
       {{:: portlet.description | truncate:160}}
     </div>
-  </a>
+  </div>
 </div>

--- a/angularjs-portal-home/src/main/webapp/partials/static-content-card-max.html
+++ b/angularjs-portal-home/src/main/webapp/partials/static-content-card-max.html
@@ -1,6 +1,6 @@
 <div class="portlet-div" id="portlet-id-{{::portlet.nodeId}}">
 
-  <div ng-click="layoutCtrl.maxStaticPortlet('/static/'+ portlet.fname,portlet)">
+  <div ng-click="layoutCtrl.maxStaticPortlet(portlet)">
     <div class="portlet-title">
         <img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i><h1>{{ ::portlet.title }}</h1>
     </div>
@@ -8,7 +8,7 @@
   <div class='card-remove'>
      <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
   </div>
-  <div ng-click="layoutCtrl.maxStaticPortlet('/static/'+ portlet.fname,portlet)">
+  <div ng-click="layoutCtrl.maxStaticPortlet(portlet)">
     <div class="portlet-content">
       {{:: portlet.description | truncate:160}}
     </div>

--- a/angularjs-portal-home/src/main/webapp/partials/static-content-max.html
+++ b/angularjs-portal-home/src/main/webapp/partials/static-content-max.html
@@ -2,12 +2,12 @@
   <div class="card-header">
     <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
     <div class="card-header-text">
-      <h1><img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i> {{ ::portlet.title }}</h1>
+      <h1><img ng-src="{{portlet.iconUrl}}" ng-if="portlet.faIcon === '' || portlet.faIcon === null" alt="App icon"><i class="fa {{portlet.faIcon}}" ng-if="portlet.faIcon !== '' && portlet.faIcon !== null"></i> {{portlet.title }}</h1>
     </div>
   </div>
   <div class="col-xs-12 no-padding portlet-section">
       <div data-loading class='loading-gif'><img src="img/ajax-loader.gif" alt="Loading content, please wait"></div>
-	  <div ng-bind-html="portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{::portlet.nodeId}}">
+	  <div ng-bind-html="portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{portlet.nodeId}}">
 	  </div>
   </div>
 </div>


### PR DESCRIPTION
+ No more server side hit on max static content load, for the most part
+ If you do a deep link to that portlet and a) its not in the shared service or b) another portlet is in the shared service, it then goes to the layout to get it. If the layout doesn't exist yet it calls the service to populate the layout.
+ Moved layout to `$rootScope` so we can reuse it if we stay on `/web`. Note that if you add a portlet to your favs from marketplace it clears the `$rootScope.layout` due to the change.
+ If the portlet is not in your layout we redirect to /web (could be better, could goto marketplace entry (/web/#/app/details/:fname), but that page looked a little broken, buttons didn't do actions, so I didn't do that. Another thought I had was adding fname to the search, then grabbing that and doing a search on the fname)


