### PR TITLE
MUMUP-1537 : Make simple content real

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -12,8 +12,6 @@
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 
       notificationsDemo : false,
-      staticContentMax : false,
-      staticContentOnHome : false,
       pithyContentOnHome : false } );
   } ]);
 

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -113,10 +113,10 @@
 				  $location.path('/');
 			  }
 		  } else {
-			  layoutService.getLayout().then(function(data){
-			      $rootScope.layout = data.layout;
-			      $scope.portlet = that.getPortlet($routeParams.fname, $rootScope.layout);
-			      if(typeof $scope.portlet.fname === 'undefined') {
+			  layoutService.getApp($routeParams.fname).then(function(data){
+			      $scope.portlet = data.portlet;
+			      if(typeof $scope.portlet === 'undefined' || 
+			              typeof $scope.portlet.fname === 'undefined') {
 			    	  $location.path('/');
 			      }
 			  });

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -15,18 +15,14 @@
     }
     
     this.portletType = function portletType(portlet) {
-      if((portlet.staticContent == null
-                        || portlet.altMaxUrl == true)
-                    && (!$localStorage.pithyContentOnHome 
-                        || portlet.pithyStaticContent == null)) {
+      if($localStorage.pithyContentOnHome && portlet.pithyStaticContent != null) {
+          return "PITHY";
+      } else if(portlet.staticContent == null
+                 || portlet.altMaxUrl == true) {
           return "NORMAL";
       } else if (portlet.staticContent != null 
-                 && portlet.altMaxUrl == false
-                 && (!$localStorage.pithyContentOnHome 
-                     || portlet.pithyStaticContent == null)) {
+                 && portlet.altMaxUrl == false) {
           return "SIMPLE";
-      } else if ($localStorage.pithyContentOnHome && portlet.pithyStaticContent != null) {
-          return "PITHY";
       }
     }
     

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -3,7 +3,7 @@
 (function() {
   var app = angular.module('portal.layout.controllers', []);
 
-  app.controller('LayoutController', [ '$location', '$sessionStorage', '$scope', '$rootScope', 'layoutService', 'miscService', 'sharedPortletService', function($location, $sessionStorage, $scope, $rootScope, layoutService, miscService, sharedPortletService) {
+  app.controller('LayoutController', [ '$location', '$localStorage', '$sessionStorage', '$scope', '$rootScope', 'layoutService', 'miscService', 'sharedPortletService', function($location, $localStorage, $sessionStorage, $scope, $rootScope, layoutService, miscService, sharedPortletService) {
     miscService.pushPageview();
     if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
       
@@ -12,6 +12,22 @@
       layoutService.getLayout().then(function(data){
         $rootScope.layout = data.layout;
       });
+    }
+    
+    this.portletType = function portletType(portlet) {
+      if((portlet.staticContent == null
+                        || portlet.altMaxUrl == true)
+                    && (!$localStorage.pithyContentOnHome 
+                        || portlet.pithyStaticContent == null)) {
+          return "NORMAL";
+      } else if (portlet.staticContent != null 
+                 && portlet.altMaxUrl == false
+                 && (!$localStorage.pithyContentOnHome 
+                     || portlet.pithyStaticContent == null)) {
+          return "SIMPLE";
+      } else if ($localStorage.pithyContentOnHome && portlet.pithyStaticContent != null) {
+          return "PITHY";
+      }
     }
     
     this.maxStaticPortlet = function gotoMaxStaticPortlet(portlet) {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -18,7 +18,7 @@ app.factory('sharedPortletService', function () {
 
 app.factory('layoutService', function($http, miscService) {
 
-    var getLayout = function() {
+  var getLayout = function() {
     return $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').then(
       function(result) {
         return  result.data;
@@ -28,7 +28,18 @@ app.factory('layoutService', function($http, miscService) {
       }
     );
   }
-  
+    
+  var getApp = function(fname) {
+      return $http.get('/portal/api/portlet/' +fname + '.json').then(
+        function(result) {
+          return  result.data;
+        } ,
+        function(reason){
+         miscService.redirectUser(reason.status, 'getApp call');
+         return reason.data;
+        }
+      );
+  }
   var moveStuff = function moveStuffFunction(index, length, sourceId, previousNodeId, nextNodeId) {
       var insertNode = function(sourceId, previousNodeId, nextNodeId){
           var saveOrderURL = "/portal/api/layout?action=movePortletAjax"
@@ -67,6 +78,7 @@ app.factory('layoutService', function($http, miscService) {
 
   return {
     getLayout : getLayout,
+    getApp : getApp,
     moveStuff : moveStuff,
     getNewStuffFeed : getNewStuffFeed
   }

--- a/angularjs-portal-home/src/main/webapp/partials/layout.html
+++ b/angularjs-portal-home/src/main/webapp/partials/layout.html
@@ -37,31 +37,19 @@
     <ul ui-sortable="sortableOptions" ng-model="layout" id="cards-sortable">
        <li class="col-xs-12 col-sm-6 col-md-6 col-lg-4 no-padding portlet-container-home" ng-repeat="portlet in layout">
           <default-card 
-            ng-if="(!$storage.staticContentOnHome || 
-                    portlet.staticContent == null)
-                    &&
-                    (!$storage.pithyContentOnHome || 
-                     portlet.pithyStaticContent == null)
-                    &&
-                    (!$storage.staticContentMax || 
-                    portlet.staticContent == null)">
+            ng-if="(portlet.staticContent == null
+                        || portlet.altMaxUrl == true)
+                    && (!$storage.pithyContentOnHome 
+                        || portlet.pithyStaticContent == null)">
           </default-card>
           <static-content-card-max 
-            ng-if="$storage.staticContentMax &&
-                    portlet.staticContent != null">
+            ng-if="portlet.staticContent != null 
+                    && portlet.altMaxUrl == false
+                   && (!$storage.pithyContentOnHome 
+                       || portlet.pithyStaticContent == null)">
           </static-content-card-max>
-          <static-content-card 
-            ng-if="$storage.staticContentOnHome   &&
-                    portlet.staticContent != null &&
-                    !$storage.staticContentMax">
-          </static-content-card>
           <pithy-content-card 
-            ng-if="((!$storage.staticContentOnHome &&
-                    !$storage.staticContentMax) ||
-                    portlet.staticContent == null)
-                    &&
-                    ($storage.pithyContentOnHome &&
-                    portlet.pithyStaticContent != null)">
+            ng-if="$storage.pithyContentOnHome && portlet.pithyStaticContent != null">
           </pithy-content-card>
         </li>
     </ul>

--- a/angularjs-portal-home/src/main/webapp/partials/layout.html
+++ b/angularjs-portal-home/src/main/webapp/partials/layout.html
@@ -37,19 +37,13 @@
     <ul ui-sortable="sortableOptions" ng-model="layout" id="cards-sortable">
        <li class="col-xs-12 col-sm-6 col-md-6 col-lg-4 no-padding portlet-container-home" ng-repeat="portlet in layout">
           <default-card 
-            ng-if="(portlet.staticContent == null
-                        || portlet.altMaxUrl == true)
-                    && (!$storage.pithyContentOnHome 
-                        || portlet.pithyStaticContent == null)">
+            ng-if="'NORMAL' === layoutCtrl.portletType(portlet)">
           </default-card>
           <static-content-card-max 
-            ng-if="portlet.staticContent != null 
-                    && portlet.altMaxUrl == false
-                   && (!$storage.pithyContentOnHome 
-                       || portlet.pithyStaticContent == null)">
+            ng-if="'SIMPLE' === layoutCtrl.portletType(portlet)">
           </static-content-card-max>
           <pithy-content-card 
-            ng-if="$storage.pithyContentOnHome && portlet.pithyStaticContent != null">
+            ng-if="'PITHY' === layoutCtrl.portletType(portlet)">
           </pithy-content-card>
         </li>
     </ul>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -44,48 +44,12 @@
        <li class="portlet-container-home beta-card-style">
          <h4>
            <span class="btn-group">
-             <label class="btn" ng-class="{'btn-success' : $storage.staticContentMax, 'btn-default' : !$storage.staticContentMax }" ng-model="$storage.staticContentMax" btn-radio="true">On</label>
-             <label class="btn" ng-class="{'btn-success' : $storage.staticContentMax, 'btn-default' : !$storage.staticContentMax }" ng-model="$storage.staticContentMax" btn-radio="false">Off</label>
-           </span>
-           Static content on an Angular max page
-         </h4>
-         <small>Just changes the ng-view to /static/fname. This will save a server trip and 2 XSLT transformations.</small>
-       </li>
-       <li class="portlet-container-home beta-card-style">
-         <h4>
-           <span class="btn-group">
-             <label class="btn" ng-class="{'btn-success' : $storage.staticContentOnHome, 'btn-default' : !$storage.staticContentOnHome }" ng-model="$storage.staticContentOnHome" btn-radio="true">On</label>
-             <label class="btn" ng-class="{'btn-success' : $storage.staticContentOnHome, 'btn-default' : !$storage.staticContentOnHome }" ng-model="$storage.staticContentOnHome" btn-radio="false">Off</label>
-           </span>
-           Static Content Cards
-         </h4>
-         <small>Shows static content cards rather than default cards for portlets with associated static content.  Static content cards are the cards that expand to show the static content right on the home.</small>
-         <div class="alert alert-info" role="alert"
-           ng-show="$storage.staticContentMax 
-                    && $storage.staticContentOnHome">
-          The "Static content on an Angular max page" feature takes precedence over 
-          "Static Content Cards", so for portlets with static content associated 
-          with them, the Static content max will display on click.
-         </div>
-       </li>
-       <li class="portlet-container-home beta-card-style">
-         <h4>
-           <span class="btn-group">
              <label class="btn" ng-class="{'btn-success' : $storage.pithyContentOnHome, 'btn-default' : !$storage.pithyContentOnHome }" ng-model="$storage.pithyContentOnHome" btn-radio="true">On</label>
              <label class="btn" ng-class="{'btn-success' : $storage.pithyContentOnHome, 'btn-default' : !$storage.pithyContentOnHome }" ng-model="$storage.pithyContentOnHome" btn-radio="false">Off</label>
            </span>
            Pithy content cards
          </h4>
          <small>Shows pithy content cards rather than default cards for portlets with associated pithy static content.  Pithy content cards are the cards show some portlet-specific markup right on the face of the card.</small>
-         <div class="alert alert-info" role="alert"
-           ng-show="$storage.pithyContentOnHome 
-                    && ($storage.staticContentOnHome ||
-                        $storage.staticContentMax)">
-          The static content features take precedence over pithy content, 
-          so for portlets with both static and pithy content associated 
-          with them, the Static content will display and 
-          the Pithy content card will not.
-         </div>
        </li>
        <li class="portlet-container-home beta-card-style">
          <h4>


### PR DESCRIPTION
+ Removes beta setting for static content (both versions)
+ Adds in check for alternative max link
+ Swaps out "get full layout, loop through and pray it finds the portlet in your layout" with "get portlet" API call. If you don't have access or gave a bogus fname it redirects to home.
+ Restructured layout.html. We now have 3 states: `NORMAL`, `STATIC`, `PITHY`

`NORMAL` = no static content, or alt max URL was utilized
`STATIC` = static content exists, no max URL
`PITHY` = pithy flag set, has pithy content (*note:* this one trumps `NORMAL` and `STATIC`)

![image](http://goo.gl/r5Ofvm)