### PR TITLE
MUMUP-1565 : Admins can now see keywords if they flip the switch

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -8,6 +8,7 @@
     $scope.$storage = $localStorage.$default( {
       showSidebar: true, 
       sidebarQuicklinks: false, 
+      showKeywordsInMarketplace : false,
       homeImg : "img/square.jpg", 
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -11,7 +11,6 @@
       $http, $scope, $location, $routeParams, marketplaceService, 
       layoutService, miscService, mainService) {
 
-    $scope.$storage = $sessionStorage;
     //init variables
     var store = this;
     store.portlets = [];

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
@@ -77,17 +77,25 @@
   <div ng-if="showDetails" class="row portlet-details-div">
     <div class="col-xs-12 col-sm-3 related-portlets">
       <h3>Related Apps</h3>
-      <ul ng-repeat="related in portlet.relatedPortlets">
-        <li><a href="{{ ::related.maxUrl }}">{{ ::related.title }}</a></li>
+      <ul >
+        <li ng-repeat="related in portlet.relatedPortlets"><a href="{{ ::related.maxUrl }}">{{ ::related.title }}</a></li>
       </ul>
     </div>
     <div class="col-xs-12 col-sm-9 portlet-screenshots" ng-if="portlet.marketplaceScreenshots.length !== 0">
       <h3>Screenshots</h3>
-      <ul ng-repeat="screenshot in portlet.marketplaceScreenshots">
-        <li>
+      <ul >
+        <li ng-repeat="screenshot in portlet.marketplaceScreenshots">
           <img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">
           <p ng-repeat="caption in screenshot.captions">{{ ::caption }}</p>
         </li>
+      </ul>
+    </div>
+    
+    <div class="col-xs-12 col-sm-3 related-portlets" ng-if="$storage.showKeywordsInMarketplace">
+        <h3>Keywords</h3>
+      <ul >
+        <li ng-repeat="keyword in portlet.keywords | orderBy:'toLowerCase()'  track by $index"><a href='#/apps/search/{{ ::keyword }}'>{{ ::keyword }}</a></li>
+        <li ng-if="portlet.keywords == null || portlet.keywords.length == 0">(no keywords set)</li>
       </ul>
     </div>
   </div>

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -61,6 +61,16 @@
          </h4>
          <small>Enable/Disable the option to jump to my profile in the sidebar</small>
        </li>
+       <li class="portlet-container-home beta-card-style">
+         <h4>
+           <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.showKeywordsInMarketplace, 'btn-default' : !$storage.showKeywordsInMarketplace }" ng-model="$storage.showKeywordsInMarketplace" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.showKeywordsInMarketplace, 'btn-default' : !$storage.showKeywordsInMarketplace }" ng-model="$storage.showKeywordsInMarketplace" btn-radio="false">Off</label>
+           </span>
+           Show Keywords in Marketplace
+         </h4>
+         <small>Enable/Disable keywords showing up in marketplace details</small>
+       </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>
         <li class="no-padding portlet-container-home  beta-card-style" style='text-align : center;'>


### PR DESCRIPTION
### Admin flag
![image](https://cloud.githubusercontent.com/assets/3534544/6088540/3286ff4a-ae1d-11e4-8349-2b86bd8ab82f.png)
+ In beta settings

### With Keywords
![image](https://cloud.githubusercontent.com/assets/3534544/6088549/4617b068-ae1d-11e4-96d6-8b3b0cfa039f.png)

+ Clicking link will do the search
+ Sorted alphabetically (case insensitive)


### Without
![image](https://cloud.githubusercontent.com/assets/3534544/6088531/2019c00e-ae1d-11e4-8bca-dc863f68e74d.png)


Minor changes
+ Moved the ng-repeats to the li instead of the ul for all of the details sections. We don't need a new ul for every item :)
+ removed $scope.$storage (which was pointing at session storage) in marketplaceController as it wasn't being used and conflicted with mainControllers $scope.$storage which was pointing at local storage