### PR TITLE
MUMUP-1079 : Typeahead to search beta feature

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
@@ -1,6 +1,15 @@
 .bucky-nav-large li:first-of-type+li{
   position:absolute;width:30%;left:35%
 }
+.portlet-search-bar ul.dropdown-menu {
+  min-width: 90%;
+
+  li:first-of-type+li {
+    position: relative;
+    width: inherit;
+    left: 0;
+  }
+}
 #myuw-header span {
   font-size:25px;
 }

--- a/angularjs-portal-frame/src/main/webapp/frame.html
+++ b/angularjs-portal-frame/src/main/webapp/frame.html
@@ -62,6 +62,7 @@
 <script type="text/javascript" src="js/sortable.js"></script>
 <script type="text/javascript" src="js/angular-page.js"></script>
 <script type="text/javascript" src="js/main/main-controllers.js"></script>
+<script type="text/javascript" src="js/main/search-controller.js"></script>
 <script type="text/javascript" src="js/main/main-service.js"></script>
 <script type="text/javascript" src="js/main/main-directives.js"></script>
 <script type="text/javascript" src="js/controllers.js"></script>

--- a/angularjs-portal-frame/src/main/webapp/js/angular-page.js
+++ b/angularjs-portal-frame/src/main/webapp/js/angular-page.js
@@ -11,7 +11,8 @@
     'portal.misc.service',
     'portal.main.controllers',
     'portal.main.service',
-    'portal.main.directives'
+    'portal.main.directives',
+    'portal.search.controllers',
      ]);
  app.config(['$routeProvider',function($routeProvider, $locationProvider) {
 	 $routeProvider.

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -34,14 +34,6 @@
     this.navbarCollapsed = true;
     $scope.showSearch = false;
     $scope.showSearchFocus = false;
-    $scope.submit = function(){
-      if($scope.initialFilter != "") {
-        $location.path("/apps/search/"+ $scope.initialFilter);
-        $scope.initialFilter = "";
-        $scope.showSearch = false;
-        $scope.showSearchFocus = false;
-      }
-    };
     
     this.toggleSearch = function() {
         $scope.showSearch = !$scope.showSearch;

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -13,7 +13,10 @@
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 
       notificationsDemo : false,
-      pithyContentOnHome : false } );
+      staticContentMax : false,
+      staticContentOnHome : false,
+      pithyContentOnHome : false,
+      typeaheadSearch: false} );
   } ]);
 
   /* Username */
@@ -22,7 +25,7 @@
     var that = this;
     that.user = [];
     mainService.getUser().then(function(result){
-      that.user = result.data.person;
+      that.user = result;
     });
   }]);
 

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-controllers.js
@@ -13,8 +13,6 @@
       sidebarShowProfile: false, 
       profileImg: "img/terrace.jpg", 
       notificationsDemo : false,
-      staticContentMax : false,
-      staticContentOnHome : false,
       pithyContentOnHome : false,
       typeaheadSearch: false} );
   } ]);

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-directives.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-directives.js
@@ -18,12 +18,35 @@
     }
   });
 
-  app.directive('search', function() {
+  app.directive('search', ['miscService', 'marketplaceService', '$location', function(miscService, marketplaceService, $location) {
     return {
       restrict : 'E',
-      templateUrl : 'partials/search.html'
+      templateUrl : 'partials/search.html',
+      controller: function($scope) {
+          $scope.initialFilter = '';
+          $scope.filterMatches = [];
+          $scope.portletListLoading = true;
+          marketplaceService.getPortlets().then(function(data){
+              $scope.portlets = data.portlets;
+              $scope.portletListLoading = false;
+          });
+
+          $scope.$watch('initialFilter', function(newVal, oldVal) {
+              if (!newVal || !$scope.portlets) {
+                  $scope.filterMatches = [];
+                  return;
+              }
+
+              $scope.filterMatches = miscService.filterPortletsBySearchTerm($scope.portlets, newVal);
+          });
+
+          $scope.onSelect = function(portlet) {
+              $scope.initialFilter = portlet.name;
+              $location.path("/apps/search/" + $scope.initialFilter);
+          };
+      }
     }
-  });
+  }]);
 
   app.directive('username', function() {
     return {

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-directives.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-directives.js
@@ -18,33 +18,11 @@
     }
   });
 
-  app.directive('search', ['miscService', 'marketplaceService', '$location', function(miscService, marketplaceService, $location) {
+  app.directive('search', [function() {
     return {
       restrict : 'E',
       templateUrl : 'partials/search.html',
-      controller: function($scope) {
-          $scope.initialFilter = '';
-          $scope.filterMatches = [];
-          $scope.portletListLoading = true;
-          marketplaceService.getPortlets().then(function(data){
-              $scope.portlets = data.portlets;
-              $scope.portletListLoading = false;
-          });
-
-          $scope.$watch('initialFilter', function(newVal, oldVal) {
-              if (!newVal || !$scope.portlets) {
-                  $scope.filterMatches = [];
-                  return;
-              }
-
-              $scope.filterMatches = miscService.filterPortletsBySearchTerm($scope.portlets, newVal);
-          });
-
-          $scope.onSelect = function(portlet) {
-              $scope.initialFilter = portlet.name;
-              $location.path("/apps/search/" + $scope.initialFilter);
-          };
-      }
+      controller: 'SearchController'
     }
   }]);
 

--- a/angularjs-portal-frame/src/main/webapp/js/main/main-service.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/main-service.js
@@ -3,18 +3,24 @@
 (function() {
 var app = angular.module('portal.main.service', []);
 
-app.factory('mainService', function($http, miscService) {
+app.factory('mainService', ['$http', 'miscService', function($http, miscService) {
   var prom = $http.get('/portal/api/session.json', { cache: true});
   var sidebarPromise = $http.get('/web/samples/sidebar.json');
+  var userPromise;
 
   var getUser = function() {
-  	return prom.success(
+    if (userPromise) {
+        return userPromise;
+    }
+
+    userPromise = prom.then(
       function(data, status) { //success function
-        return data.person;
-      }).error(function(data, status) { // failure function
+          return data.data.person;
+      }, function(data, status) { // failure function
       miscService.redirectUser(status, "Get User Info");
     });
-  }
+    return userPromise;
+  };
   
   var getSidebar = function() {
     return sidebarPromise.success(
@@ -23,13 +29,13 @@ app.factory('mainService', function($http, miscService) {
       }).error(function(data, status) { // failure function
       miscService.redirectUser(status, "Get sidebar info");
     });
-  }
+  };
   
   return {
     getUser: getUser,
     getSidebar : getSidebar
-  }
+  };
 
-});
+}]);
 
 })();

--- a/angularjs-portal-frame/src/main/webapp/js/main/search-controller.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/search-controller.js
@@ -1,0 +1,27 @@
+'use strict';
+
+(function() {
+  var app = angular.module('portal.search.controllers', []);
+  app.controller('SearchController', [ 'miscService', '$location', '$scope', '$localStorage', function(miscService, $location, $scope, $localStorage) {
+      $scope.initialFilter = '';
+      $scope.filterMatches = [];
+      $scope.portletListLoading = true;
+      if($localStorage && $localStorage.typeaheadSearch) {
+          //TODO : Add in search for somewhere for frame
+      }
+
+      $scope.$watch('initialFilter', function(newVal, oldVal) {
+          if (!newVal || !$scope.portlets) {
+              $scope.filterMatches = [];
+              return;
+          }
+
+          $scope.filterMatches = [];//this is where you would run your filter function
+      });
+
+      $scope.onSelect = function(portlet) {
+          $scope.initialFilter = portlet.name;
+          $location.path("/apps/search/" + $scope.initialFilter);
+      };
+    }]);
+})();

--- a/angularjs-portal-frame/src/main/webapp/js/main/search-controller.js
+++ b/angularjs-portal-frame/src/main/webapp/js/main/search-controller.js
@@ -20,8 +20,19 @@
       });
 
       $scope.onSelect = function(portlet) {
-          $scope.initialFilter = portlet.name;
-          $location.path("/apps/search/" + $scope.initialFilter);
+              $location.path("/apps/search/"+ portlet.name);
+              $scope.initialFilter = "";
+              $scope.showSearch = false;
+              $scope.showSearchFocus = false;
       };
+      
+      $scope.submit = function(){
+          if($scope.initialFilter != "") {
+            $location.path("/apps/search/"+ $scope.initialFilter);
+            $scope.initialFilter = "";
+            $scope.showSearch = false;
+            $scope.showSearchFocus = false;
+          }
+        };
     }]);
 })();

--- a/angularjs-portal-frame/src/main/webapp/js/services.js
+++ b/angularjs-portal-frame/src/main/webapp/js/services.js
@@ -31,10 +31,60 @@ app.factory('miscService', function($http, $window, $location) {
     $window._gaq.push(['_trackEvent', category, action, label]);
   }
 
+    var portletMatchesSearchTerm = function(portlet, searchTerm, opts) {
+        if (!searchTerm) {
+            return false;
+        }
+
+        var lowerSearchTerm = searchTerm.toLowerCase(); //create local var for searchTerm
+
+        if(portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {//check title
+            return true;
+        }
+
+        if (opts && opts.searchDescription) {
+            //check description match
+            if(portlet.description && portlet.description.toLowerCase().indexOf(lowerSearchTerm) !== -1) {
+                return true;
+            }
+        }
+
+        //last ditch effort, check keywords
+        if (opts && opts.searchKeywords) {
+            if (portlet.keywords) {
+                for (var i = 0; i < portlet.keywords.length; i++) {
+                    if (portlet.keywords[i].toLowerCase().indexOf(lowerSearchTerm) !== -1) {
+                        return true;
+                    }
+                }
+            }
+        }
+        return false;
+    };
+
+    var filterPortletsBySearchTerm = function(portletList, searchTerm, opts) {
+        var matches;
+
+        if (!angular.isArray(portletList)) {
+            return null;
+        }
+
+        matches = [];
+        angular.forEach(portletList, function(portlet) {
+            if (portletMatchesSearchTerm(portlet, searchTerm, opts)) {
+                matches.push(portlet);
+            }
+        });
+
+        return matches;
+    };
+
   return {
     redirectUser: redirectUser,
     pushPageview: pushPageview,
-    pushGAEvent : pushGAEvent
+    pushGAEvent : pushGAEvent,
+    filterPortletsBySearchTerm: filterPortletsBySearchTerm,
+    portletMatchesSearchTerm: portletMatchesSearchTerm
   }
 
 });

--- a/angularjs-portal-frame/src/main/webapp/js/services.js
+++ b/angularjs-portal-frame/src/main/webapp/js/services.js
@@ -31,60 +31,10 @@ app.factory('miscService', function($http, $window, $location) {
     $window._gaq.push(['_trackEvent', category, action, label]);
   }
 
-    var portletMatchesSearchTerm = function(portlet, searchTerm, opts) {
-        if (!searchTerm) {
-            return false;
-        }
-
-        var lowerSearchTerm = searchTerm.toLowerCase(); //create local var for searchTerm
-
-        if(portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {//check title
-            return true;
-        }
-
-        if (opts && opts.searchDescription) {
-            //check description match
-            if(portlet.description && portlet.description.toLowerCase().indexOf(lowerSearchTerm) !== -1) {
-                return true;
-            }
-        }
-
-        //last ditch effort, check keywords
-        if (opts && opts.searchKeywords) {
-            if (portlet.keywords) {
-                for (var i = 0; i < portlet.keywords.length; i++) {
-                    if (portlet.keywords[i].toLowerCase().indexOf(lowerSearchTerm) !== -1) {
-                        return true;
-                    }
-                }
-            }
-        }
-        return false;
-    };
-
-    var filterPortletsBySearchTerm = function(portletList, searchTerm, opts) {
-        var matches;
-
-        if (!angular.isArray(portletList)) {
-            return null;
-        }
-
-        matches = [];
-        angular.forEach(portletList, function(portlet) {
-            if (portletMatchesSearchTerm(portlet, searchTerm, opts)) {
-                matches.push(portlet);
-            }
-        });
-
-        return matches;
-    };
-
   return {
     redirectUser: redirectUser,
     pushPageview: pushPageview,
     pushGAEvent : pushGAEvent,
-    filterPortletsBySearchTerm: filterPortletsBySearchTerm,
-    portletMatchesSearchTerm: portletMatchesSearchTerm
   }
 
 });

--- a/angularjs-portal-frame/src/main/webapp/partials/search.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/search.html
@@ -11,6 +11,7 @@
             typeahead-on-select="onSelect($item, $model, $label)"
             typeahead-loading="portletListLoading"
             typeahead-min-length="2"
+            typeahead-focus-first='false'
             autocomplete="off" >
 
       <input type="search" class="main-search"

--- a/angularjs-portal-frame/src/main/webapp/partials/search.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/search.html
@@ -1,6 +1,26 @@
 <form ng-submit="submit()">
-  <div class="input-group">
-    <input type="search" class="main-search" placeholder="Search MyUW" name="initialFilter" ng-model="initialFilter" aria-label="Search MyUW" focus-me="showSearchFocus">
+  <div class="input-group portlet-search-bar">
+    <input type="search" class="main-search"
+            placeholder="Search MyUW"
+            name="initialFilter"
+            ng-model="initialFilter"
+            aria-label="Search MyUW"
+            focus-me="showSearchFocus"
+            ng-show="$storage.typeaheadSearch"
+            typeahead="title as match.title for match in filterMatches | limitTo:10"
+            typeahead-on-select="onSelect($item, $model, $label)"
+            typeahead-loading="portletListLoading"
+            typeahead-min-length="2">
+
+      <input type="search" class="main-search"
+            placeholder="Search MyUW"
+            name="initialFilter"
+            ng-model="initialFilter"
+            aria-label="Search MyUW"
+            focus-me="showSearchFocus"
+            ng-hide="$storage.typeaheadSearch"/>
+
+
     <span class="input-group-btn">
       <button class="btn btn-default btn-search">
         <i class="fa fa-search"></i>

--- a/angularjs-portal-frame/src/main/webapp/partials/search.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/search.html
@@ -10,7 +10,8 @@
             typeahead="title as match.title for match in filterMatches | limitTo:10"
             typeahead-on-select="onSelect($item, $model, $label)"
             typeahead-loading="portletListLoading"
-            typeahead-min-length="2">
+            typeahead-min-length="2"
+            autocomplete="off" >
 
       <input type="search" class="main-search"
             placeholder="Search MyUW"
@@ -18,7 +19,8 @@
             ng-model="initialFilter"
             aria-label="Search MyUW"
             focus-me="showSearchFocus"
-            ng-hide="$storage.typeaheadSearch"/>
+            ng-hide="$storage.typeaheadSearch"
+            autocomplete="off" />
 
 
     <span class="input-group-btn">

--- a/angularjs-portal-home/src/main/webapp/home.html
+++ b/angularjs-portal-home/src/main/webapp/home.html
@@ -62,6 +62,7 @@
   <script type="text/javascript" src="js/sortable.js"></script>
   <script type="text/javascript" src="js/angular-page.js"></script>
   <script type="text/javascript" src="js/main/main-controllers.js"></script>
+  <script type="text/javascript" src="js/main/search-controller.js"></script>
   <script type="text/javascript" src="js/main/main-service.js"></script>
   <script type="text/javascript" src="js/main/main-directives.js"></script>
   <script type="text/javascript" src="js/layout/layout-controller.js"></script>

--- a/angularjs-portal-home/src/main/webapp/js/angular-page.js
+++ b/angularjs-portal-home/src/main/webapp/js/angular-page.js
@@ -14,6 +14,7 @@
     'portal.layout.directives',
     'portal.layout.controllers',
     'portal.layout.service',
+    'portal.search.controllers',
     'portal.main.directives',
     'portal.marketplace.controller',
     'portal.marketplace.service',

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -17,8 +17,6 @@ app.factory('sharedPortletService', function () {
 });
 
 app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionStorage', '$q', function($http, miscService, mainService, $sessionStorage, $q) {
-    var layoutPromise;
-    
   var addToHome = function addToHomeFunction(portlet) {
       var fname = portlet.fname;
       var tabName = "UW Bucky Home";
@@ -73,19 +71,6 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
                 return defer.promise;
             }
 
-            // then check for outstanding requests that may have not yet been cached.
-
-            // Downside of adding caching in getUser() is that the
-            // promise in getUser blocks till we get results.  That blocks
-            // the call to getLayout.  So, they pile up.  Then, when
-            // getUser clears, all the getUser promises fire immediately.
-            // They all fire so fast that the layout data doesn't make it
-            // to cache between calls.  So, cache the very first promise locally.
-            // Then, if the layout promise exists use it again.
-            if (layoutPromise) {
-                return layoutPromise;
-            }
-
             successFn = function(result) {
                 var data =  result.data;
                 storeLayoutInCache(data);
@@ -98,8 +83,7 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
             };
 
             // no caching...  request from the server
-            layoutPromise = $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').then(successFn, errorFn);
-            return layoutPromise;
+            return $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').then(successFn, errorFn);;
         });
     };
     

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -16,7 +16,8 @@ app.factory('sharedPortletService', function () {
     };
 });
 
-app.factory('layoutService', function($http, miscService) {
+app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionStorage', '$q', function($http, miscService, mainService, $sessionStorage, $q) {
+    var layoutPromise;
     
   var addToHome = function addToHomeFunction(portlet) {
       var fname = portlet.fname;
@@ -41,16 +42,66 @@ app.factory('layoutService', function($http, miscService) {
       return ret;
     };
 
-  var getLayout = function() {
-    return $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').then(
-      function(result) {
-        return  result.data;
-      } ,
-      function(reason){
-       miscService.redirectUser(reason.status, 'layoutDoc call');
-      }
-    );
-  }
+    var checkLayoutCache = function() {
+        var userPromise = mainService.getUser();
+        return userPromise.then(function(user) {
+            if ($sessionStorage.sessionKey === user.sessionKey && $sessionStorage.layout) {
+                return $sessionStorage.layout;
+            }
+
+            return null;
+        });
+    };
+
+    var storeLayoutInCache = function(data) {
+        var userPromise = mainService.getUser();
+        userPromise.then(function(user) {
+            $sessionStorage.sessionKey = user.sessionKey;
+            $sessionStorage.layout = data;
+        });
+    };
+
+
+    var getLayout = function() {
+        return checkLayoutCache().then(function(data) {
+            var successFn, errorFn, defer;
+
+            // first, check the local storage...
+            if (data) {
+                defer = $q.defer();
+                defer.resolve(data);
+                return defer.promise;
+            }
+
+            // then check for outstanding requests that may have not yet been cached.
+
+            // Downside of adding caching in getUser() is that the
+            // promise in getUser blocks till we get results.  That blocks
+            // the call to getLayout.  So, they pile up.  Then, when
+            // getUser clears, all the getUser promises fire immediately.
+            // They all fire so fast that the layout data doesn't make it
+            // to cache between calls.  So, cache the very first promise locally.
+            // Then, if the layout promise exists use it again.
+            if (layoutPromise) {
+                return layoutPromise;
+            }
+
+            successFn = function(result) {
+                var data =  result.data;
+                storeLayoutInCache(data);
+
+                return data;
+            };
+
+            errorFn = function(reason) {
+                miscService.redirectUser(reason.status, 'layoutDoc call');
+            };
+
+            // no caching...  request from the server
+            layoutPromise = $http.get('/portal/api/layoutDoc?tab=UW Bucky Home').then(successFn, errorFn);
+            return layoutPromise;
+        });
+    };
     
   var getApp = function(fname) {
       return $http.get('/portal/api/portlet/' +fname + '.json').then(
@@ -107,6 +158,6 @@ app.factory('layoutService', function($http, miscService) {
     addToHome : addToHome
   }
 
-});
+}]);
 
 })();

--- a/angularjs-portal-home/src/main/webapp/js/main/search-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/main/search-controller.js
@@ -1,0 +1,30 @@
+'use strict';
+
+(function() {
+  var app = angular.module('portal.search.controllers', []);
+  app.controller('SearchController', [ 'marketplaceService', '$location', '$scope', '$localStorage', function(marketplaceService, $location, $scope, $localStorage) {
+      $scope.initialFilter = '';
+      $scope.filterMatches = [];
+      $scope.portletListLoading = true;
+      if($localStorage && $localStorage.typeaheadSearch) {
+          marketplaceService.getPortlets().then(function(data){
+              $scope.portlets = data.portlets;
+              $scope.portletListLoading = false;
+          });
+      }
+
+      $scope.$watch('initialFilter', function(newVal, oldVal) {
+          if (!newVal || !$scope.portlets) {
+              $scope.filterMatches = [];
+              return;
+          }
+
+          $scope.filterMatches = marketplaceService.filterPortletsBySearchTerm($scope.portlets, newVal);
+      });
+
+      $scope.onSelect = function(portlet) {
+          $scope.initialFilter = portlet.name;
+          $location.path("/apps/search/" + $scope.initialFilter);
+      };
+    }]);
+})();

--- a/angularjs-portal-home/src/main/webapp/js/main/search-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/main/search-controller.js
@@ -23,8 +23,19 @@
       });
 
       $scope.onSelect = function(portlet) {
-          $scope.initialFilter = portlet.name;
-          $location.path("/apps/search/" + $scope.initialFilter);
+          $location.path("/apps/search/"+ portlet.name);
+          $scope.initialFilter = "";
+          $scope.showSearch = false;
+          $scope.showSearchFocus = false;
       };
+  
+      $scope.submit = function(){
+      if($scope.initialFilter != "") {
+        $location.path("/apps/search/"+ $scope.initialFilter);
+        $scope.initialFilter = "";
+        $scope.showSearch = false;
+        $scope.showSearchFocus = false;
+      }
+    };
     }]);
 })();

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -16,29 +16,10 @@
     store.portlets = [];
     store.count = 0;
     store.user = [];
-    mainService.getUser().then(function(person){
-      store.user = person;
-
-      //get marketplace portlets
-      if($sessionStorage.sessionKey == store.user.sessionKey
-        && $sessionStorage.marketplace != null
-        && $sessionStorage.categories != null) {
-
-          store.portlets = $sessionStorage.marketplace;
-          $scope.categories = $sessionStorage.categories;
-          
-      } else {
-          marketplaceService.getPortlets().then(function(data) {
-            store.portlets = data.portlets;
-            $scope.categories = data.categories;
-            $scope.layout = data.layout;
-            
-            $sessionStorage.marketplace = data.portlets;
-            $sessionStorage.categories = data.categories;
-            $sessionStorage.sessionKey = store.user.sessionKey;
-          });
-      }
-      
+    
+    marketplaceService.getPortlets().then(function(data) {
+        store.portlets = data.portlets;
+        $scope.categories = data.categories;
     });
     
     

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -74,6 +74,7 @@
                     marketplaceEntries[0].hasInLayout = true;
                 }
                 $rootScope.layout = null; //reset layout due to modifications
+                $sessionStorage.layout = null;
             });
           })
         .error(function(request, text, error) {
@@ -100,9 +101,10 @@
     };
 
     $scope.searchTermFilter = function(portlet) {
-      return miscService.portletMatchesSearchTerm(portlet, $scope.searchTerm, {
+      return marketplaceService.portletMatchesSearchTerm(portlet, $scope.searchTerm, {
           searchDescription: true,
-          searchKeywords: true
+          searchKeywords: true,
+          defaultReturn : true,
       });
     };
 

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-controller.js
@@ -16,8 +16,8 @@
     store.portlets = [];
     store.count = 0;
     store.user = [];
-    mainService.getUser().then(function(result){
-      store.user = result.data.person;
+    mainService.getUser().then(function(person){
+      store.user = person;
 
       //get marketplace portlets
       if($sessionStorage.sessionKey == store.user.sessionKey
@@ -100,30 +100,10 @@
     };
 
     $scope.searchTermFilter = function(portlet) {
-        if($scope.searchTerm === undefined) {//nothing filled for search
-            return true;
-        }
-        var searchTerm = $scope.searchTerm.toLowerCase(); //create local var for searchTerm
-        
-        if(portlet.title.toLowerCase().indexOf(searchTerm) !== -1) {//check title
-            return true;
-        }
-        
-        //check description match
-        if(portlet.description !== null 
-                && portlet.description.toLowerCase().indexOf(searchTerm) !== -1) {
-            return true;
-        }
-        
-        //last ditch effort, check keywords
-        if(portlet.keywords !== null) {
-            for(var i = 0; i < portlet.keywords.length; i++) {
-                if(portlet.keywords[i].toLowerCase().indexOf(searchTerm) !== -1) {
-                    return true;
-                }
-            }
-        }
-        return false;
+      return miscService.portletMatchesSearchTerm(portlet, $scope.searchTerm, {
+          searchDescription: true,
+          searchKeywords: true
+      });
     };
 
 

--- a/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-service.js
+++ b/angularjs-portal-home/src/main/webapp/js/marketplace/marketplace-service.js
@@ -73,6 +73,54 @@ app.factory('marketplaceService', ['$q', '$http', 'layoutService', 'miscService'
     result.layout = layout;
   }
   
+  var portletMatchesSearchTerm = function(portlet, searchTerm, opts) {
+      if (!searchTerm) {
+          return opts && opts.defaultReturn;
+      }
+
+      var lowerSearchTerm = searchTerm.toLowerCase(); //create local var for searchTerm
+
+      if(portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {//check title
+          return true;
+      }
+
+      if (opts && opts.searchDescription) {
+          //check description match
+          if(portlet.description && portlet.description.toLowerCase().indexOf(lowerSearchTerm) !== -1) {
+              return true;
+          }
+      }
+
+      //last ditch effort, check keywords
+      if (opts && opts.searchKeywords) {
+          if (portlet.keywords) {
+              for (var i = 0; i < portlet.keywords.length; i++) {
+                  if (portlet.keywords[i].toLowerCase().indexOf(lowerSearchTerm) !== -1) {
+                      return true;
+                  }
+              }
+          }
+      }
+      return false;
+  };
+
+  var filterPortletsBySearchTerm = function(portletList, searchTerm, opts) {
+      var matches;
+
+      if (!angular.isArray(portletList)) {
+          return null;
+      }
+
+      matches = [];
+      angular.forEach(portletList, function(portlet) {
+          if (portletMatchesSearchTerm(portlet, searchTerm, opts)) {
+              matches.push(portlet);
+          }
+      });
+
+      return matches;
+  };
+  
   //return list of avaliable functions
 
   return {
@@ -80,7 +128,9 @@ app.factory('marketplaceService', ['$q', '$http', 'layoutService', 'miscService'
     initialFilter: initialFilter,
     getInitialFilter: getInitialFilter,
     getUserRating : getUserRating,
-    saveRating : saveRating
+    saveRating : saveRating,
+    filterPortletsBySearchTerm: filterPortletsBySearchTerm,
+    portletMatchesSearchTerm: portletMatchesSearchTerm
   };
 
 }]);

--- a/angularjs-portal-home/src/main/webapp/partials/settings.html
+++ b/angularjs-portal-home/src/main/webapp/partials/settings.html
@@ -69,6 +69,16 @@
          </h4>
          <small>Enable/Disable keywords showing up in marketplace details</small>
        </li>
+       <li class="portlet-container-home beta-card-style">
+            <h4>
+           <span class="btn-group">
+             <label class="btn" ng-class="{'btn-success' : $storage.typeaheadSearch, 'btn-default' : !$storage.typeaheadSearch }" ng-model="$storage.typeaheadSearch" btn-radio="true">On</label>
+             <label class="btn" ng-class="{'btn-success' : $storage.typeaheadSearch, 'btn-default' : !$storage.typeaheadSearch }" ng-model="$storage.typeaheadSearch" btn-radio="false">Off</label>
+           </span>
+                Enable typeahead in the portlet search bar
+            </h4>
+            <small>Enable/Disable the typeahead in the portlet search bar</small>
+        </li>
     </ul>
     <ul class="col-sm-6" style='padding-top: 1em;'>
         <li class="no-padding portlet-container-home  beta-card-style" style='text-align : center;'>


### PR DESCRIPTION
This has all the work from #119 (many thanks @jhelmer-unicon ) plus some additional re-factoring.

### From #119:
Add typeahead to the searchbox.   

Screens:
![http://goo.gl/Y4NViM](http://goo.gl/Y4NViM)

### Additional changes:
+ Restructured search to be in the marketplace code base, and in home module, for the most part
+ Created a stub search controller for frame so adopters have somewhere to start with
+ Moved the session storage caching for marketplace to the service layer (mimic of what was done in layout)
+ Fixed some minor bugs with on submit
+ Made the fetch of the marketplace only happen if the beta flag is set to true.

![image](https://cloud.githubusercontent.com/assets/3534544/6175548/556679ce-b2bd-11e4-95a6-58d6d2ddb0a5.png)

### Known bugs
+ When you select a typeahead item, it just goes to marketplace entry. (what it should do it TBD)
+ When you select a typeahead item, the focus is not correct when you hit the marketplace (this doesn't happen all the time, but sometimes)
+ #betafeature 