### PR TITLE
MUMUP-1470: Bigger Screenshots

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
@@ -218,17 +218,95 @@
   padding:0px;
   display:inline-block;
   border-left:1px solid #ddd;
+  
   ul {
     margin:0px;
     padding:0px 0px 0px 20px;
   }
+  
+  ul.enlarge{
+  	list-style-type:none;
+  }
+  
+  ul.enlarge li{
+  	display:inline-block;
+  	position: relative;
+  	z-index: 0;
+  	margin: 10px 40px 0 20px;
+  }
+  
+  ul.enlarge span img{
+  	padding: 2px;
+  }
+  
+  ul.enlarge span{
+  	position:absolute;
+  	left: -9999px;
+  	padding: 5px 5px 0px 5px;
+  	background:#D8D8D8;
+  	font-size:.9em;
+  	text-align: center;
+  	color: black;
+  	-webkit-border-radius: 8px;
+  }
+
+  ul.enlarge li:hover{
+  	z-index: 50;
+  	cursor:pointer;
+  }
+  
+  @media only screen and (min-width: 768px){
+  	ul.enlarge li:hover span{
+  		
+  		top:-220px;
+  		left:-190px;
+  		width:590px;
+  	}
+  }
+  
+  @media only screen and (min-width: 956px){
+    ul.enlarge li:hover span{
+  		
+  		top: -300px;
+  		left: -210px;
+  		width: 740px;
+  	}
+  }
+
+ 
+  @media only screen and (min-width: 1330px){
+    ul.enlarge li:hover span{
+    	
+  		top: -220px;
+  		left:-250px;
+  		width:640px;
+  	}
+  } 
+   @media only screen and (min-width: 1557px){
+    ul.enlarge li:hover span{
+    	
+  		top: -300px;
+  		left: -210px;
+  		width: 740px;
+  	}
+  }
+  
+
+  
+  
+  
+ 
   li {
     display:inline-block;
     float:left;
     margin:5px;
+    border-style: solid;
+    border-width: 1px;
+    border-color: #dddddd;
   }
+  
   img {
-    width:200px;
+    max-width:100%;
   }
 }
 input:focus,span:focus {

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
@@ -83,10 +83,17 @@
     </div>
     <div class="col-xs-12 col-sm-9 portlet-screenshots" ng-if="portlet.marketplaceScreenshots.length !== 0">
       <h3>Screenshots</h3>
-      <ul >
-        <li ng-repeat="screenshot in portlet.marketplaceScreenshots">
-          <img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">
-          <p ng-repeat="caption in screenshot.captions">{{ ::caption }}</p>
+<<<<<<< HEAD
+      
+      <ul class="enlarge" ng-repeat="screenshot in portlet.marketplaceScreenshots">
+        <li>
+          <img ng-src="{{ ::screenshot.url }}" width ="320px" alt="{{ ::screenshot.captions }}">
+          <span>
+          	<img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">
+          	<p ng-repeat="caption in screenshot.captions">{{ ::caption }}</p>
+          </span>
+          
+>>>>>>> MUMUP-1470: Bigger Screenshots
         </li>
       </ul>
     </div>

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
@@ -83,8 +83,6 @@
     </div>
     <div class="col-xs-12 col-sm-9 portlet-screenshots" ng-if="portlet.marketplaceScreenshots.length !== 0">
       <h3>Screenshots</h3>
-<<<<<<< HEAD
-      
       <ul class="enlarge" ng-repeat="screenshot in portlet.marketplaceScreenshots">
         <li>
           <img ng-src="{{ ::screenshot.url }}" width ="320px" alt="{{ ::screenshot.captions }}">
@@ -92,8 +90,6 @@
           	<img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">
           	<p ng-repeat="caption in screenshot.captions">{{ ::caption }}</p>
           </span>
-          
->>>>>>> MUMUP-1470: Bigger Screenshots
         </li>
       </ul>
     </div>

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-portlet.html
@@ -83,8 +83,8 @@
     </div>
     <div class="col-xs-12 col-sm-9 portlet-screenshots" ng-if="portlet.marketplaceScreenshots.length !== 0">
       <h3>Screenshots</h3>
-      <ul class="enlarge" ng-repeat="screenshot in portlet.marketplaceScreenshots">
-        <li>
+      <ul class="enlarge">
+        <li ng-repeat="screenshot in portlet.marketplaceScreenshots">
           <img ng-src="{{ ::screenshot.url }}" width ="320px" alt="{{ ::screenshot.captions }}">
           <span>
           	<img ng-src="{{ ::screenshot.url }}" alt="{{ ::screenshot.captions }}">


### PR DESCRIPTION
Previously, screenshots were really tiny and users had no ability to enlarge them or really understand what content the portlet has to offer by seeing the screenshots. I used a bunch of CSS to make them a little bigger, added a border, and also added a hover feature that makes a larger version of the image pop out so the user can get a good glimpse of the content in this portlet.

Before:
![before](https://cloud.githubusercontent.com/assets/7268126/6193896/1a0e64b8-b385-11e4-8b04-75347f4bb3ee.png)

After (with larger images in background + hover-enlarge ability):
![screenshot](https://cloud.githubusercontent.com/assets/7268126/6193906/2fa4de7e-b385-11e4-9592-d228bd24c1c4.png)

After (with smaller window):
![screenshot 2 p1](https://cloud.githubusercontent.com/assets/7268126/6193861/d56c692c-b384-11e4-99aa-e3d5deba7bbf.png)

After (with smaller window and hover-enlarging)
![screenshot 2 p2](https://cloud.githubusercontent.com/assets/7268126/6193865/e150050a-b384-11e4-9c00-6bdfe392aeb7.png)

The bigger image disappears as soon as the mouse hovers off of it. 

Also, for those wondering, having the @media only screen several different times was the very inefficient way of keeping the enlarged images from being cut off, but it works very well.

Please note that this is disabled on mobile/smaller devices.
