### PR TITLE
Replace absolute url to crest image with relative path

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/partials/header.html
+++ b/angularjs-portal-frame/src/main/webapp/partials/header.html
@@ -8,7 +8,7 @@
                  <span class="icon-bar"></span>
              </button>
              <div class="header-mobile">
-               <h3><a class="header-text" href="#/" id="myuw-header"><img src="/portal/media/skins/bucky/common/images/uwcrest_web_sm.png" class="hidden-xs" alt="UW Crest"><span>MyUW</span><span class="beta-logo">Beta</span></a></h3>
+               <h3><a class="header-text" href="#/" id="myuw-header"><img src="img/uwcrest_web_sm.png" class="hidden-xs" alt="UW Crest"><span>MyUW</span><span class="beta-logo">Beta</span></a></h3>
              </div>
               <div class="search-mobile-icon hidden-sm hidden-md hidden-lg">
                 <i class="fa fa-search" ng-click="headerCtrl.toggleSearch()"></i>


### PR DESCRIPTION
The previous iteration had an absolute (MUM deployment specific) URL for the crest image. Changed to a relative URL available in the build result.

Allows downstream consumers of angularjs-portal-frame to use this
partial unmodified.