### PR TITLE
MUMUP-1704 : Support "App" model

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/frame.html
+++ b/angularjs-portal-frame/src/main/webapp/frame.html
@@ -71,5 +71,6 @@
 <script type="text/javascript" src="js/filters.js"></script>
 <script type="text/javascript" src="js/ui-bootstrap.js"></script>
 <script type="text/javascript" src="js/ga.js"></script>
+<script type="text/javascript" src="my-app.js"></script>
 </body>
 </html>

--- a/angularjs-portal-frame/src/main/webapp/js/angular-page.js
+++ b/angularjs-portal-frame/src/main/webapp/js/angular-page.js
@@ -1,4 +1,3 @@
-(function() {
  var app = angular.module('portal', [
     'ngRoute',
     'ngStorage',
@@ -21,7 +20,4 @@
       otherwise({templateUrl: 'partials/main.html'});
       }
  	]);
-
-
-
-})();
+ 	

--- a/angularjs-portal-frame/src/main/webapp/my-app.js
+++ b/angularjs-portal-frame/src/main/webapp/my-app.js
@@ -1,0 +1,6 @@
+/*
+This file intentionally left blank. This file is intended to serve as an extension point
+for My UW Madison 'App' developers that overlay angularjs-portal-frame.
+
+For more information, see: https://github.com/UW-Madison-DoIT/my-app-seed
+*/


### PR DESCRIPTION
This change set includes 2 important changes:

1. The 'app' variable provided by angular-page.js is no longer hidden
from global scope. This will allow "Apps" that overlay
angularjs-portal-frame to have access to the result of angular.module.
2. Adds 'my-app.js' to frame.html. The file included in this project is
intentionally blank. It's inclusion allows an "App" developer an
extension point; the end result is that the downstream app does not have
to have a copy of frame.html, they can just write their own my-app.js.