### PR TITLE
MUMUP-1615 : Mail widget for realz

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -118,12 +118,9 @@
                                               
     miscService.pushPageview();
     $scope.toggle = APP_FLAGS.enableToggle;
-    if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
-      
-      $rootScope.layout = [];
+    var that = this;
     
-      layoutService.getLayout().then(function(data){
-        $rootScope.layout = data.layout;
+    that.populateWidgetContent = function() {
         for(var i=0; i < $rootScope.layout.length; i++) {
             if($rootScope.layout[i].widgetURL && $rootScope.layout[i].widgetType) {
               //fetch portlet widget json
@@ -144,7 +141,20 @@
               });
             }
         }
+    }
+    
+    if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
+      
+      $rootScope.layout = [];
+    
+      layoutService.getLayout().then(function(data){
+        $rootScope.layout = data.layout;
+        that.populateWidgetContent();
+        $rootScope.widgetsPopulated = true;
       });
+    } else if (!($rootScope.widgetsPopulated)) {
+        that.populateWidgetContent();
+        $rootScope.widgetsPopulated = true;
     }
     
     this.portletType = function portletType(portlet) {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -125,7 +125,7 @@
             if($rootScope.layout[i].widgetURL && $rootScope.layout[i].widgetType) {
               //fetch portlet widget json
               $rootScope.layout[i].widgetData = [];
-              layoutService.getWidgetJson($rootScope.layout[i], i).then(function(data) {
+              layoutService.getWidgetJson($rootScope.layout[i]).then(function(data) {
                 if(data) {
                     console.log(data);
                 } else {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -130,7 +130,12 @@
               $rootScope.layout[i].widgetData = [];
               layoutService.getWidgetJson($rootScope.layout[i], i).then(function(data) {
                 if(data) {
-                    $rootScope.layout[data.index].widgetData = data.result;
+                    if(data.result) {
+                      $rootScope.layout[data.index].widgetData = data.result;
+                    }
+                    if(data.content) {
+                      $rootScope.layout[data.index].widgetContent = data.content;
+                    }
                     console.log($rootScope.layout[data.index].fname + "'s widget data came back with data: ");
                     console.log(data);
                 } else {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -127,13 +127,6 @@
               $rootScope.layout[i].widgetData = [];
               layoutService.getWidgetJson($rootScope.layout[i], i).then(function(data) {
                 if(data) {
-                    if(data.result) {
-                      $rootScope.layout[data.index].widgetData = data.result;
-                    }
-                    if(data.content) {
-                      $rootScope.layout[data.index].widgetContent = data.content;
-                    }
-                    console.log($rootScope.layout[data.index].fname + "'s widget data came back with data: ");
                     console.log(data);
                 } else {
                     console.warn("Got nothing back from widget fetch");

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -27,7 +27,7 @@
       
       $rootScope.layout = [];
     
-      layoutService.getLayout(false).then(function(data){
+      layoutService.getLayout().then(function(data){
         $rootScope.layout = data.layout;
       });
     }
@@ -122,7 +122,7 @@
       
       $rootScope.layout = [];
     
-      layoutService.getLayout(true).then(function(data){
+      layoutService.getLayout().then(function(data){
         $rootScope.layout = data.layout;
         for(var i=0; i < $rootScope.layout.length; i++) {
             if($rootScope.layout[i].widgetURL && $rootScope.layout[i].widgetType) {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -27,18 +27,17 @@
       
       $rootScope.layout = [];
     
-      layoutService.getLayout().then(function(data){
+      layoutService.getLayout(false).then(function(data){
         $rootScope.layout = data.layout;
       });
     }
     
     this.portletType = function portletType(portlet) {
-      if(portlet.staticContent == null
-                 || portlet.altMaxUrl == true) {
-          return "NORMAL";
-      } else if (portlet.staticContent != null 
+      if (portlet.staticContent != null 
                  && portlet.altMaxUrl == false) {
           return "SIMPLE";
+      } else {
+          return "NORMAL";
       }
     }
     
@@ -123,20 +122,21 @@
       
       $rootScope.layout = [];
     
-      layoutService.getLayout().then(function(data){
+      layoutService.getLayout(true).then(function(data){
         $rootScope.layout = data.layout;
       });
     }
     
     this.portletType = function portletType(portlet) {
-      if($localStorage.pithyContentOnHome && portlet.pithyStaticContent != null) {
+      if (portlet.widgetType) {
+          return "WIDGET";
+      }else if($localStorage.pithyContentOnHome && portlet.pithyStaticContent != null) {
           return "PITHY";
-      } else if(portlet.staticContent == null
-                 || portlet.altMaxUrl == true) {
-          return "NORMAL";
       } else if (portlet.staticContent != null 
                  && portlet.altMaxUrl == false) {
           return "SIMPLE";
+      } else {
+          return "NORMAL";
       }
     }
     

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -124,12 +124,33 @@
     
       layoutService.getLayout(true).then(function(data){
         $rootScope.layout = data.layout;
+        for(var i=0; i < $rootScope.layout.length; i++) {
+            if($rootScope.layout[i].widgetURL && $rootScope.layout[i].widgetType) {
+              //fetch portlet widget json
+              $rootScope.layout[i].widgetData = [];
+              layoutService.getWidgetJson($rootScope.layout[i], i).then(function(data) {
+                if(data) {
+                    $rootScope.layout[data.index].widgetData = data.result;
+                    console.log($rootScope.layout[data.index].fname + "'s widget data came back with data: ");
+                    console.log(data);
+                } else {
+                    console.warn("Got nothing back from widget fetch");
+                }
+              });
+            }
+        }
       });
     }
     
     this.portletType = function portletType(portlet) {
       if (portlet.widgetType) {
-          return "WIDGET";
+          if('option-link' === portlet.widgetType) {
+              //portlet.widgetData = [{"value" : "levett@wisc.edu"}];
+              return "OPTION_LINK";
+          } else {
+              return "WIDGET";
+          }
+          
       }else if($localStorage.pithyContentOnHome && portlet.pithyStaticContent != null) {
           return "PITHY";
       } else if (portlet.staticContent != null 

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -62,7 +62,13 @@
    
    app.directive('optionLink', function(){
        function link (scope, element, attrs) {
-           scope.selectedUrl = attrs.app[attrs.valueEl];
+           if(scope.hasSingleEl) {
+               //set the default selected url
+               scope.portlet.selectedUrl = scope.portlet.widgetData[scope.valueEl];
+           } else if(scope.portlet.widgetData[scope.arrayName].length > 0) {
+               scope.portlet.widgetData[scope.arrayName][0][scope.valueEl];
+           }
+           
            scope.$watch(attrs.app, function(value) {
               scope.portlet = value;
            });

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -59,5 +59,12 @@
           templateUrl: 'partials/home-header.html'
       }
    });
+   
+   app.directive('optionLink', function(){
+       return{
+           restrict: 'E',
+           templateUrl: 'partials/widgets/option-link.html'
+       }
+    });
 
 })();

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -61,9 +61,24 @@
    });
    
    app.directive('optionLink', function(){
+       function link (scope, element, attrs) {
+           scope.selectedUrl = attrs.app[attrs.valueEl];
+           scope.$watch(attrs.app, function(value) {
+              scope.portlet = value;
+           });
+       }
+       
        return{
            restrict: 'E',
-           templateUrl: 'partials/widgets/option-link.html'
+           scope : {
+               portlet : '=app',
+               valueEl : '@valueName',
+               displayEl : '@displayName',
+               arrayName : '@arrayName',
+               hasSingleEl : '@singleElement'
+           },
+           templateUrl: 'partials/widgets/option-link.html',
+           link : link
        }
     });
 

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -60,7 +60,7 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
     };
 
 
-    var getLayout = function() {
+    var getLayout = function(populateWidgetContent) {
         return checkLayoutCache().then(function(data) {
             var successFn, errorFn, defer;
 
@@ -73,8 +73,12 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
 
             successFn = function(result) {
                 var data =  result.data;
+                if(populateWidgetContent) {
+                    //populate widget content
+                    console.log('populating widget content');
+                    data.populateWidgetContent = true;
+                }
                 storeLayoutInCache(data);
-
                 return data;
             };
 

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -133,7 +133,7 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
         );
       }
     
-    var getWidgetJson = function(portlet, index) {
+    var getWidgetJson = function(portlet) {
         return $http.get(portlet.widgetURL,{ cache : true}).then(
            function(result) {
                var data = result.data;

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -137,13 +137,26 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
           }
         );
       }
+    
+    var getWidgetJson = function(portlet, index) {
+        return $http.get(portlet.widgetURL,{ cache : true}).then(
+           function(result) {
+               result.data.index = index;
+               return result.data;
+           },
+           function(reason) {
+               miscService.redirectUser(reason.status, 'widget json for ' + portlet.fname + " failed.");
+           }
+        );
+    }
 
   return {
     getLayout : getLayout,
     getApp : getApp,
     moveStuff : moveStuff,
     getNewStuffFeed : getNewStuffFeed,
-    addToHome : addToHome
+    addToHome : addToHome,
+    getWidgetJson : getWidgetJson
   }
 
 }]);

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -136,8 +136,17 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
     var getWidgetJson = function(portlet, index) {
         return $http.get(portlet.widgetURL,{ cache : true}).then(
            function(result) {
-               result.data.index = index;
-               return result.data;
+               var data = result.data;
+               if(data) {
+                 if(data.result) {
+                     portlet.widgetData = data.result;
+                 }
+                 if(data.content) {
+                     portlet.widgetContent = data.content;
+                 }
+                 console.log(portlet.fname + "'s widget data came back with data");
+               }
+               return data;
            },
            function(reason) {
                miscService.redirectUser(reason.status, 'widget json for ' + portlet.fname + " failed.");

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-services.js
@@ -60,7 +60,7 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
     };
 
 
-    var getLayout = function(populateWidgetContent) {
+    var getLayout = function() {
         return checkLayoutCache().then(function(data) {
             var successFn, errorFn, defer;
 
@@ -73,11 +73,6 @@ app.factory('layoutService', ['$http', 'miscService', 'mainService', '$sessionSt
 
             successFn = function(result) {
                 var data =  result.data;
-                if(populateWidgetContent) {
-                    //populate widget content
-                    console.log('populating widget content');
-                    data.populateWidgetContent = true;
-                }
                 storeLayoutInCache(data);
                 return data;
             };

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -12,11 +12,12 @@
     <i title="Remove" class="fa fa-times portlet-options" ng-click="widgetCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
   </div>
   
+  <div class="widget-title">
+    <h4>{{ ::portlet.title }}</h4>
+  </div>
+  
   <!-- For widgets, show fancy markup! -->
   <div ng-if="'WIDGET' === widgetCtrl.portletType(portlet)">
-    <div class="widget-title">
-      <h4>{{ ::portlet.title }}</h4>
-    </div>
     <div class="portlet-content">
        <div ng-bind-html="portlet.widgetContent"></div>
     </div>
@@ -25,9 +26,6 @@
   
   <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
   <a ng-if="'NORMAL' === widgetCtrl.portletType(portlet)" href="{{::portlet.url}}" target="{{::portlet.target}}">
-    <div class="widget-title">
-      <h4>{{ ::portlet.title }}</h4>
-    </div>
     <div class="widget-icon-container">
       <portlet-icon></portlet-icon>
     </div>
@@ -36,9 +34,6 @@
   
   <!-- For pithy content, display the pithy content -->
   <div ng-if="'PITHY' === widgetCtrl.portletType(portlet)">
-    <div class="widget-title">
-      <h4>{{ ::portlet.title }}</h4>
-    </div>
     <div class="portlet-content">
        <div ng-bind-html="portlet.pithyStaticContent"></div>
     </div>
@@ -47,14 +42,9 @@
   
   <!-- For simple content portlets, show only an icon -->
   <a ng-if="'SIMPLE' === widgetCtrl.portletType(portlet)" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="simple-content-container">
-    <div class="widget-title">
-      <h4>{{ ::portlet.title }}</h4>
-    </div>
     <div class="widget-icon-container">
       <portlet-icon></portlet-icon>
     </div>
     <button class="btn btn-default launch-app-button">Launch Full App</button>
-  </a>
-  
-  
+  </a>  
 </div>

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -30,7 +30,7 @@
   </div>
   
   <div ng-if="'OPTION_LINK' === widgetCtrl.portletType(portlet)">
-    <option-link></option-link>
+    <option-link value-name='uri' display-name='email' single-element='true' array-name='linked' app="portlet"></option-link>
   </div>
   
   <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -19,9 +19,41 @@
   <!-- For widgets, show fancy markup! -->
   <div ng-if="'WIDGET' === widgetCtrl.portletType(portlet)">
     <div class="portlet-content">
-       <div ng-bind-html="portlet.widgetContent"></div>
+       <div ng-if="'option-link' === portlet.widgetType">
+         <div class="widget-icon-container">
+           <portlet-icon></portlet-icon>
+         </div>
+       </div>
+       <div ng-if='portlet.widgetContent' ng-bind-html="portlet.widgetContent"></div>
     </div>
     <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch Full App</a>
+  </div>
+  
+  <div ng-if="'OPTION_LINK' === widgetCtrl.portletType(portlet)">
+    <div class="portlet-content">
+       <div ng-if="'option-link' === portlet.widgetType">
+         <div class="widget-icon-container">
+           <portlet-icon></portlet-icon>
+         </div>
+         <div>
+            <div  style='font-size : larger; text-align: center;'>
+            <div ng-if="portlet.widgetData && portlet.widgetData.length == 0">
+                loading...
+            </div>
+            <div ng-if="portlet.widgetData && portlet.widgetData.linked.length == 0" >
+                {{portlet.widgetData.email}}
+            </div>
+            <div ng-if="portlet.widgetData && portlet.widgetData.linked.length >= 1">
+                <select ng-model="portlet.selectedUrl">
+                    <option selected="selected" value="{{portlet.widgetData.uri}}">{{portlet.widgetData.email}}</option>
+                    <option ng-repeat='obj in portlet.widgetData.linked' value="{{obj.uri}}">{{obj.email}}</option>
+                </select>
+            </div>
+            </div>
+         </div>
+       </div>
+    </div>
+    <a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch Email</a>
   </div>
   
   <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -32,23 +32,23 @@
   <div ng-if="'OPTION_LINK' === widgetCtrl.portletType(portlet)">
     <div class="portlet-content">
        <div ng-if="'option-link' === portlet.widgetType">
-         <div class="widget-icon-container">
+         <div class="widget-icon-container" style='  max-height: 110px;'>
            <portlet-icon></portlet-icon>
          </div>
          <div>
-            <div  style='font-size : larger; text-align: center;'>
-            <div ng-if="portlet.widgetData && portlet.widgetData.length == 0">
-                loading...
-            </div>
-            <div ng-if="portlet.widgetData && portlet.widgetData.linked.length == 0" >
-                {{portlet.widgetData.email}}
-            </div>
-            <div ng-if="portlet.widgetData && portlet.widgetData.linked.length >= 1">
-                <select ng-model="portlet.selectedUrl">
-                    <option selected="selected" value="{{portlet.widgetData.uri}}">{{portlet.widgetData.email}}</option>
-                    <option ng-repeat='obj in portlet.widgetData.linked' value="{{obj.uri}}">{{obj.email}}</option>
-                </select>
-            </div>
+            <div>
+             <div ng-if="portlet.widgetData && portlet.widgetData.length == 0">
+                 loading...
+             </div>
+             <div ng-if="portlet.widgetData && portlet.widgetData.linked.length == 0" >
+                 {{portlet.widgetData.email}}
+             </div>
+             <div ng-if="portlet.widgetData && portlet.widgetData.linked.length >= 1">
+                 <select ng-model="portlet.selectedUrl" class='form-control'>
+                     <option selected="selected" value="{{portlet.widgetData.uri}}">{{portlet.widgetData.email}}</option>
+                     <option ng-repeat='obj in portlet.widgetData.linked' value="{{obj.uri}}">{{obj.email}}</option>
+                 </select>
+             </div>
             </div>
          </div>
        </div>

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -24,7 +24,7 @@
            <portlet-icon></portlet-icon>
          </div>
        </div>
-       <div ng-if='portlet.widgetContent' ng-bind-html="portlet.widgetContent"></div>
+       <div ng-bind-html="portlet.widgetContent"></div>
     </div>
     <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch Full App</a>
   </div>

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -30,30 +30,7 @@
   </div>
   
   <div ng-if="'OPTION_LINK' === widgetCtrl.portletType(portlet)">
-    <div class="portlet-content">
-       <div ng-if="'option-link' === portlet.widgetType">
-         <div class="widget-icon-container" style='  max-height: 110px;'>
-           <portlet-icon></portlet-icon>
-         </div>
-         <div>
-            <div>
-             <div ng-if="portlet.widgetData && portlet.widgetData.length == 0">
-                 loading...
-             </div>
-             <div ng-if="portlet.widgetData && portlet.widgetData.linked.length == 0" >
-                 {{portlet.widgetData.email}}
-             </div>
-             <div ng-if="portlet.widgetData && portlet.widgetData.linked.length >= 1">
-                 <select ng-model="portlet.selectedUrl" class='form-control'>
-                     <option selected="selected" value="{{portlet.widgetData.uri}}">{{portlet.widgetData.email}}</option>
-                     <option ng-repeat='obj in portlet.widgetData.linked' value="{{obj.uri}}">{{obj.email}}</option>
-                 </select>
-             </div>
-            </div>
-         </div>
-       </div>
-    </div>
-    <a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch Email</a>
+    <option-link></option-link>
   </div>
   
   <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->

--- a/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
@@ -1,0 +1,24 @@
+<div class="portlet-content">
+   <div ng-if="'option-link' === portlet.widgetType">
+     <div class="widget-icon-container" style='  max-height: 110px;'>
+       <portlet-icon></portlet-icon>
+     </div>
+     <div>
+        <div>
+         <div ng-if="portlet.widgetData && portlet.widgetData.length == 0">
+             loading...
+         </div>
+         <div ng-if="portlet.widgetData && portlet.widgetData.linked.length == 0" >
+             {{portlet.widgetData.email}}
+         </div>
+         <div ng-if="portlet.widgetData && portlet.widgetData.linked.length >= 1">
+             <select ng-model="portlet.selectedUrl" class='form-control'>
+                 <option selected="selected" value="{{portlet.widgetData.uri}}">{{portlet.widgetData.email}}</option>
+                 <option ng-repeat='obj in portlet.widgetData.linked' value="{{obj.uri}}">{{obj.email}}</option>
+             </select>
+         </div>
+        </div>
+     </div>
+   </div>
+</div>
+<a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch Email</a>

--- a/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
@@ -21,4 +21,4 @@
      </div>
    </div>
 </div>
-<a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch Email</a>
+<a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch {{portlet.title}}</a>

--- a/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
@@ -8,11 +8,11 @@
           <div ng-if="portlet.widgetData.length == 0">
               loading...
           </div>
-          <div ng-if="hasSingleEl && portlet.widgetData[arrayName].length == 0" >
+          <div ng-if="hasSingleEl && portlet.widgetData[arrayName].length == 0" style='text-align: center; font-size: larger;'>
               {{portlet.widgetData[displayEl]}}
           </div>
           <div ng-if="portlet.widgetData && portlet.widgetData[arrayName].length >= 1">
-             <select ng-model="selectedUrl" class='form-control'>
+             <select ng-model="portlet.selectedUrl" class='form-control'>
                  <option ng-if='hasSingleEl' selected="selected" value="{{portlet.widgetData[valueEl]}}">{{portlet.widgetData[displayEl]}}</option>
                  <option ng-repeat='obj in portlet.widgetData[arrayName]' value="{{obj[valueEl]}}">{{obj[displayEl]}}</option>
              </select>
@@ -21,4 +21,4 @@
      </div>
    </div>
 </div>
-<a class="btn btn-default launch-app-button" href="{{selectedUrl}}" target="_blank">Launch {{portlet.title}}</a>
+<a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch {{portlet.title}}</a>

--- a/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
@@ -1,24 +1,24 @@
 <div class="portlet-content">
-   <div ng-if="'option-link' === portlet.widgetType">
+   <div>
      <div class="widget-icon-container" style='  max-height: 110px;'>
        <portlet-icon></portlet-icon>
      </div>
      <div>
         <div>
-         <div ng-if="portlet.widgetData && portlet.widgetData.length == 0">
-             loading...
-         </div>
-         <div ng-if="portlet.widgetData && portlet.widgetData.linked.length == 0" >
-             {{portlet.widgetData.email}}
-         </div>
-         <div ng-if="portlet.widgetData && portlet.widgetData.linked.length >= 1">
-             <select ng-model="portlet.selectedUrl" class='form-control'>
-                 <option selected="selected" value="{{portlet.widgetData.uri}}">{{portlet.widgetData.email}}</option>
-                 <option ng-repeat='obj in portlet.widgetData.linked' value="{{obj.uri}}">{{obj.email}}</option>
+          <div ng-if="portlet.widgetData.length == 0">
+              loading...
+          </div>
+          <div ng-if="hasSingleEl && portlet.widgetData[arrayName].length == 0" >
+              {{portlet.widgetData[displayEl]}}
+          </div>
+          <div ng-if="portlet.widgetData && portlet.widgetData[arrayName].length >= 1">
+             <select ng-model="selectedUrl" class='form-control'>
+                 <option ng-if='hasSingleEl' selected="selected" value="{{portlet.widgetData[valueEl]}}">{{portlet.widgetData[displayEl]}}</option>
+                 <option ng-repeat='obj in portlet.widgetData[arrayName]' value="{{obj[valueEl]}}">{{obj[displayEl]}}</option>
              </select>
-         </div>
+          </div>
         </div>
      </div>
    </div>
 </div>
-<a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch {{portlet.title}}</a>
+<a class="btn btn-default launch-app-button" href="{{selectedUrl}}" target="_blank">Launch {{portlet.title}}</a>

--- a/angularjs-portal-home/src/main/webapp/samples/wiscmail-accounts-1.json
+++ b/angularjs-portal-home/src/main/webapp/samples/wiscmail-accounts-1.json
@@ -1,0 +1,10 @@
+{
+ "result" : {
+  "system" : "o365",
+  "uri" : "https://outlook.com/owa/wisc.edu/",
+  "email" : "first.last@wisc.edu",
+  "linked" : [
+    
+  ]
+ }
+}

--- a/angularjs-portal-home/src/main/webapp/samples/wiscmail-accounts.json
+++ b/angularjs-portal-home/src/main/webapp/samples/wiscmail-accounts.json
@@ -1,14 +1,19 @@
-{"result" :  
-            {
-                "system" : "wiscmail",
-                "uri"    : "https://wiscmail.wisc.edu",
-                "linked" : [
-                            {
-                                "sample-link@doit.wisc.edu" {
-                                    "system" : "office365",
-                                    "uri" : "https://wiscmail.wisc.edu"
-                                }
-                            }
-                           ]
-            }
+{
+ "result" : {
+  "system" : "o365",
+  "uri" : "https://outlook.com/owa/wisc.edu/",
+  "email" : "first.last@wisc.edu",
+  "linked" : [
+    {
+      "system" : "wiscmail",
+      "uri" : "https://wiscmail.wisc.edu/login",
+      "email" : "wiscmail-ex@wisc.edu"
+    },
+    {
+      "system" : "o365",
+      "uri" : "https://outlook.com/owa/my-core_doit@wisc.edu/",
+      "email" : "my-core@doit.wisc.edu"
+    }
+  ]
+ }
 }


### PR DESCRIPTION
### Please Read
I know, TL;DR. I would like to have 2x :+1: for this at least. Maybe a post-standup chat.

#### Screenshots

Single Account
![image](https://cloud.githubusercontent.com/assets/3534544/6396941/3edd87ca-bda7-11e4-9f41-3fe7673750e2.png)

Multiple Accounts
![screen shot 2015-02-25 at 10 54 46 pm](https://cloud.githubusercontent.com/assets/3534544/6386615/5afa27bc-bd41-11e4-9874-c7e1502c7232.png)

Side by Side
![image](https://cloud.githubusercontent.com/assets/3534544/6397556/19a19fd8-bdab-11e4-951a-df070a829ec0.png)


#### Features
+ Creates a `option-link` widget (idea behind it is one that has a select, and that changes the url for the link)
+ Creates a way of calling the widget URL when the widget mode is loaded (got it working, could be a little better)
+ Plugs in data when we get it
+ Adds in a `WIDGET` flag for generic widgets that will display content from callback (this could be better, but it's a start)
+ Adds in a `OPTION_LINK` flag that will use the option link partial (email will be one of those for now)
+ On selection of the option it will update the URL

#### TODO || Things that could be better
+ The promise to get the widget content is doing data.result, another email JSON specific thing
+ I'm not a huge fan of passing the index to the promise. if that takes a while a reorder could mess things up.
+ Make option link widget more generic

#### Notes
+ This depends on a uPortal PR https://github.com/UW-Madison-DoIT/uPortal/pull/320
+ This is depending on a change to the JSON we are getting from wiscmail to add in the email addresses as a field, for demo purposes we can just use the `/samples/wiscmail-accounts.json`