### PR TITLE
MUMUP-1615 : Create configuration for widgets

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -70,7 +70,13 @@
                    scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
                }
            } else {
-               console.warn('config not set for option link directive');
+               //setting up defaults
+               scope.config = {
+                   singleElement : false,
+                   arrayName : 'array',
+                   value : 'value',
+                   display : 'display'
+               };
            }
            
            scope.$watch(attrs.app, function(value) {

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -62,11 +62,15 @@
    
    app.directive('optionLink', function(){
        function link (scope, element, attrs) {
-           if(scope.hasSingleEl) {
-               //set the default selected url
-               scope.portlet.selectedUrl = scope.portlet.widgetData[scope.valueEl];
-           } else if(scope.portlet.widgetData[scope.arrayName].length > 0) {
-               scope.portlet.widgetData[scope.arrayName][0][scope.valueEl];
+           if(scope.config) {
+               if(scope.config.singleElement) {
+                   //set the default selected url
+                   scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
+               } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
+                   scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
+               }
+           } else {
+               console.warn('config not set for option link directive');
            }
            
            scope.$watch(attrs.app, function(value) {
@@ -78,10 +82,7 @@
            restrict: 'E',
            scope : {
                portlet : '=app',
-               valueEl : '@valueName',
-               displayEl : '@displayName',
-               arrayName : '@arrayName',
-               hasSingleEl : '@singleElement'
+               config  : '=config'
            },
            templateUrl: 'partials/widgets/option-link.html',
            link : link

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -63,11 +63,13 @@
    app.directive('optionLink', function(){
        function link (scope, element, attrs) {
            if(scope.config) {
-               if(scope.config.singleElement) {
-                   //set the default selected url
-                   scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
-               } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
-                   scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
+               if(scope.portlet.widgetData) {
+                   if(scope.config.singleElement) {
+                       //set the default selected url
+                       scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
+                   } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
+                       scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
+                   }
                }
            } else {
                //setting up defaults
@@ -81,6 +83,14 @@
            
            scope.$watch(attrs.app, function(value) {
               scope.portlet = value;
+              if(scope.portlet.widgetData) {
+                  if(scope.config.singleElement) {
+                      //set the default selected url
+                      scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
+                  } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
+                      scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
+                  }
+              }
            });
        }
        

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -67,7 +67,7 @@
                    //set the default selected url
                    scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
                } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
-                   scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
+                   scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
                }
            } else {
                //setting up defaults

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-directives.js
@@ -60,39 +60,17 @@
       }
    });
    
+   /**
+    * <option-link> directive is used to display widget content.
+    * You need to setup a config JSON object, or just use the defaults defined below
+    * config = {
+    *             singleElement : false, //flags if your widgetData object as a single set in addition to the array
+    *             arrayName : 'array', //the array name under widgetData
+    *             value : 'value', //what you want the value to be (usually a URL)
+    *             display : 'display' // what to display in the drop down
+    *         }
+    */
    app.directive('optionLink', function(){
-       function link (scope, element, attrs) {
-           if(scope.config) {
-               if(scope.portlet.widgetData) {
-                   if(scope.config.singleElement) {
-                       //set the default selected url
-                       scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
-                   } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
-                       scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
-                   }
-               }
-           } else {
-               //setting up defaults
-               scope.config = {
-                   singleElement : false,
-                   arrayName : 'array',
-                   value : 'value',
-                   display : 'display'
-               };
-           }
-           
-           scope.$watch(attrs.app, function(value) {
-              scope.portlet = value;
-              if(scope.portlet.widgetData) {
-                  if(scope.config.singleElement) {
-                      //set the default selected url
-                      scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.value];
-                  } else if(scope.portlet.widgetData[scope.config.arrayName].length > 0) {
-                      scope.portlet.selectedUrl = scope.portlet.widgetData[scope.config.arrayName][0][scope.config.value];
-                  }
-              }
-           });
-       }
        
        return{
            restrict: 'E',
@@ -101,7 +79,7 @@
                config  : '=config'
            },
            templateUrl: 'partials/widgets/option-link.html',
-           link : link
+           controller : 'OptionLinkController'
        }
     });
 

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -30,7 +30,7 @@
   </div>
   
   <div ng-if="'OPTION_LINK' === widgetCtrl.portletType(portlet)">
-    <option-link value-name='uri' display-name='email' single-element='true' array-name='linked' app="portlet"></option-link>
+    <option-link app="portlet" config="portlet.widgetConfig"></option-link>
   </div>
   
   <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->

--- a/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widgets/option-link.html
@@ -8,13 +8,13 @@
           <div ng-if="portlet.widgetData.length == 0">
               loading...
           </div>
-          <div ng-if="hasSingleEl && portlet.widgetData[arrayName].length == 0" style='text-align: center; font-size: larger;'>
-              {{portlet.widgetData[displayEl]}}
+          <div ng-if="config.singleElement && portlet.widgetData[config.arrayName].length == 0" style='text-align: center; font-size: larger;'>
+              {{portlet.widgetData[config.display]}}
           </div>
-          <div ng-if="portlet.widgetData && portlet.widgetData[arrayName].length >= 1">
+          <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName].length >= 1">
              <select ng-model="portlet.selectedUrl" class='form-control'>
-                 <option ng-if='hasSingleEl' selected="selected" value="{{portlet.widgetData[valueEl]}}">{{portlet.widgetData[displayEl]}}</option>
-                 <option ng-repeat='obj in portlet.widgetData[arrayName]' value="{{obj[valueEl]}}">{{obj[displayEl]}}</option>
+                 <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}">{{portlet.widgetData[config.display]}}</option>
+                 <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}">{{obj[config.display]}}</option>
              </select>
           </div>
         </div>


### PR DESCRIPTION
+ This will make `option-link` 100% reusable
+ Adds in a config object that is needed to configure where to get the JSON
```json
{
 "value" : "uri", 
 "display" : "email", 
 "arrayName" : "linked", 
 "singleElement" : true
}
```
+ Has defaults if someone doesn't want to supply config
+ Refactors to a controller instead of a link function for the directive