### PR TITLE
Make weather pretty

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/widget.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/widget.less
@@ -1,8 +1,19 @@
 weather {
     .forecast .day {
         text-align: center;
-        border: 1px black solid;
         border-radius: 4px;
-        box-shadow: 2px 1px 5px gray;
+        padding:0px 8px;
+        p {
+          font-size:11px;
+        }
     }
+    img {
+      width:50px;
+      position:relative;
+      right:1px;
+    }
+    a {
+      color:#666;
+    }
+  
 }

--- a/angularjs-portal-home/src/main/webapp/partials/widgets/weather.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widgets/weather.html
@@ -1,27 +1,27 @@
 <div>
-    <ul style='padding-left: 10px;'>
+    <ul class="widget-list">
         <li ng-repeat="weather in portlet.widgetData | limitTo:2">
-            <h4 ng-click="showDetails($index)">{{weather.location.city}}, {{weather.location.stateOrCountry}}
-                <small>
-                    <a ng-hide='details' ng-click="details = !details" href='javascript:;'><i class='fa fa-plus'></i></a>
-                    <a ng-show='details' ng-click="details = !details" href='javascript:;'><i class='fa fa-minus'></i></a>
-                </small>
-            </h4>
+          <a href="{{weather.moreInformationLink}}">
+            <p class="bold">{{weather.location.city}}, {{weather.location.stateOrCountry}}
+            </p>
             <div>
-                <p class="current" ng-hide="details">
-                    <img ng-src="{{config.iconPrefix}}{{weather.currentWeather.imgName}}{{config.iconPostfix}}" title="{{weather.currentWeather.condition}}" alt="{{weather.currentWeather.condition}}"> {{weather.currentWeather.temperature}}{{weather.temperatureUnit}}
-                </p>
-                <div class="forecast" ng-show='details'>
-                    <div class='container-fluid row' style='font-size: x-small; width: 100%; margin: 0;'>
-                        <div class='col-lg-4 day' ng-repeat="forecast in weather.forecast">
-                            {{forecast.day}}
-                            <img style='height: 25px;' ng-src="{{config.iconPrefix}}{{forecast.imgName}}{{config.iconPostfix}}" title="{{forecast.condition}}" alt="{{forecast.condition}}">
-                            H:{{forecast.highTemperature}}
-                            L:{{forecast.lowTemperature}}
+                <div class="forecast">
+                    <div class='row'>
+                        <div class="col-xs-3 day">
+                          <p>Now</p>
+                          <img ng-src="{{config.iconPrefix}}{{weather.currentWeather.imgName}}{{config.iconPostfix}}" title="{{weather.currentWeather.condition}}" alt="{{weather.currentWeather.condition}}">
+                          <p>{{weather.currentWeather.temperature}}&deg; {{weather.temperatureUnit}}</p>
+                        </div>
+                        <div class='col-xs-3 day' ng-repeat="forecast in weather.forecast">
+                            <p>{{forecast.day}}</p>
+                            <img ng-src="{{config.iconPrefix}}{{forecast.imgName}}{{config.iconPostfix}}" title="{{forecast.condition}}" alt="{{forecast.condition}}">
+                            <p>H: {{forecast.highTemperature}}&deg;</p>
+                            <p>L: {{forecast.lowTemperature}}&deg;</p>
                         </div>
                     </div>
                 </div>
             </div>
+          </a>
         </li>
     </ul>
     <div>


### PR DESCRIPTION
Reorganized the content and styles of @timlevett's first pass of the Weather widget. Getting it ready for primetime!

- Removed the min/max view in favor of showing everything at once. Less clicks = happier users, and I don't think it looks too messy
- Still using old icons. If we want to switch icons we can do that in a separate pull, but with the new styling it doesn't seem as necessary
- Clicking a city goes straight to the World Weather Online website for that city. Pretty cool.
- Styles consistent with other widgets


![image](https://cloud.githubusercontent.com/assets/1919535/6495511/8850c168-c290-11e4-897b-7bda85177ffa.png)

Click on Madison:
![image](https://cloud.githubusercontent.com/assets/1919535/6495548/ede63ae4-c290-11e4-815a-ad815f0f6e88.png)

Go to World Weather Online's beautiful website:
![image](https://cloud.githubusercontent.com/assets/1919535/6495572/12e44232-c291-11e4-8587-3bc8864b6f6a.png)

