### PR TITLE
Fix styling on new-stuff bar

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/notifications.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/notifications.less
@@ -53,7 +53,6 @@ li.read:hover {
 // New Stuff Div
 
 .header-opaque {
-  height:40px;
   width:100%;
   position:absolute;
   background-color:rgba(256,256,256,0.8);

--- a/angularjs-portal-home/src/main/webapp/samples/new-stuff.json
+++ b/angularjs-portal-home/src/main/webapp/samples/new-stuff.json
@@ -5,7 +5,7 @@
                 "expireYr"  : 2016,
                 "expireMon" : 2,
                 "expireDay" : 20,
-                "title" : "New Sidebar",
+                "title" : "Collapsible Sidebar",
                 "shortDesc" : "Don't see the new sidebar?  Sorry for the glitch!  Refresh the page and it should appear. ",
                 "link" : null
               }


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/1919535/6535949/da34a678-c40e-11e4-9d9d-c3fb46ad164e.png)

![image](https://cloud.githubusercontent.com/assets/1919535/6536053/ba0e245e-c40f-11e4-8d91-4bf7e44abc37.png)


This was the easiest fix. If you have other ideas for how to display the new stuff are, let me know.

Also, since us developers are going to see this forever and some of us are OCD, I fixed the New New annoyingness :)