### PR TITLE
MUMUP-1729 : Bug : Stays scrolled down from bottom of favorites to somewhere in /apps

### DIFF
--- a/angularjs-portal-home/src/main/webapp/home.html
+++ b/angularjs-portal-home/src/main/webapp/home.html
@@ -45,7 +45,7 @@
         <span class="fa fa-bars"></span>
       </div>
       <div id="region-main" class="col-xs-12 my-uw" ng-class="{'col-sm-10 col-sm-offset-2' : $storage.showSidebar, 'col-sm-11 max-view' : !($storage.showSidebar)}">
-        <div ng-view></div>
+        <div ng-view="" autoscroll=""></div>
       </div>
     </div>
   </div>

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-light.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-light.html
@@ -1,5 +1,5 @@
 <div class="list-content add-favorites">
-   <a href='#/apps'>
+   <a href='#/apps' onClick="scrollUp()">
      <div class="icon-container">
        <i class="fa fa-plus"></i>
      </div>
@@ -8,3 +8,9 @@
      </div>
    </a>
 </div>
+<script>
+function scrollUp(){
+    var myDiv = document.getElementById('list-content add-favorites');
+    myDiv.scrollTop = 0;
+    }
+</script>

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-light.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-light.html
@@ -8,4 +8,3 @@
      </div>
    </a>
 </div>
-<script>

--- a/angularjs-portal-home/src/main/webapp/partials/marketplace-light.html
+++ b/angularjs-portal-home/src/main/webapp/partials/marketplace-light.html
@@ -1,5 +1,5 @@
 <div class="list-content add-favorites">
-   <a href='#/apps' onClick="scrollUp()">
+   <a href='#/apps'>
      <div class="icon-container">
        <i class="fa fa-plus"></i>
      </div>
@@ -9,8 +9,3 @@
    </a>
 </div>
 <script>
-function scrollUp(){
-    var myDiv = document.getElementById('list-content add-favorites');
-    myDiv.scrollTop = 0;
-    }
-</script>


### PR DESCRIPTION
This was a bug where when the user would be scrolled down on their home page and click on the add to favorites (tile), then they would be taken to the marketplace but the scroll would not reset, and thus they'd be left in the middle of the page. 

Here are some screenshots from the JIRA story to help you understand the problem.

User scrolls down and decides to click on Add to favorites

![before clicking](https://cloud.githubusercontent.com/assets/7268126/6536389/e16da454-c412-11e4-8ea2-5650cd8a15e2.png)

Immediately after clicking the user sees this, instead of being taken to the top of the marketplace.

![after clicking](https://cloud.githubusercontent.com/assets/7268126/6536394/ebfb17ee-c412-11e4-9396-1142562645d9.png)

Anyways, I added some javascript that scrolls up whenever the button is clicked

Now it looks like this:

Before clicking:

![fixed before clicking](https://cloud.githubusercontent.com/assets/7268126/6536487/ae6bef24-c413-11e4-9d81-e21eebeaa14e.png)

After clicking:

![fixed after clicking](https://cloud.githubusercontent.com/assets/7268126/6536490/b2b3c3ae-c413-11e4-8106-d487e0d4f096.png)

