### PR TITLE
MUMUP-1751 : Create template-able widgets

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/js/directives.js
+++ b/angularjs-portal-frame/src/main/webapp/js/directives.js
@@ -145,5 +145,25 @@
     		templateUrl: 'partials/portlet-header.html'
     	};
     });
+    
+    /**
+     * content-item is a directive that 
+     * displays a template with provided content
+     * 
+     * Params:
+     *  - template: the template to display (can have angular markup)
+     */
+    app.directive('contentItem', function ($compile) {
+
+        var linker = function(scope, element, attrs) {
+            element.html(scope.template).show();
+            $compile(element.contents())(scope);
+        }
+
+        return {
+            restrict: "E",
+            link: linker
+        };
+    });
 
 })();

--- a/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/layout-controller.js
@@ -128,6 +128,8 @@
               return "OPTION_LINK";
           } else if('weather' === portlet.widgetType) {
               return "WEATHER";
+          } else if('generic' === portlet.widgetType) {
+              return "GENERIC";
           } else {
               return "WIDGET";
           }

--- a/angularjs-portal-home/src/main/webapp/js/layout/widget-controllers.js
+++ b/angularjs-portal-home/src/main/webapp/js/layout/widget-controllers.js
@@ -33,7 +33,7 @@
                       $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
                   }
               } else {
-                  console.warn("Got nothing back from widget fetch");
+                  console.warn("Got nothing back from widget fetch for " + $scope.portlet.fname);
               }
             });
           }
@@ -59,8 +59,31 @@
             });
           }
       }
-      console.log("Config: " + $scope.config);
+      console.log("Config: " + $scope.portlet.widgetConfig);
       populateWidgetContent();
       $scope.details=false;
+  }]);
+  
+  app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService){
+      var populateWidgetContent = function() {
+          if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+            //fetch portlet widget json
+            layoutService.getWidgetJson($scope.portlet).then(function(data) {
+              if(data) {
+                  console.log(data);
+                  $scope.portlet.widgetData = data;
+                  $scope.content = $scope.portlet.widgetData;
+              } else {
+                  console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
+              }
+            });
+          }
+      }
+      
+      $scope.content = [];
+      $scope.template =  $scope.portlet.widgetConfig.template;
+      $scope.portlet.widgetData = [];
+      console.log("Config for "+ $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
+      populateWidgetContent();
   }]);
 })();

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -37,6 +37,12 @@
     <weather app="portlet" config="portlet.widgetConfig"></weather>
   </div>
   
+  <div ng-if="'GENERIC' === widgetCtrl.portletType(portlet)">
+    <div ng-controller="GenericWidgetController as genericWidgetCtrl">
+        <content-item></content-item>
+    </div>
+  </div>
+  
   <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
   <a ng-if="'NORMAL' === widgetCtrl.portletType(portlet)" href="{{::portlet.url}}" target="{{::portlet.target}}">
     <div class="widget-icon-container">


### PR DESCRIPTION
This creates a mechanism that we can supply a JSON URL, and a template in the config, and we get smart widgets.

I have one example out of the box solution: 

#### Step 1 - Add widget preferences to entity file

```xml
<portlet-preference>
        <name>widgetURL</name>
        <value>/portal/p/earnings-statement/max/earningStatements.resource.uP</value>
    </portlet-preference>
    <portlet-preference>
        <name>widgetType</name>
        <value>generic</value>
    </portlet-preference>
    <portlet-preference>
        <name>widgetConfig</name>
        <value><![CDATA[{"template" : "<table class='table table-striped'><tr><th>Paid</th><th>Earned</th></tr><tr ng-repeat=\"item in content.report |orderBy: ['-paid.substring(6)','-paid.substring(0,2)','-paid.substring(3,5)'] | limitTo:3\"><td><a href='/portal/p/earnings-statement/max/earning_statement.pdf.resource.uP?pP_docId={{item.docId}}' target='_blank'>{{item.paid}}</a></td><td><a href='/portal/p/earnings-statement/max/earning_statement.pdf.resource.uP?pP_docId={{item.docId}}' target='_blank'>{{item.earned}}</a></td></tr></table><a class='btn btn-default launch-app-button' href='/portal/p/earnings-statement'>See More</a>"}]]></value>
    </portlet-preference>
```
Pretty version of the template (note you have to escape the double quotes):
```html
<table class='table table-striped'>
 <tr><th>Paid</th><th>Earned</th></tr>
  <tr ng-repeat=\"item in content.report |orderBy: ['-paid.substring(6)','-paid.substring(0,2)','-paid.substring(3,5)'] | limitTo:3\">
    <td><a href='/portal/p/earnings-statement/max/earning_statement.pdf.resource.uP?pP_docId={{item.docId}}' target='_blank'>{{item.paid}}</a></td>
    <td><a href='/portal/p/earnings-statement/max/earning_statement.pdf.resource.uP?pP_docId={{item.docId}}' target='_blank'>{{item.earned}}</a></td>
  </tr>
</table>
<a class='btn btn-default launch-app-button' href='/portal/p/earnings-statement'>See More</a>
```

#### Step 2, Results

![image](https://cloud.githubusercontent.com/assets/3534544/6626304/a82c9e2e-c8c3-11e4-9bf0-acdc0fbdd2f5.png)