### PR TITLE
MUMPO-433: Screenshots don't resize if user is not in chrome

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
@@ -236,6 +236,7 @@
   
   ul.enlarge span img{
   	padding: 2px;
+  	width:100%;
   }
   
   ul.enlarge span{
@@ -257,16 +258,61 @@
   	cursor:pointer;
   }
   
+  img{
+  		width:100%;
+  }
   @media only screen and (min-width: 768px){
   	ul.enlarge li:hover span{
+
       width:60vw;
   		top:20%;
       left:28.67%;
+
+  	
+
+  	}
+  	img{
+  		width:320px;
   	}
   }
   
-  
-  
+
+  @media only screen and (min-width: 956px){
+    ul.enlarge li:hover span{
+  		
+  		top: -300px;
+  		left: -210px;
+  		width: 740px;
+  	}
+  	img{
+  		width:320px;
+  	}
+  }
+
+ 
+  @media only screen and (min-width: 1330px){
+    ul.enlarge li:hover span{
+    	
+  		top: -220px;
+  		left:-250px;
+  		width:640px;
+  	}
+  	img{
+  		width:320px;
+  	}
+  } 
+   @media only screen and (min-width: 1557px){
+    ul.enlarge li:hover span{
+    	
+  		top: -300px;
+  		left: -210px;
+  		width: 740px;
+  	}
+  	img{
+  		width:320px;
+  	}
+  }
+
 
   
   

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
@@ -261,63 +261,20 @@
   img{
   		width:100%;
   }
+  
   @media only screen and (min-width: 768px){
   	ul.enlarge li:hover span{
 
       width:60vw;
-  		top:20%;
+  	  top:20%;
       left:28.67%;
 
-  	
-
-  	}
-  	img{
-  		width:320px;
-  	}
-  }
-  
-
-  @media only screen and (min-width: 956px){
-    ul.enlarge li:hover span{
-  		
-  		top: -300px;
-  		left: -210px;
-  		width: 740px;
   	}
   	img{
   		width:320px;
   	}
   }
 
- 
-  @media only screen and (min-width: 1330px){
-    ul.enlarge li:hover span{
-    	
-  		top: -220px;
-  		left:-250px;
-  		width:640px;
-  	}
-  	img{
-  		width:320px;
-  	}
-  } 
-   @media only screen and (min-width: 1557px){
-    ul.enlarge li:hover span{
-    	
-  		top: -300px;
-  		left: -210px;
-  		width: 740px;
-  	}
-  	img{
-  		width:320px;
-  	}
-  }
-
-
-  
-  
-  
- 
   li {
     display:inline-block;
     float:left;


### PR DESCRIPTION
This pull request fixes the problem with screenshots not re-sizing in Firefox. I set the width for the default screenshots to 100% and whenever the window is >= 768 pixels the width of the default screenshots automatically changes to 320px (so they don't get too big for desktop windows). Also I set the width of the enlarged screenshots to 100% so that it doesn't get affected by the width change to 320px.

Before and After:                                                                                                                                               


![before screenshots](https://cloud.githubusercontent.com/assets/7268126/6646144/2c6890d6-c990-11e4-8e29-13823b72ac3c.png) ![small screenshots](https://cloud.githubusercontent.com/assets/7268126/6646146/312b59e6-c990-11e4-8be5-03879b5c29d0.png)                                 




Also, because users cannot get an enlarged version of the screenshots when their devices width is below 768px, I had the default screenshots width set to 100% only under that scenario (width<768px), so that tablet /mobile users can enjoy the bigger screenshots and so that the screenshots take up the otherwise empty space.

See below (Note that this does not maximize on hover):

![tablet size](https://cloud.githubusercontent.com/assets/7268126/6646176/614f0910-c990-11e4-9ab3-c00af211351b.png)

All screenshots were taken in Firefox.