### PR TITLE
minor style change to make marketplace entries stop giving the pointer for no reason

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
@@ -137,9 +137,7 @@
   min-height:100px;
   background-color:@white;
 }
-.portlet-list-item:hover {
-  cursor:pointer;
-}
+
 .portlet_hover {
   min-height:100px;
   border-bottom:0px solid #ddd;


### PR DESCRIPTION
Marketplace entries are no longer clickable, so we should probably stop using the pointer on hover.