### PR TITLE
Use an icon for widgets, just not font-awesome

### DIFF
--- a/angularjs-portal-home/src/main/webapp/partials/portlet-icon.html
+++ b/angularjs-portal-home/src/main/webapp/partials/portlet-icon.html
@@ -1,3 +1,4 @@
 <img ng-src="{{portlet.iconUrl}}" ng-if="!portlet.faIcon && portlet.iconUrl" alt="App icon">
-<i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon"></i>
+<i class="fa {{::portlet.faIcon}}" ng-if="portlet.faIcon && portlet.faIcon.indexOf('fa-')===0"></i>
+<i class="{{::portlet.faIcon}}" ng-if="portlet.faIcon && portlet.faIcon.indexOf('fa-')!==0"></i>
 <i class="fa fa-star" ng-if="!portlet.faIcon && !portlet.iconUrl"></i>


### PR DESCRIPTION
To get the conversation started on how we want to handle this.

This has the advantage that this is 100% backwards compatible.  Merging this won't break anything or require us to go back and change entity files.

Disadvantage is that we're checking 'index of' twice for every portlet and the variable name faIcon hanging around.  We would also have to take a look and maybe do some more stylings.  Noticed that the font-awesome and glyphicons are slightly different sizes.

See this branch where I changed the icon to a glyphicon: 
https://github.com/UW-Madison-DoIT/uPortal/tree/glyphicons

![screen shot 2015-03-18 at 11 19 19 am](https://cloud.githubusercontent.com/assets/5521429/6713491/ae901718-cd60-11e4-9c95-f3bba28f1039.png)

