### PR TITLE
Rename some classes to be more semantic and follow Style Guide

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
@@ -1,4 +1,4 @@
-.card-remove {
+.widget-remove {
   top: 0px;
   position: absolute;
   right:0px;
@@ -213,10 +213,10 @@ div.table-cell {
     }
   }
 }
-.list-content .card-info,
-.list-content .card-remove,
-.widget-content .card-info,
-.widget-content .card-remove {
+.list-content .widget-info,
+.list-content .widget-remove,
+.widget-frame .widget-info,
+.widget-frame .widget-remove {
   display:none;
   .tooltip-inner {
     max-width:200px;
@@ -224,8 +224,8 @@ div.table-cell {
   }
 }
 .list-content:hover,
-.widget-content:hover {
-  .card-info {
+.widget-frame:hover {
+  .widget-info {
     display:inline;
     position:absolute;
     left:8px;
@@ -239,7 +239,7 @@ div.table-cell {
     }
   }
   
-  .card-remove {
+  .widget-remove {
     display:inline;
     position:absolute;
     right:8px;
@@ -268,7 +268,7 @@ div.table-cell {
 
 // Widget View
 
-.widget-content {
+.widget-frame {
   position:relative;
   margin:5px;
   background:#f3f3f3;
@@ -326,7 +326,7 @@ div.table-cell {
     }
   }
 }
-.widget-content select.form-control {
+.widget-frame select.form-control {
   margin:0px auto 10px;
   width:auto;
 }

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
@@ -387,6 +387,14 @@ div.table-cell {
   overflow:scroll;
 }
 
+
+
+/* New Stuff */
+.new-stuff p {
+  width:100%;
+  max-width:100%;
+}
+
 @demo-color:@color1;
 @demo-color-darker:@color2;
 .ribbon-wrapper {

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/myuw-toolkit-temporary.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/myuw-toolkit-temporary.less
@@ -31,6 +31,13 @@ It also contains a body div (.portlet-body), that houses the content.
   padding:5px 20px 0px;
   z-index:5;
 }
+.portlet-header p {
+  color:@white;
+  width:60%;
+  max-width:500px;
+  padding:0px 20px;
+  z-index:5;
+}
 .portlet-header img {
   width:120%;
   z-index:-1;

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/portlet-frame.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/portlet-frame.less
@@ -6,7 +6,7 @@ It contains a header div (.portlet-header), usually with a title, description, a
 It also contains a body div (.portlet-body), that houses the content.
 */
 
-.portlet-frame {
+/*.portlet-frame {
   border-radius:4px;
   padding:0px 0px;
   margin:16px 0px 16px;
@@ -61,4 +61,4 @@ It also contains a body div (.portlet-body), that houses the content.
     font-size:20px;
     color:@white;
   }
-}
+}*/

--- a/angularjs-portal-home/src/main/webapp/partials/default-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/default-card.html
@@ -1,12 +1,12 @@
 <div class="list-content" id="portlet-id-{{::portlet.nodeId}}">
-  <div class='card-info'>
+  <div class='widget-info'>
     <i title="Info" class="fa fa-info-circle"
     tooltip="{{::portlet.description}}"
     tooltip-trigger="mouseenter"
     tooltip-placement="top"
     tooltip-popup-delay="200"></i>
   </div>
-  <div class='card-remove'>
+  <div class='widget-remove'>
     <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
   </div>
   <a ng-if="'NORMAL' === layoutCtrl.portletType(portlet)" href="{{::portlet.url}}" target="{{::portlet.target}}">

--- a/angularjs-portal-home/src/main/webapp/partials/example-widgets.html
+++ b/angularjs-portal-home/src/main/webapp/partials/example-widgets.html
@@ -1,6 +1,6 @@
 <!-- My Courses Example -->
 <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">  
-  <div class="widget-content" id="portlet-id-{{::portlet.nodeId}}">
+  <div class="widget-frame" id="portlet-id-{{::portlet.nodeId}}">
     <div class="ribbon-wrapper"><div class="ribbon">Demo</div></div>
     <div>
       <div class="widget-title">
@@ -35,7 +35,7 @@
 <!-- End Example -->
 <!-- Email Example -->
 <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">  
-  <div class="widget-content" id="portlet-id-{{::portlet.nodeId}}">
+  <div class="widget-frame" id="portlet-id-{{::portlet.nodeId}}">
     <div class="ribbon-wrapper"><div class="ribbon">Demo</div></div>
     <div>
       <div class="widget-title">
@@ -70,7 +70,7 @@
 </li>
 <!-- Calendar Example -->
 <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">  
-  <div class="widget-content" id="portlet-id-{{::portlet.nodeId}}">
+  <div class="widget-frame" id="portlet-id-{{::portlet.nodeId}}">
     <div class="ribbon-wrapper"><div class="ribbon">Demo</div></div>
     <div>
       <div class="widget-title">
@@ -106,7 +106,7 @@
 
 <!-- Professional Development Example -->
 <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">  
-  <div class="widget-content" id="portlet-id-{{::portlet.nodeId}}">
+  <div class="widget-frame" id="portlet-id-{{::portlet.nodeId}}">
     <div>
       <div class="widget-title">
         <h4>My Professional Development</h4>

--- a/angularjs-portal-home/src/main/webapp/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/partials/home-header.html
@@ -1,16 +1,16 @@
 <div class="portlet-header">
   <img ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
     <h1>MyUW Home</h1>
-    <!-- <p>This is the Angular version of MyUW. Enjoy!</p> -->
-  <div ng-controller="NewStuffController as newStuffCtrl">
-    <div ng-repeat="stuff in newStuffArray">
-        <div ng-if='newStuffCtrl.show(stuff)'  class="header-opaque new-stuff">
-            <div><p class="new">New</p></div>
-            <div><h3>{{::stuff.title}}</h3></div>
-            <div class="description"><p>{{::stuff.shortDesc}}<a ng-if="stuff.link !== null" href="{{::stuff.link}}">Find out more.</a></p></div>
-        </div>
+    <p>This is the Angular version of MyUW. Enjoy!</p>
+    <div ng-controller="NewStuffController as newStuffCtrl">
+      <div ng-repeat="stuff in newStuffArray">
+          <div ng-if='newStuffCtrl.show(stuff)'  class="header-opaque new-stuff">
+              <div><p class="new">New</p></div>
+              <div><h3>{{::stuff.title}}</h3></div>
+              <div class="description"><p>{{::stuff.shortDesc}}<a ng-if="stuff.link !== null" href="{{::stuff.link}}">Find out more.</a></p></div>
+          </div>
+      </div>
     </div>
-  </div>
 </div>
 <div class="col-xs-12 notification-section" ng-show="{{$storage.notificationsDemo}}">
   <h3 class="home-section-header">Notifications</h3>

--- a/angularjs-portal-home/src/main/webapp/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/partials/home-header.html
@@ -1,7 +1,7 @@
 <div class="portlet-header">
   <img ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
     <h1>MyUW Home</h1>
-    <p>This is the Angular version of MyUW. Enjoy!</p>
+    <!-- <p>This is the Angular version of MyUW. Enjoy!</p> -->
     <div ng-controller="NewStuffController as newStuffCtrl">
       <div ng-repeat="stuff in newStuffArray">
           <div ng-if='newStuffCtrl.show(stuff)'  class="header-opaque new-stuff">

--- a/angularjs-portal-home/src/main/webapp/partials/home-widget-view.html
+++ b/angularjs-portal-home/src/main/webapp/partials/home-widget-view.html
@@ -11,7 +11,7 @@
     </ul>
     <ul class="tile-list">
        <li class="col-xs-12 col-sm-6 col-md-4 col-lg-3 no-padding list-container">
-         <div class="widget-content add-favorites">
+         <div class="widget-frame add-favorites">
            <a href='#/apps'>
              <div class="widget-icon-container">
                <i class="fa fa-plus"></i>

--- a/angularjs-portal-home/src/main/webapp/partials/static-content-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/static-content-card.html
@@ -4,7 +4,7 @@
       <portlet-icon></portlet-icon><h1>{{ ::portlet.title }}</h1>
   </div>
   
-  <div class='card-remove'>
+  <div class='widget-remove'>
      <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
   </div>
   <div class="portlet-content">

--- a/angularjs-portal-home/src/main/webapp/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/partials/widget-card.html
@@ -1,19 +1,20 @@
-<div class="widget-content" id="portlet-id-{{::portlet.nodeId}}">
-  
-  <!-- Widget Chrome -->
-  <div class='card-info'>
-    <i title="Info" class="fa fa-info-circle"
-    tooltip="{{::portlet.description}}"
-    tooltip-trigger="mouseenter"
-    tooltip-placement="top"
-    tooltip-popup-delay="200"></i>
-  </div>
-  <div class='card-remove'>
-    <i title="Remove" class="fa fa-times portlet-options" ng-click="widgetCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
-  </div>
-  
-  <div class="widget-title">
-    <h4>{{ ::portlet.title }}</h4>
+<div class="widget-frame" id="portlet-id-{{::portlet.nodeId}}">
+  <div class="widget-header">
+    <!-- Widget Chrome -->
+    <div class='widget-info'>
+      <i title="Info" class="fa fa-info-circle"
+      tooltip="{{::portlet.description}}"
+      tooltip-trigger="mouseenter"
+      tooltip-placement="top"
+      tooltip-popup-delay="200"></i>
+    </div>
+    <div class='widget-remove'>
+      <i title="Remove" class="fa fa-times portlet-options" ng-click="widgetCtrl.removePortlet(portlet.nodeId, portlet.title)"></i>
+    </div>
+    
+    <div class="widget-title">
+      <h4>{{ ::portlet.title }}</h4>
+    </div>
   </div>
   
   <!-- For widgets, show fancy markup! -->


### PR DESCRIPTION
`.widget-content` -> `.widget-frame`
`.card-remove` -> `.widget-remove`
`.card-info` -> `.widget-info`
