### PR TITLE
MUMUP-1757 : Weather app error handling

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/widget.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/widget.less
@@ -13,7 +13,6 @@ weather {
 	  text-align:center;
 	  padding-bottom:20px;
 	  padding-top:12px;
-	  
 	}
    .warning-message-weather-widget{
 	  text-align:-webkit-center;
@@ -23,20 +22,16 @@ weather {
       font-size:50px;
       width:100%;
       text-align:center;
-      
       padding: 0px 123px;
     }
-        	
    .error-message-weather-widget{
 	  font-size:smaller;
 	  text-align:center;
-	  
 	  a{
-	  	color:red;
+		color:red;
 	  }
 	}
-	
-  img {
+  img{
     width:42px;
     position:relative;
     right:1px;

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/widget.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/widget.less
@@ -7,6 +7,35 @@ weather {
         font-size:11px;
       }
   }
+  .fa-exclamation-triangle{
+	  font-size: -webkit-xxx-large;
+	  width:100%;
+	  text-align:center;
+	  padding-bottom:20px;
+	  padding-top:12px;
+	  
+	}
+   .warning-message-weather-widget{
+	  text-align:-webkit-center;
+	  padding: 20px 20px;
+	}
+  .fa-frown-o{
+      font-size:50px;
+      width:100%;
+      text-align:center;
+      
+      padding: 0px 123px;
+    }
+        	
+   .error-message-weather-widget{
+	  font-size:smaller;
+	  text-align:center;
+	  
+	  a{
+	  	color:red;
+	  }
+	}
+	
   img {
     width:42px;
     position:relative;

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -1,5 +1,9 @@
 <div>
-    <loading-gif data-object='weatherData'></loading-gif>
+
+	<div id="loading">
+    	<loading-gif data-object='weatherData'></loading-gif>
+    </div>
+	
     <ul class="widget-list">
         <li ng-repeat="weather in portlet.widgetData | limitTo:2">
           <a href="{{weather.moreInformationLink}}" target='_blank'>
@@ -25,6 +29,44 @@
           </a>
         </li>
     </ul>
+    
+    <div ng-if="weather.location == null">
+		<div ng-model="noLocations" ng-init="noLocations=true">
+			<i class="fa fa-exclamation-triangle" aria-label='Warning'></i>
+			<div class="warning-message">Hold up! You haven't set any weather locations yet! Launch the full app to select your weather locations.</div>
+			<style>
+			
+				.fa-exclamation-triangle{
+					font-size: -webkit-xxx-large;
+					padding: 20px 120px;
+				}
+				.warning-message{
+					text-align:-webkit-center;
+					padding: 9px 0px;
+				}
+				
+			</style>
+		</div>
+	</div>
+    
+    <div ng-if="weatherData.length == 0 && noLocations==false">
+	    <i class="fa fa-frown-o" aria-label='Error'></i>
+        <div class="error-message"> Oops! The weather service seems to be down. Try clicking <a href="http://www.weather.com/weather/today/l/USWI0411:1:US" target="_blank" style="color: red">here</a> for local weather!</div>
+        <style>
+        
+        	.fa-frown-o{
+        		font-size:50px;
+        		padding: 0px 123px;
+        	}
+        	
+			.error-message{
+				font-size:smaller;
+				text-align:center;
+			}
+			
+		</style>
+	</div>
+    
     <p class="credit">Weather provided by <a href="http://www.worldweatheronline.com/">World Weather Online</a></p>
 </div>
 <a class="btn btn-default launch-app-button" href="{{::portlet.url}}">Launch Full App</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -1,8 +1,20 @@
 <div>
 
-	<div id="loading">
-    	<loading-gif data-object='weatherData'></loading-gif>
-    </div>
+    <div ng-if="!weather.location">
+		<div ng-model="noLocations" ng-init="noLocations=true">
+			<i class="fa fa-exclamation-triangle" aria-label='Warning'></i>
+			<div class="warning-message-weather-widget">Hold up! You haven't set any weather locations yet! Launch the full app to select your weather locations.</div>
+		</div>
+		
+		<div ng-if="!noLocations"id="loading">
+    		<loading-gif data-object='weatherData'></loading-gif>
+    	</div>
+	</div>
+
+    <div ng-if="weather.location && weatherData.length == 0">
+	    <i class="fa fa-frown-o" aria-label="Error"></i>
+        <div class="error-message-weather-widget"> Oops! The weather service seems to be down. <a href="http://www.weather.com/weather/today/l/USWI0411:1:US" target="_blank">Try clicking here for local weather!</a></div>
+	</div>
 	
     <ul class="widget-list">
         <li ng-repeat="weather in portlet.widgetData | limitTo:2">
@@ -29,43 +41,7 @@
           </a>
         </li>
     </ul>
-    
-    <div ng-if="weather.location == null">
-		<div ng-model="noLocations" ng-init="noLocations=true">
-			<i class="fa fa-exclamation-triangle" aria-label='Warning'></i>
-			<div class="warning-message">Hold up! You haven't set any weather locations yet! Launch the full app to select your weather locations.</div>
-			<style>
-			
-				.fa-exclamation-triangle{
-					font-size: -webkit-xxx-large;
-					padding: 20px 120px;
-				}
-				.warning-message{
-					text-align:-webkit-center;
-					padding: 9px 0px;
-				}
-				
-			</style>
-		</div>
-	</div>
-    
-    <div ng-if="weatherData.length == 0 && noLocations==false">
-	    <i class="fa fa-frown-o" aria-label='Error'></i>
-        <div class="error-message"> Oops! The weather service seems to be down. Try clicking <a href="http://www.weather.com/weather/today/l/USWI0411:1:US" target="_blank" style="color: red">here</a> for local weather!</div>
-        <style>
-        
-        	.fa-frown-o{
-        		font-size:50px;
-        		padding: 0px 123px;
-        	}
-        	
-			.error-message{
-				font-size:smaller;
-				text-align:center;
-			}
-			
-		</style>
-	</div>
+
     
     <p class="credit">Weather provided by <a href="http://www.worldweatheronline.com/">World Weather Online</a></p>
 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -13,7 +13,7 @@
 
     <div ng-if="weather.location && weatherData.length == 0">
 	    <i class="fa fa-frown-o" aria-label="Error"></i>
-        <div class="error-message-weather-widget"> Oops! The weather service seems to be down. <a href="http://www.weather.com/weather/today/l/USWI0411:1:US" target="_blank">Try clicking here for local weather!</a></div>
+        <div class="error-message-weather-widget"> Oops! The weather service seems to be down. <a href="http://www.weather.com/weather/today/l/USWI0411:1:US" target="_blank">Try clicking here for Madison weather!</a></div>
 	</div>
 	
     <ul class="widget-list">


### PR DESCRIPTION
This pull request is in regards to error handling for the weather widget under two scenarios: 1st, that the user actually has locations selected in their weather portlet settings, otherwise a frowny face and fix-instructions appear, and 2nd that when the World Weather Online service fails for whatever reason, the user will be gracefully told to click on the link provided to view the local weather (from a different weather service).

Due to the Weather app not actually loading weather on local host, I wasn't exactly able to test my changes under the condition that the back-end services actually work, and so I was hoping to do that on my-test once/if this gets merged. That is, of course, if everything here looks good to you guys.

Screenshots of what i would eventually look like (once working)

User has no locations set in their weather portlet settings
![no locations](https://cloud.githubusercontent.com/assets/7268126/7208962/e65d2f9e-e509-11e4-8dc6-c5edba99dc79.png)

Weather service is down or being very slow(still trying to fetch data from service and thus the loading icon should remain)

![no service](https://cloud.githubusercontent.com/assets/7268126/7208975/ff21adf2-e509-11e4-87d8-d0afabccaf47.png)
