### PR TITLE
MUMUP-1814: Bug: weather  widget "World Weather Online" link doesn't open in new window

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -25,6 +25,6 @@
           </a>
         </li>
     </ul>
-    <p class="credit">Weather provided by <a href="http://www.worldweatheronline.com/">World Weather Online</a></p>
+    <p class="credit">Weather provided by <a href="http://www.worldweatheronline.com/" target="_blank">World Weather Online</a></p>
 </div>
 <a class="btn btn-default launch-app-button" href="{{::portlet.url}}">Launch Full App</a>


### PR DESCRIPTION
The world weather online link at the bottom of the weather widget doesn't open in a new tab when clicked. I added target="_blank" to the HTML code and now it works. 

For reference, the link this issue is about is at the bottom of this screenshot: "Weather provided...
![linkatbottom](https://cloud.githubusercontent.com/assets/7268126/7376652/bc0f97fe-eda6-11e4-9906-d95984e53740.png)
