### PR TITLE
[SPFP-81]  Redirect to index by default

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/WEB-INF/web.xml
+++ b/angularjs-portal-frame/src/main/webapp/WEB-INF/web.xml
@@ -2,7 +2,7 @@
  "-//Sun Microsystems, Inc.//DTD Web Application 2.3//EN"
  "http://java.sun.com/dtd/web-app_2_3.dtd" >
 
-<web-app 
+<web-app
     xmlns="http://java.sun.com/xml/ns/javaee"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
@@ -11,16 +11,19 @@
   <welcome-file-list>
     <welcome-file>index.jsp</welcome-file>
   </welcome-file-list>
-  
-  <servlet>
-      <servlet-name>StaticServlet</servlet-name>
-      <jsp-file>/index.jsp</jsp-file>
-  </servlet>
-  
-  <!-- Keep this in sync with angular-page.js -->
-  <servlet-mapping>
-      <servlet-name>StaticServlet</servlet-name>
-      <url-pattern>/settings</url-pattern>
-  </servlet-mapping>
+
+  <!-- Since this is a one-page angular app, let requests that don't map to resources fall back
+       to the app.  This way, we don't need an explicit servlet-mapping for every url pattern
+       already defined for the angular $routeProvider, nor to keep the two mappings in sync.
+       index.jsp will change the response status to 200 to hide this hack from the requester. -->
+  <error-page>
+    <error-code>404</error-code>
+    <location>/index.jsp</location>
+  </error-page>
+  <error-page>
+    <error-code>403</error-code>
+    <location>/index.jsp</location>
+  </error-page>
+
 </web-app>
 

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
@@ -62,7 +62,7 @@ default-card portlet-icon img {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   padding:6px 30px 5px 12px;
-  
+
 }
 .portlet-title h1, .portlet-title i.fa {
   font-size: 1.5em;
@@ -128,17 +128,17 @@ div.table-cell {
 }
 
 
-.tile-list { 
-  list-style-type: none; 
-  margin: 5px; 
+.tile-list {
+  list-style-type: none;
+  margin: 5px;
   padding: 0px;
-  max-width:1200px; 
+  max-width:1200px;
 }
 
 // View Toggle
 .home-title {
   padding:0px 0px 0px 15px;
-  
+
 }
 .inner-nav-container .inner-nav li.home-title {
   border-bottom:3px solid transparent !important;
@@ -157,7 +157,7 @@ div.table-cell {
     font-size:18px;
     color:@color1;
   }
-  
+
 }
 
 
@@ -243,7 +243,7 @@ div.table-cell {
       }
     }
   }
-  
+
   .widget-remove {
     display:inline;
     position:absolute;
@@ -364,7 +364,7 @@ div.table-cell {
     padding:0px;
     font-size:12px;
   }
-  
+
   .bold {
     font-weight:600;
     color:#222;
@@ -439,17 +439,32 @@ div.table-cell {
   top: 15px;
   width: 120px;
   background-color: @demo-color;
-  background-image: -webkit-gradient(linear, left top, left bottom, from(@demo-color), to(@demo-color-darker)); 
-  background-image: -webkit-linear-gradient(top, @demo-color, @demo-color-darker); 
-  background-image:    -moz-linear-gradient(top, @demo-color, @demo-color-darker); 
-  background-image:     -ms-linear-gradient(top, @demo-color, @demo-color-darker); 
-  background-image:      -o-linear-gradient(top, @demo-color, @demo-color-darker); 
+  background-image: -webkit-gradient(linear, left top, left bottom, from(@demo-color), to(@demo-color-darker));
+  background-image: -webkit-linear-gradient(top, @demo-color, @demo-color-darker);
+  background-image:    -moz-linear-gradient(top, @demo-color, @demo-color-darker);
+  background-image:     -ms-linear-gradient(top, @demo-color, @demo-color-darker);
+  background-image:      -o-linear-gradient(top, @demo-color, @demo-color-darker);
   -webkit-box-shadow: 0px 0px 3px rgba(0,0,0,0.3);
   -moz-box-shadow:    0px 0px 3px rgba(0,0,0,0.3);
   box-shadow:         0px 0px 3px rgba(0,0,0,0.3);
   z-index:999;
 }
 
+.error-page {
+  height:100%;
+  width:100%;
+  text-align:center;
+  padding-top:100px;
+  font-size:18px;
+  span {
+    font-size:50px;
+    margin:30px 0px 10px;
+  }
+  a {
+    color:@color1;
+    font-weight:600;
+  }
+}
 
 @media (max-width: 767px) {
   div.table {

--- a/angularjs-portal-frame/src/main/webapp/index.jsp
+++ b/angularjs-portal-frame/src/main/webapp/index.jsp
@@ -1,3 +1,4 @@
 <%@ taglib prefix="c" uri="http://java.sun.com/jsp/jstl/core" %>
+<% response.setStatus(200); %>
 <jsp:include page="/WEB-INF/classes/frame.jsp" />
 

--- a/angularjs-portal-frame/src/main/webapp/my-app/main.js
+++ b/angularjs-portal-frame/src/main/webapp/my-app/main.js
@@ -1,4 +1,4 @@
-define(['angular', 'jquery', 'portal', 'portal/main/route', 'portal/settings/route'], function(angular, $, portal, main, settings) {
+define(['angular', 'jquery', 'portal', 'portal/main/route', 'portal/settings/route', 'portal/error/route'], function(angular, $, portal, main, settings, error) {
     /*
      This module intentionally left empty. This file is intended to serve as an extension point
      for My UW Madison 'App' developers that overlay angularjs-portal-frame.
@@ -12,9 +12,9 @@ define(['angular', 'jquery', 'portal', 'portal/main/route', 'portal/settings/rou
     app.config(['$routeProvider', '$locationProvider', function ($routeProvider, $locationProvider) {
         $locationProvider.html5Mode(true);
         $routeProvider.
+            when('/', main).
             when('/settings', settings).
-            /* when('/notifications', {templateUrl: require.toUrl('./partials/notifications-full.html')}). */
-            otherwise(main);
+            otherwise(error);
     }]);
 
     return app

--- a/angularjs-portal-frame/src/main/webapp/portal/error/partials/error.html
+++ b/angularjs-portal-frame/src/main/webapp/portal/error/partials/error.html
@@ -1,0 +1,5 @@
+<div class="error-page">
+    <span class="fa fa-frown-o"></span>
+    <p>Sorry, we couldn't find a page by that name.<br/><a href="/">Return to main page</a></p>
+</div>
+

--- a/angularjs-portal-frame/src/main/webapp/portal/error/route.js
+++ b/angularjs-portal-frame/src/main/webapp/portal/error/route.js
@@ -1,0 +1,8 @@
+define(['require'], function(require) {
+
+    return {
+        templateUrl: require.toUrl('./partials/error.html')
+    }
+
+});
+

--- a/pom.xml
+++ b/pom.xml
@@ -17,14 +17,14 @@
         <name>My UW Dev Team</name>
     </developer>
   </developers>
-  
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>
       <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
     </license>
   </licenses>
-  
+
   <scm>
     <connection>scm:git:git@github.com:UW-Madison-DoIT/angularjs-portal.git</connection>
     <developerConnection>scm:git:git@github.com:UW-Madison-DoIT/angularjs-portal.git</developerConnection>
@@ -165,6 +165,7 @@
         <groupId>org.eclipse.jetty</groupId>
         <artifactId>jetty-maven-plugin</artifactId>
         <version>9.3.0.M2</version>
+        <inherited>false</inherited>
         <configuration>
           <contextHandlers>
             <contextHandler implementation="org.eclipse.jetty.maven.plugin.JettyWebAppContext">


### PR DESCRIPTION
Having to take every URL pattern from your angular app and copy it into servlet-mappings is a pain!
Moreso if you wanted to use Java based config in your app (SPFP), because XML configuration gets a higher precedence than annotation or Java-based config.

This change sends any would-be 404 to the angular app, although clients like `angularjs-portal-home` can still overlay web.xml to get that fine-grained control and explicitly map as currently.

Example:
```
/frame/ --> default servlet --> index.jsp --> angular $routeProvider --> main page
/frame/settings --> default servlet --> not found --> index.jsp --> angular $routeProvider --> settings page
/frame/quuux --> default servlet --> not found --> index.jsp --> angular $routeProvider --> main page
/web/quuux --> default servlet --> not found --> 404
```