### PR TITLE
MUMMNG-1395: Reign in exclamation points in the  Weather Widget

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -3,7 +3,7 @@
     <div ng-if="weatherData && weatherData.length == 0 && !loading && !error">
         <div>
             <i class="fa fa-exclamation-triangle" aria-label='Warning'></i>
-            <div class="warning-message-weather-widget">Hold up! You haven't set any weather locations yet! Launch the full app to select your weather locations.</div>
+            <div class="warning-message-weather-widget">Hold up! You haven't set any weather locations yet. Launch the full app to select your weather locations.</div>
         </div>
     </div>
     
@@ -12,7 +12,7 @@
    </div>
 
     <div ng-if="error">
-        <p class='error-message-weather-widget'><i class="fa fa-frown-o" aria-label="Error"></i><br/>Oops! The weather service seems to be down. <a href="http://www.ssec.wisc.edu/localweather/" target="_blank">Try clicking here for Madison weather!</a></p>
+        <p class='error-message-weather-widget'><i class="fa fa-frown-o" aria-label="Error"></i><br/>Oops! The weather service seems to be down. <a href="http://www.ssec.wisc.edu/localweather/" target="_blank">Try clicking here for Madison weather.</a></p>
     </div>
     
     <ul class="widget-list">


### PR DESCRIPTION
I cut down the error messages to 1 exclamation point per message (as requested by Phyllis).

When no locations are set:
"Hold up! You haven't set any weather locations yet. Launch the full app to select your weather locations."

When backend service fails:
"Oops! The weather service seems to be down. Try clicking here for Madison weather."