### PR TITLE
Fix details link overlap

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/marketplace.less
@@ -86,6 +86,9 @@
   color:@grayscale7;
   cursor:default !important;
 }
+.category-list {
+  min-height:20px;
+}
 .category-links {
   background-color:@white;
   color:#066999;


### PR DESCRIPTION
Phyllis pointed out in the sprint review that for apps without a category, the Details link overlaps the bottom border. After fixing this I couldn't find an example in production so I don't think this is actually an issue...but now it's fixed just in case :)

Localhost before:
![image](https://cloud.githubusercontent.com/assets/1919535/7500529/c8c08e4c-f3f3-11e4-9da8-fac588fee811.png)

After:
![image](https://cloud.githubusercontent.com/assets/1919535/7500630/59b7188a-f3f4-11e4-85a0-ad21751dc4d9.png)

