### PR TITLE
MUMUP-1428: Error experience for <IE10 users

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
@@ -451,9 +451,14 @@ div.table-cell {
 }
 
 .browserupgrade {
+  position:fixed;
+  height:100%;
+  width:100%;
+  background-color:#fff;
   text-align:center;
-  padding:20px;
+  padding:100px;
   font-size:18px;
+  z-index:9000;
   span {
     font-size:50px;
     margin:30px 0px 10px;

--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/home.less
@@ -450,6 +450,20 @@ div.table-cell {
   z-index:999;
 }
 
+.browserupgrade {
+  text-align:center;
+  padding:20px;
+  font-size:18px;
+  span {
+    font-size:50px;
+    margin:30px 0px 10px;
+  }
+  a {
+    color:@color1;
+    font-weight:600;
+  }
+}
+
 
 @media (max-width: 767px) {
   div.table {

--- a/angularjs-portal-frame/src/main/webapp/frame.jsp
+++ b/angularjs-portal-frame/src/main/webapp/frame.jsp
@@ -21,7 +21,7 @@
 <!--[if lt IE 10]>
 <div class="browserupgrade">
   <span class="fa fa-frown-o"></span>
-  <p>Sorry, your browser is out of date and not supported by MyUW. Learn how to upgrade <a href="http://browsehappy.com/">here</a>.</p>
+  <p>Sorry, your browser is out of date and not supported by MyUW.<br/>Learn how to upgrade <a href="http://browsehappy.com/">here</a>.</p>
 </div>
 <![endif]-->
 <noscript>

--- a/angularjs-portal-frame/src/main/webapp/frame.jsp
+++ b/angularjs-portal-frame/src/main/webapp/frame.jsp
@@ -21,7 +21,7 @@
 <!--[if lt IE 10]>
 <div class="browserupgrade">
   <span class="fa fa-frown-o"></span>
-  <p>Sorry, your browser is out of date and not supported by MyUW.<br/>Learn how to upgrade <a href="http://browsehappy.com/">here</a>.</p>
+  <p>Sorry, MyUW beta does not support your browser.<br/><a href="http://browsehappy.com/">Learn how to upgrade your browser.</a><br/>Can't upgrade? <a href="http://my.wisc.edu/portal/Login?profile=default">Switch back to MyUW classic.</a></p>
 </div>
 <![endif]-->
 <noscript>

--- a/angularjs-portal-frame/src/main/webapp/frame.jsp
+++ b/angularjs-portal-frame/src/main/webapp/frame.jsp
@@ -21,7 +21,7 @@
 <!--[if lt IE 10]>
 <div class="browserupgrade">
   <span class="fa fa-frown-o"></span>
-  <p>Sorry, MyUW beta does not support your browser.<br/><a href="http://browsehappy.com/">Learn how to upgrade your browser.</a><br/>Can't upgrade? <a href="http://my.wisc.edu/portal/Login?profile=default">Switch back to MyUW classic.</a></p>
+  <p>Sorry, MyUW beta does not support your browser.<br/><a href="https://kb.wisc.edu/myuw/page.php?id=51345">Learn how to upgrade your browser.</a><br/>Can't upgrade? <a href="http://my.wisc.edu/portal/Login?profile=default">Switch back to MyUW classic.</a></p>
 </div>
 <![endif]-->
 <noscript>

--- a/angularjs-portal-frame/src/main/webapp/frame.jsp
+++ b/angularjs-portal-frame/src/main/webapp/frame.jsp
@@ -18,6 +18,12 @@
 </head>
 
 <body  ng-controller="MainController as mainCtrl">
+<!--[if lt IE 10]>
+<div class="browserupgrade">
+  <span class="fa fa-frown-o"></span>
+  <p>You are using an outdated browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+</div>
+<![endif]-->
 <noscript>
     <div class="alert alert-warning alert-dismissible" role="alert" style="margin-bottom:0;">
     <div class="container">

--- a/angularjs-portal-frame/src/main/webapp/frame.jsp
+++ b/angularjs-portal-frame/src/main/webapp/frame.jsp
@@ -21,7 +21,7 @@
 <!--[if lt IE 10]>
 <div class="browserupgrade">
   <span class="fa fa-frown-o"></span>
-  <p>You are using an outdated browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
+  <p>Sorry, your browser is out of date and not supported by MyUW. Learn how to upgrade <a href="http://browsehappy.com/">here</a>.</p>
 </div>
 <![endif]-->
 <noscript>


### PR DESCRIPTION
So Angular straight up doesn't support IE 8, but I don't think our experience on IE 9 is that great either. Do we want to support IE 9 or leave it in the dust? Right now I have it not supported, but it's easy to change it to support IE9.

This code will display a simple div at the top of the page informing users browsing on < IE 10 that they are using an outdated browser and they should update it. This snippet is commonly used on many other websites and links to a site called Browse Happy that shows users how to download a better, up-to-date browser. Personally, I think this would be more engaging and intuitive than linking to a KB doc, but I understand if we want to be more UW-specific with this and go that route instead. Thoughts?

Screenshot of how IE8 would look (I don't have an easy way to test on IE9):
![image](https://cloud.githubusercontent.com/assets/1919535/7501730/f9641b9c-f3fb-11e4-8cc9-ebfbede1d584.png)


