### PR TITLE
Use correct artifact for ui-bootstrap

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/main.js
+++ b/angularjs-portal-frame/src/main/webapp/main.js
@@ -14,7 +14,7 @@ require.config({
         'ngSanitize'    : "bower_components/angular-sanitize/angular-sanitize.min",
         'ngStorage'     : "bower_components/ngstorage/ngStorage.min",
         'sortable'      : "js/sortable",
-        'ui-bootstrap'  : "bower_components/angular-bootstrap/ui-bootstrap.min",
+        'ui-bootstrap'  : "bower_components/angular-bootstrap/ui-bootstrap-tpls.min",
         'ui-gravatar'   : "bower_components/angular-gravatar/build/angular-gravatar",
         // Use ui-bootstrap instead of bootstrap or uw-ui-toolkit.  See https://angular-ui.github.io/bootstrap/
         //'uw-ui-toolkit' : "bower_components/uw-ui-toolkit/dist/js/uw-ui-toolkit.min"


### PR DESCRIPTION
`ui-bootstrap.js` references a bunch of html templates, but does not define them.  So, for instance, you'd get a 404 on "templates/accordion/accordion.html".  The cryptically named `ui-bootstrap-tpls.js` is the one to use, because it includes the templates.

I also noticed the file had CRLF line endings (my bad) so I replaced them with LF.