### PR TITLE
Fix search bar pixel

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
@@ -153,6 +153,7 @@ a#myuw-header img {
   color: @color3;
   float: right;
   padding: 3px 0px 3px 15px;
+  height:38px;
 }
 .main-search[placeholder="Search My-UW"] {
   color: @color1;
@@ -165,6 +166,7 @@ a#myuw-header img {
   border:0px solid transparent;
   background-color:@color4;
   top:2px;
+  height:38px;
   &:hover {
     background-color:#efe8d8;
   }


### PR DESCRIPTION
This doesn't completely fix the issue - it's still off by a pixel at other zooms, but it fixes it for 100% zoom, which is what most people will be using.

It's a bug with Bootstrap, which is also a tad wonky at different zooms.

MyUW, 100% Before:
![image](https://cloud.githubusercontent.com/assets/1919535/8111654/9f6f2778-1028-11e5-9993-93505085a81c.png)

MyUW, 100% After:
![image](https://cloud.githubusercontent.com/assets/1919535/8111665/af3f5b96-1028-11e5-8335-ad5fa6a356a5.png)

MyUW, 110% After:
![image](https://cloud.githubusercontent.com/assets/1919535/8111671/bd91b108-1028-11e5-8516-d8fa9b47e9ba.png)

Bootstrap, 110%:
![image](https://cloud.githubusercontent.com/assets/1919535/8111688/da683464-1028-11e5-8f0d-ee70f3945937.png)
