### PR TITLE
MUMUP-1904 : Clean up email-widget

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/portal/misc/filters.js
+++ b/angularjs-portal-frame/src/main/webapp/portal/misc/filters.js
@@ -19,6 +19,18 @@ define(['angular'], function(angular) {
             return input;
         };
     });
+    
+    app.filter('trimMiddle', function() {
+        return function(input, maxlen) {
+            maxlen = maxlen || 20;
+            if(input && input.length > maxlen) {
+              return input.substring(0,Math.floor(maxlen/2)-3) + " ... " + input.substring(input.length - (Math.floor(maxlen/2)-4), input.length);
+            } else {
+                return input;
+            }
+        };
+    });
+    
     app.filter('showApplicable', function() {
         return function(portlets, showAll) {
             var filteredPortlets = [];

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
@@ -5,16 +5,16 @@
 </div>
 <div>
   <div>
-    <div ng-if="portlet.widgetData.length == 0">
-        loading...
+    <div ng-if="portlet.widgetData.length == 0" class='center'>
+        <loading-gif data-object='portlet.widgetData'></loading-gif>
     </div>
     <div ng-if="config.singleElement && (!portlet.widgetData[config.arrayName] || portlet.widgetData[config.arrayName].length == 0)" class='center'>
-        {{portlet.widgetData[config.display]}}
+        <span title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</span>
     </div>
     <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1" style='margin-top: -10px;'>
        <select ng-model="portlet.selectedUrl" class='form-control'>
-           <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}">{{portlet.widgetData[config.display]}}</option>
-           <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}">{{obj[config.display]}}</option>
+           <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}" title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</option>
+           <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}" title='{{obj[config.display].length > 26 ? obj[config.display] : ""}}'>{{obj[config.display] | trimMiddle:26}}</option>
        </select>
     </div>
   </div>

--- a/angularjs-portal-home/src/main/webapp/samples/wiscmail-accounts.json
+++ b/angularjs-portal-home/src/main/webapp/samples/wiscmail-accounts.json
@@ -10,6 +10,11 @@
       "email" : "wiscmail-ex@wisc.edu"
     },
     {
+      "system" : "wiscmail",
+      "uri" : "https://wiscmail.wisc.edu/login",
+      "email" : "reallylongnamethatextendspastthethresholdsowehavetoaddafilter@wisc.edu"
+    },
+    {
       "system" : "o365",
       "uri" : "https://outlook.com/owa/my-core_doit@wisc.edu/",
       "email" : "my-core@doit.wisc.edu"


### PR DESCRIPTION
#### Changes:
* Added in the loading-gif icon while it loads, and centered said gif.
* Added in a `trimMiddle` filter that cuts out the middle of the string, adds in ` ... ` in the middle
* Added filter to option-link filter, with max length 26
* Added title if filter is in effect on the option to show the full text

#### Before:

![http://goo.gl/DBDGvp](http://goo.gl/DBDGvp)

#### After:

##### Multiple
![screen shot 2015-06-11 at 11 46 43 am](https://cloud.githubusercontent.com/assets/3534544/8112750/952e94f4-102f-11e5-9ba6-b6082d558068.png)

##### Single
![screen shot 2015-06-11 at 11 51 46 am](https://cloud.githubusercontent.com/assets/3534544/8112861/4d31c120-1030-11e5-82b6-5ad88b3f73ce.png)

_I was having issues getting the title to capture, but trust me, its there on hover of an option_
