### PR TITLE
MUMUP-1876 : Fix style so that you can have longer than normal app names

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/header.less
@@ -172,7 +172,6 @@ a#myuw-header img {
   }
 }
 .header-mobile {
-  width:50%;
   display:inline-block;
 }
 .navbar-header .search-mobile-icon .fa-search {


### PR DESCRIPTION
### Before 
![http://goo.gl/e6oznh](http://goo.gl/e6oznh)
### After

![http://goo.gl/5zlaIg](http://goo.gl/5zlaIg)

![http://goo.gl/jyzVyk](http://goo.gl/jyzVyk)

_Please note that this doesn't actually change the name, just lets frame apps have the ability to be more wordy in there title._