### PR TITLE
MUMUP-1930 update README re providing endpoint.properties .

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,28 @@
 This is an angular approach to the dashboard view of uPortal. This dashboard will work along side uPortal, more of a companion app. It utilizes the uPortal rest APIs to collect layout info. It pulls notifications from the notification portlet resource URL.
 
 ### Building
-`mvn package` from the root directory.
+
+First, copy
+
+```
+angularjs-portal/angularjs-portal-home/src/main/resources/endpoint.properties.example
+```
+
+to
+
+```
+angularjs-portal/angularjs-portal-home/src/main/resources/endpoint.properties
+```
+
+so that the `/web` war file you are packaging includes an `endpoint.properties` file, so that the
+ `/web` Sprint application context can initialize successfully.
+ 
+You do not have to actually set any properties in that properties file to achieve basic 
+workingness ; it might be simplest if you did not.
+
+Once the source is ready to build by your having provided a suitable `endpoint.properties`, run
+
+`mvn package` from the root directory to build the war files.
 
 ### Modules
 


### PR DESCRIPTION
If you don't provide an `endpoint.properties`, the `/web` war file will not Spring applicationContext init, and so fails to come up under e.g. `jetty:run`.

This PR updates `README.md` to document that one needs to do this before building.

Went for documentation of the step rather than just going ahead and providing an empty `endpoint.properties`, since a `.gitignore` had carefully excluded `endpoint.properties`.