### PR TITLE
filtering tabs (most popular/a-z/categories)

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -6,10 +6,10 @@
     <p class="portlet-description"></p>
     <span class="fa fa-search mp-search-icon"></span><input type="text" class="marketplace-search" placeholder="What are you looking for?" ng-model="searchText" select-on-page-load aria-label="Search bar enter the app you are looking for">
     <div class="header-opaque mp-opaque">
-      <ul>
-        <li ng-click="selectFilter('popular','')" ng-class="{true:'selected-filter'}[selectedFilter === 'popular']">Most Popular</li>
-        <li ng-click="selectFilter('az','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'az']">A-Z</li>
-        <li ng-click="selectFilter('category','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'category']">Categories</li>
+      <ul class="nav nav-tabs">
+        <li class="active" ng-click="selectFilter('popular','')" ng-class="{true:'selected-filter'}[selectedFilter === 'popular']"><a href="#" aria-label="search from the most popular apps">Most Popular</a></li>
+        <li ng-click="selectFilter('az','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'az']"><a href="#" aria-label="search by alphabetical order">A-Z</a></li>
+        <li ng-click="selectFilter('category','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'category']"><a href="#" aria-label="search by categories">Categories</a></li>
       </ul>
     </div>
   </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -6,8 +6,8 @@
     <p class="portlet-description"></p>
     <span class="fa fa-search mp-search-icon"></span><input type="text" class="marketplace-search" placeholder="What are you looking for?" ng-model="searchText" select-on-page-load aria-label="Search bar enter the app you are looking for">
     <div class="header-opaque mp-opaque">
-      <ul class="nav nav-tabs">
-        <li class="active" ng-click="selectFilter('popular','')" ng-class="{true:'selected-filter'}[selectedFilter === 'popular']"><a href="#" aria-label="search from the most popular apps">Most Popular</a></li>
+      <ul>
+        <li ng-click="selectFilter('popular','')" ng-class="{true:'selected-filter'}[selectedFilter === 'popular']"><a href="#" aria-label="search from the most popular apps">Most Popular</a></li>
         <li ng-click="selectFilter('az','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'az']"><a href="#" aria-label="search by alphabetical order">A-Z</a></li>
         <li ng-click="selectFilter('category','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'category']"><a href="#" aria-label="search by categories">Categories</a></li>
       </ul>


### PR DESCRIPTION
filtering tabs (most popular/a-z/categories)
issue: tab navigation skips & for A-Z tab, screenreader says "AH ZED"
solve: add aria-label (description) and make tab works for switching search types