### PR TITLE
Fix hover state of notification on full

### DIFF
--- a/angularjs-portal-frame/src/main/webapp/css/buckyless/notifications.less
+++ b/angularjs-portal-frame/src/main/webapp/css/buckyless/notifications.less
@@ -17,11 +17,6 @@
 
 .notifications-list li:hover {
   background-color:#f3f3f3;
-  width:101%;
-  position:relative;
-  left:-0.5%;
-  box-shadow:0px 0px 7px @grayscale4;
-  border-bottom:none;
 }
 .notifications-list a {
   color: @color1;


### PR DESCRIPTION
We had this hover move thing going on as part of the demo. Just cleaning it up a bit so just the background color shade changes a bit.

### Before
![http://goo.gl/8cZucT](http://goo.gl/8cZucT)

### After
![http://goo.gl/Aadmtd](http://goo.gl/Aadmtd)