### PR TITLE
improve the accessibility for widget view

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -13,10 +13,10 @@
     </div>
     
     <div class="widget-title">
-      <h4 id="appTitle{{::portlet.title}}" aria-labelledby="appTitle{{::portlet.title}}" tabindex="0">{{ ::portlet.title }}</h4>
+      <h4 id="appTitle_portlet.title-{{::portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{::portlet.nodeId}}" tabindex="0">{{ ::portlet.title }}</h4>
     </div>
   </div>
-  <sub class="sr-only" id="goToApps{{::portlet.title}}">go to</sub>
+  <sub class="sr-only" id="goToApps-{{::portlet.nodeId}}">go to</sub>
   <!-- For widgets, show fancy markup! -->
   <div ng-if="'WIDGET' === widgetCtrl.portletType(portlet)">
     <div class="portlet-content">
@@ -49,7 +49,7 @@
     <div class="widget-icon-container">
       <portlet-icon></portlet-icon>
     </div>
-    <button aria-labelledby="goToApps{{::portlet.title}} appTitle{{::portlet.title}}" class="btn btn-default launch-app-button">Launch full app</button>
+    <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
   </a>
   
   <!-- For pithy content, display the pithy content -->
@@ -65,6 +65,6 @@
     <div class="widget-icon-container">
       <portlet-icon></portlet-icon>
     </div>
-    <button aria-labelledby="goToApps{{::portlet.title}} appTitle{{::portlet.title}}" class="btn btn-default launch-app-button">Launch full app</button>
+    <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
   </a>
 </div>


### PR DESCRIPTION
could recognize all containers title on widget page now.
also skip the icon for not repeat read the {{::portlet.title}} again.