### PR TITLE
Accessibility improvement - apps/details/  page

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -47,9 +47,8 @@
 			      <span class="fa fa-plus"></span> Add to home
 			    </button>
 
-		    <sub class="sr-only" id="goTo-portlet.title-{{::portlet.fname}}">go to this app</sub>
             <!-- Launch button with access -->
-		    <a aria-labelledby="goTo-portlet.title-{{::portlet.fname}}" class="btn btn-success" href="{{::portlet.maxUrl}}" target="{{::portlet.target}}" ng-if="portlet.canAdd"><span class="fa fa-arrow-circle-o-right"></span> Launch</a>
+		    <a aria-label="launch {{::portlet.title}}" class="btn btn-success" href="{{::portlet.maxUrl}}" target="{{::portlet.target}}" ng-if="portlet.canAdd"><span class="fa fa-arrow-circle-o-right"></span> Launch</a>
 
 		    <!-- Launch button without access -->
 		    <a class="btn btn-disabled" href ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -13,9 +13,9 @@
 
   <div class="row details-header no-margin" ng-if='!loading && !error'>
   	<div class="col-xs-12 col-lg-6">
-  		<h2 tabindex="0" aria-labelledby="portlet.title-{{::portlet.fname}}">
+  		<h2 tabindex="0">
 		    <portlet-icon></portlet-icon>
-		    <span id="portlet.title-{{::portlet.fname}}" class="portlet-title">{{::portlet.title}} Details</span>
+		    <span class="portlet-title">{{::portlet.title}} Details</span>
 		  </h2>
 		  <a href="apps" class="back-to-home"><i class="fa fa-arrow-circle-o-left"></i> Back to Search and Browse</a>
   	</div>
@@ -57,24 +57,24 @@
 	</div>
 	<div class="row no-margin"  ng-if='!loading && !error'>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item">
-			<h3 tabindex="0" aria-label="Description" class="center">Description</h3>
-			<p tabindex="0" id="portlet.title-{{::portlet.fname}}-Description" aria-describedby="portlet.title-{{::portlet.fname}}-Description" class="app-description">{{::portlet.description}}</p>
+			<h3 tabindex="0" class="center">Description</h3>
+			<p tabindex="0" class="app-description">{{::portlet.description}}</p>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center rating-div">
-			<h3 tabindex="0" aria-label="Rating">Ratings</h3>
+			<h3 tabindex="0">Ratings</h3>
 			<span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
     ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
   		</span><br>
   		<button ng-click="openRating('sm',portlet.fname, portlet.title)" class="btn btn-default rate-button">Rate</button>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center">
-			<h3 tabindex="0" aria-label="Related Apps">Related Apps</h3>
+			<h3 tabindex="0">Related Apps</h3>
       <ul>
         <li ng-repeat="related in portlet.relatedPortlets"><a href="apps/details/{{ ::related.fname }}">{{ ::related.title }}</a></li>
       </ul>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center">
-			<h3 tabindex="0" aria-label="Categories">Categories</h3>
+			<h3 tabindex="0">Categories</h3>
 			<a ng-repeat="category in portlet.categories" href="" ng-click="selectFilter('category',category)" class="category-links">{{::category}}</a>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center" ng-if="$storage.showKeywordsInMarketplace">

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -13,9 +13,9 @@
 
   <div class="row details-header no-margin" ng-if='!loading && !error'>
   	<div class="col-xs-12 col-lg-6">
-  		<h2>
+  		<h2 tabindex="0" aria-labelledby="portlet.title-{{::portlet.fname}}">
 		    <portlet-icon></portlet-icon>
-		    <span class="portlet-title">{{::portlet.title}} Details</span>
+		    <span id="portlet.title-{{::portlet.fname}}" class="portlet-title">{{::portlet.title}} Details</span>
 		  </h2>
 		  <a href="apps" class="back-to-home"><i class="fa fa-arrow-circle-o-left"></i> Back to Search and Browse</a>
   	</div>
@@ -47,8 +47,9 @@
 			      <span class="fa fa-plus"></span> Add to home
 			    </button>
 
-		    <!-- Launch button with access -->
-		    <a class="btn btn-success" href="{{::portlet.maxUrl}}" target="{{::portlet.target}}" ng-if="portlet.canAdd"><span class="fa fa-arrow-circle-o-right"></span> Launch</a>
+		    <sub class="sr-only" id="goTo-portlet.title-{{::portlet.fname}}">go to this app</sub>
+            <!-- Launch button with access -->
+		    <a aria-labelledby="goTo-portlet.title-{{::portlet.fname}}" class="btn btn-success" href="{{::portlet.maxUrl}}" target="{{::portlet.target}}" ng-if="portlet.canAdd"><span class="fa fa-arrow-circle-o-right"></span> Launch</a>
 
 		    <!-- Launch button without access -->
 		    <a class="btn btn-disabled" href ng-hide="portlet.canAdd" popover="You do not have access to this app" popover-trigger="mouseenter" popover-placement="top" popover-popup-delay="500"><span class="fa fa-arrow-circle-o-right"></span>Launch</a>
@@ -57,24 +58,24 @@
 	</div>
 	<div class="row no-margin"  ng-if='!loading && !error'>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item">
-			<h3 class="center">Description</h3>
-			<p class="app-description">{{::portlet.description}}</p>
+			<h3 tabindex="0" aria-label="Description" class="center">Description</h3>
+			<p tabindex="0" id="portlet.title-{{::portlet.fname}}-Description" aria-describedby="portlet.title-{{::portlet.fname}}-Description" class="app-description">{{::portlet.description}}</p>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center rating-div">
-			<h3>Ratings</h3>
+			<h3 tabindex="0" aria-label="Rating">Ratings</h3>
 			<span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
     ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
   		</span><br>
   		<button ng-click="openRating('sm',portlet.fname, portlet.title)" class="btn btn-default rate-button">Rate</button>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center">
-			<h3>Related Apps</h3>
+			<h3 tabindex="0" aria-label="Related Apps">Related Apps</h3>
       <ul>
         <li ng-repeat="related in portlet.relatedPortlets"><a href="apps/details/{{ ::related.fname }}">{{ ::related.title }}</a></li>
       </ul>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center">
-			<h3>Categories</h3>
+			<h3 tabindex="0" aria-label="Categories">Categories</h3>
 			<a ng-repeat="category in portlet.categories" href="" ng-click="selectFilter('category',category)" class="category-links">{{::category}}</a>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center" ng-if="$storage.showKeywordsInMarketplace">


### PR DESCRIPTION
Portlets' title able to get by TAB
the user will know which portlet it is before they "launch" it
make all of those four columns able to be read out in vertical order ( title -> content under the title)

