### PR TITLE
Misc Cleanup

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -98,13 +98,17 @@ define(['angular'], function(angular){
         };
       
         $scope.filteredArray = function (array, objectVar, strings) {
-          return array.filter(function (letter) {
-            for(var i = 0; i < strings.length ; i++) {
-              if(letter[objectVar].indexOf(strings[i]) != -1) {
-                return true;
+          if(array && objectVar && strings) {
+            return array.filter(function (letter) {
+              for(var i = 0; i < strings.length ; i++) {
+                if(letter[objectVar].indexOf(strings[i]) != -1) {
+                  return true;
+                }
               }
-            }
-          });
+            });
+          } else {
+            return [];
+          }
         };
 
         if($scope.portlet.widgetTemplate) {

--- a/angularjs-portal-mock-portal/src/main/webapp/WEB-INF/web.xml
+++ b/angularjs-portal-mock-portal/src/main/webapp/WEB-INF/web.xml
@@ -8,6 +8,9 @@
     xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_2_5.xsd"
     version="2.5">
   <display-name>Mock Portal ENV</display-name>
+  <error-page>
+    <location>/general-error.html</location>
+  </error-page>
 </web-app>
 
 

--- a/angularjs-portal-mock-portal/src/main/webapp/general-error.html
+++ b/angularjs-portal-mock-portal/src/main/webapp/general-error.html
@@ -1,0 +1,11 @@
+<html>
+  <head>
+    <title>Error : This page is mocking you</title>
+  </head>
+  <body bgcolor="#ffffff">
+    <div style='text-align: center; font-size: large;'>
+        <img src='/badger-animal.jpg' alt='Badger looking confused'  height='200px'><br/>
+        In the real deployment you would probably hit a portlet in a full screen. Since you are just running mock portal you are stuck reading this message. <a href='/web/'>Go Home</a>        
+    </div>
+  </body>
+</html>

--- a/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
@@ -1,5 +1,22 @@
 {
    "layout":[
+  {  
+         "nodeId":"n2926",
+         "title":"Directory",
+         "description":"Where you can find people or directories.",
+         "url":"http://www.wisc.edu/directories",
+         "iconUrl":null,
+         "faIcon":"fa-users",
+         "fname":"directory",
+         "target":"_blank",
+         "widgetURL":null,
+         "widgetType":"generic",
+         "widgetTemplate":"\n            <div class='widget-body'>\n         <form action='http://www.wisc.edu/directories' target='_blank'>\n            <div class='input-group'><input type='text' name='q' class='form-control' placeholder='Enter a name'><span class='input-group-btn'><button class='btn btn-primary' type='submit'><i class='fa fa-search'></i></button></span></div>\n         </form>\n         <div class='row'>\n            <div class='col-xs-5 col-xs-offset-1 icon-button-div'>\n               <div class='btn btn-primary rounded icon-button'><a href='http://www.wisc.edu/directories' target='_blank'><i class='fa fa-users'></i></a></div>\n               <p>Directory</p>\n            </div>\n            <div class='col-xs-5 icon-button-div'>\n               <div class='btn btn-primary rounded icon-button'><a href='https://apps.mbo.wisc.edu/ds/deptsearch.aspx' target='_blank'><i class='fa fa-sitemap'></i></a></div>\n               <p>Departmental Directory</p>\n            </div>\n         </div>\n      </div>\n      <a class='btn btn-default launch-app-button' href='{{::portlet.url}}' target='{{::portlet.target}}'>Goto Directory</a>\n        ",
+         "widgetConfig":null,
+         "staticContent":"\n            \n                Click <a href=\"http://www.wisc.edu/directories\">here</a> to access the campus directory.\n            \n        ",
+         "pithyStaticContent":null,
+         "altMaxUrl":true
+      },
       {
          "nodeId":"u23l1n28",
          "title":"Manager Time and Approval",


### PR DESCRIPTION
+ MUMMNG-1812 : Cleanup controller filter for widgets. There was a weird state of the filter (going to be used for time & absence portlet) where the service hasn't returned yet but we were trying to run the filter on an undefined object. It would vomit errors in the log. This checks for null first now. :)
+ MUMUP-2090 : Add generic error page in mock data with a redirect link to `/web`
+ EC : Add directory widget to `layoutDoc`