### PR TITLE
MUMMNG-1524: Adds metric units to weather widget - UPDATED

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -2,194 +2,189 @@
 
 define(['angular'], function(angular){
 
-	var app = angular.module('my-app.layout.widget.controllers', []);
+  var app = angular.module('my-app.layout.widget.controllers', []);
 
-	app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService){
+  app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService){
 
-		var configInit = function(){
-			if(!$scope.config) {
-				//setting up defaults since config doesn't exist
-				$scope.config = {
-						singleElement : false,
-						arrayName : 'array',
-						value : 'value',
-						display : 'display'
-				};
-			}
-		};
+    var configInit = function(){
+      if(!$scope.config) {
+        //setting up defaults since config doesn't exist
+        $scope.config = {
+            singleElement : false,
+            arrayName : 'array',
+            value : 'value',
+            display : 'display'
+        };
+      }
+    };
 
-		var populateWidgetContent = function() {
-			if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-				//fetch portlet widget json
-				$scope.portlet.widgetData = [];
+    var populateWidgetContent = function() {
+      if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+        //fetch portlet widget json
+        $scope.portlet.widgetData = [];
 
-				layoutService.getWidgetJson($scope.portlet).then(function(data) {
-					if(data) {
-						console.log(data);
-						//set init
-						if($scope.config.singleElement) {
-							//set the default selected url
-							$scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.value];
-						} else if($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
-							$scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
-						}
-					} else {
-						console.warn("Got nothing back from widget fetch for " + $scope.portlet.fname);
-					}
-				});
-			}
-		};
-		configInit();
-		populateWidgetContent();
-	}]);
+        layoutService.getWidgetJson($scope.portlet).then(function(data) {
+          if(data) {
+            console.log(data);
+            //set init
+            if($scope.config.singleElement) {
+              //set the default selected url
+              $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.value];
+            } else if($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
+              $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
+            }
+          } else {
+            console.warn("Got nothing back from widget fetch for " + $scope.portlet.fname);
+          }
+        });
+      }
+    };
+    configInit();
+    populateWidgetContent();
+  }]);
 
-	app.controller('WeatherController', ['$scope', 'layoutService', function($scope, layoutService){
-		$scope.weatherData = [];
-		$scope.loading = false;
-		$scope.showMetric = false;
-		$scope.tempInC1 = 0;
-		$scope.tempInC2 = 0;
-		$scope.celsiusForecasts = [];
-		$scope.dailyHigh = 0;
-		$scope.dailyLow = 0;
-		$scope.currentlyImperial = true;
-		var populateWidgetContent = function() {
-			if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-				$scope.loading = true;
-				//fetch portlet widget json
-				$scope.portlet.widgetData = [];
-				layoutService.getWidgetJson($scope.portlet).then(function(data) {
-					$scope.loading = false;
-					if(data) {
-						console.log(data);
-						$scope.portlet.widgetData = data.weathers;
-						$scope.weatherData = $scope.portlet.widgetData;
-					} else {
-						$scope.error = true;
-						console.warn("Got nothing back from widget fetch");
-					}
-				}, function(){
-					$scope.loading = false;
-					$scope.error = true;
-				});
-			}
-		};
-		$scope.changeToC = function(){
-			if ($scope.currentlyImperial){
-				for (var i = 0; i < $scope.weatherData.length; i++){
-					$scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature-32)*(5/9);
-					
-					for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
-						$scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature-32)*(5/9)
-						$scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature-32)*(5/9)
-					}
-				}
-				$scope.currentlyImperial = false;
-			}
-		};
-		$scope.changeToF = function(){
-			if (!$scope.currentlyImperial){
-				for (var i = 0; i < $scope.weatherData.length; i++){
-					$scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature)*(9/5) +32;
-					
-					for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
-						$scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature)*(9/5) + 32;
-						$scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature)*(9/5) + 32;
-					}
-				}
-				$scope.currentlyImperial = true;
-			}
-		}
-		console.log("Config: " + $scope.portlet.widgetConfig);
-		populateWidgetContent();
-		$scope.details=false;
-	}]);
+  app.controller('WeatherController', ['$scope', 'layoutService', function($scope, layoutService){
+    $scope.weatherData = [];
+    $scope.loading = false;
+    $scope.showMetric = false;
+    $scope.currentlyImperial = true;
+    var populateWidgetContent = function() {
+      if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+        $scope.loading = true;
+        //fetch portlet widget json
+        $scope.portlet.widgetData = [];
+        layoutService.getWidgetJson($scope.portlet).then(function(data) {
+          $scope.loading = false;
+          if(data) {
+            console.log(data);
+            $scope.portlet.widgetData = data.weathers;
+            $scope.weatherData = $scope.portlet.widgetData;
+          } else {
+            $scope.error = true;
+            console.warn("Got nothing back from widget fetch");
+          }
+        }, function(){
+          $scope.loading = false;
+          $scope.error = true;
+        });
+      }
+    };
+    $scope.changeToC = function(){
+      if ($scope.currentlyImperial){
+        for (var i = 0; i < $scope.weatherData.length; i++){
+          $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature-32)*(5/9);
 
-	app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService){
-		var populateWidgetContent = function() {
-			if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-				//fetch portlet widget json
-				layoutService.getWidgetJson($scope.portlet).then(function(data) {
-					if(data) {
-						console.log(data);
-						$scope.portlet.widgetData = data;
-						$scope.content = $scope.portlet.widgetData;
-						if(Array.isArray($scope.content) &&  $scope.content.length == 0) {
-							$scope.isEmpty = true;
-						} else if($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
-								&& eval($scope.portlet.widgetConfig.evalString)) {
-							//ideally this would do a check on an embedded object for emptiness
-							//example : '$scope.content.report.length === 0'
-							$scope.isEmpty = true;
-						}
-					} else {
-						console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
-						$scope.isEmpty = true;
-					}
-				});
-			}
-		};
-		$scope.filteredArray = function (array, objectVar, strings) {
-			return array.filter(function (letter) {
-				for(var i = 0; i < strings.length ; i++) {
-					if(letter[objectVar].indexOf(strings[i]) != -1) {
-						return true;
-					}
-				}
-			});
-		};
-		if($scope.portlet.widgetTemplate) {
-			$scope.content = [];
-			$scope.template =  $scope.portlet.widgetTemplate;
-			$scope.isEmpty = false;
-			$scope.portlet.widgetData = [];
-			console.log("Config for "+ $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
-			populateWidgetContent();
-		} else {
-			console.error($scope.portlet.fname + " said its a widget, but no template defined.");
-			$scope.isEmpty = true;
-		}
-	}]);
+          for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
+            $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature-32)*(5/9)
+            $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature-32)*(5/9)
+          }
+        }
+        $scope.currentlyImperial = false;
+      }
+    };
+    $scope.changeToF = function(){
+      if (!$scope.currentlyImperial){
+        for (var i = 0; i < $scope.weatherData.length; i++){
+          $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature)*(9/5) +32;
 
-	app.controller("RSSWidgetController", ['$scope', 'layoutService', function($scope, layoutService){
-		var init = function(){
-			$scope.loading = true;
-			if($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
-				if(!$scope.config) {
-					$scope.config = {};
-				}
+          for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
+            $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature)*(9/5) + 32;
+            $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature)*(9/5) + 32;
+          }
+        }
+        $scope.currentlyImperial = true;
+      }
+    }
+    console.log("Config: " + $scope.portlet.widgetConfig);
+    populateWidgetContent();
+    $scope.details=false;
+  }]);
 
-				if(!$scope.config.lim) {
-					$scope.config.lim = 5;
-				}
-				var successFn = function(result){
-					$scope.loading = false;
-					$scope.data = result.data;
-					if($scope.data.responseStatus != 200) {
-						$scope.error = true;
-					} else if(!$scope.data.responseData 
-							|| !$scope.data.responseData.feed 
-							|| $scope.data.responseData.feed.entries.length == 0) {
-						$scope.isEmpty = true;
-					}
-				};
-				var errorFn = function(data){
-					$scope.error = true;
-					$scope.isEmpty = true;
-					$scope.loading = false;
-				};
+  app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService){
+    var populateWidgetContent = function() {
+      if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+        //fetch portlet widget json
+        layoutService.getWidgetJson($scope.portlet).then(function(data) {
+          if(data) {
+            console.log(data);
+            $scope.portlet.widgetData = data;
+            $scope.content = $scope.portlet.widgetData;
+            if(Array.isArray($scope.content) &&  $scope.content.length == 0) {
+              $scope.isEmpty = true;
+            } else if($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
+                && eval($scope.portlet.widgetConfig.evalString)) {
+              //ideally this would do a check on an embedded object for emptiness
+              //example : '$scope.content.report.length === 0'
+              $scope.isEmpty = true;
+            }
+          } else {
+            console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
+            $scope.isEmpty = true;
+          }
+        });
+      }
+    };
+    $scope.filteredArray = function (array, objectVar, strings) {
+      return array.filter(function (letter) {
+        for(var i = 0; i < strings.length ; i++) {
+          if(letter[objectVar].indexOf(strings[i]) != -1) {
+            return true;
+          }
+        }
+      });
+    };
+    if($scope.portlet.widgetTemplate) {
+      $scope.content = [];
+      $scope.template =  $scope.portlet.widgetTemplate;
+      $scope.isEmpty = false;
+      $scope.portlet.widgetData = [];
+      console.log("Config for "+ $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
+      populateWidgetContent();
+    } else {
+      console.error($scope.portlet.fname + " said its a widget, but no template defined.");
+      $scope.isEmpty = true;
+    }
+  }]);
 
-				layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn,errorFn);
-			} else {
-				$scope.loading = false;
-				$scope.error = true;
-			}
-		}
+  app.controller("RSSWidgetController", ['$scope', 'layoutService', function($scope, layoutService){
+    var init = function(){
+      $scope.loading = true;
+      if($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
+        if(!$scope.config) {
+          $scope.config = {};
+        }
 
-		init();
+        if(!$scope.config.lim) {
+          $scope.config.lim = 5;
+        }
+        var successFn = function(result){
+          $scope.loading = false;
+          $scope.data = result.data;
+          if($scope.data.responseStatus != 200) {
+            $scope.error = true;
+          } else if(!$scope.data.responseData 
+              || !$scope.data.responseData.feed 
+              || $scope.data.responseData.feed.entries.length == 0) {
+            $scope.isEmpty = true;
+          }
+        };
+        var errorFn = function(data){
+          $scope.error = true;
+          $scope.isEmpty = true;
+          $scope.loading = false;
+        };
 
-	}]);
+        layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn,errorFn);
+      } else {
+        $scope.loading = false;
+        $scope.error = true;
+      }
+    }
 
-	return app;
+    init();
+
+  }]);
+
+  return app;
 
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -2,163 +2,194 @@
 
 define(['angular'], function(angular){
 
-    var app = angular.module('my-app.layout.widget.controllers', []);
+	var app = angular.module('my-app.layout.widget.controllers', []);
 
-    app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService){
+	app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService){
 
-        var configInit = function(){
-            if(!$scope.config) {
-                //setting up defaults since config doesn't exist
-                $scope.config = {
-                    singleElement : false,
-                    arrayName : 'array',
-                    value : 'value',
-                    display : 'display'
-                };
-            }
-        };
+		var configInit = function(){
+			if(!$scope.config) {
+				//setting up defaults since config doesn't exist
+				$scope.config = {
+						singleElement : false,
+						arrayName : 'array',
+						value : 'value',
+						display : 'display'
+				};
+			}
+		};
 
-        var populateWidgetContent = function() {
-            if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-                //fetch portlet widget json
-                $scope.portlet.widgetData = [];
+		var populateWidgetContent = function() {
+			if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+				//fetch portlet widget json
+				$scope.portlet.widgetData = [];
 
-                layoutService.getWidgetJson($scope.portlet).then(function(data) {
-                    if(data) {
-                        console.log(data);
-                        //set init
-                        if($scope.config.singleElement) {
-                            //set the default selected url
-                            $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.value];
-                        } else if($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
-                            $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
-                        }
-                    } else {
-                        console.warn("Got nothing back from widget fetch for " + $scope.portlet.fname);
-                    }
-                });
-            }
-        };
-        configInit();
-        populateWidgetContent();
-    }]);
+				layoutService.getWidgetJson($scope.portlet).then(function(data) {
+					if(data) {
+						console.log(data);
+						//set init
+						if($scope.config.singleElement) {
+							//set the default selected url
+							$scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.value];
+						} else if($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
+							$scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
+						}
+					} else {
+						console.warn("Got nothing back from widget fetch for " + $scope.portlet.fname);
+					}
+				});
+			}
+		};
+		configInit();
+		populateWidgetContent();
+	}]);
 
-    app.controller('WeatherController', ['$scope', 'layoutService', function($scope, layoutService){
-        $scope.weatherData = [];
-        $scope.loading = false;
-        var populateWidgetContent = function() {
-            if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-                $scope.loading = true;
-                //fetch portlet widget json
-                $scope.portlet.widgetData = [];
-                layoutService.getWidgetJson($scope.portlet).then(function(data) {
-                    $scope.loading = false;
-                    if(data) {
-                        console.log(data);
-                        $scope.portlet.widgetData = data.weathers;
-                        $scope.weatherData = $scope.portlet.widgetData;
-                    } else {
-                        $scope.error = true;
-                        console.warn("Got nothing back from widget fetch");
-                    }
-                }, function(){
-                    $scope.loading = false;
-                    $scope.error = true;
-                });
-            }
-        };
-        console.log("Config: " + $scope.portlet.widgetConfig);
-        populateWidgetContent();
-        $scope.details=false;
-    }]);
-    
-    app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService){
-        var populateWidgetContent = function() {
-            if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-                //fetch portlet widget json
-                layoutService.getWidgetJson($scope.portlet).then(function(data) {
-                    if(data) {
-                        console.log(data);
-                        $scope.portlet.widgetData = data;
-                        $scope.content = $scope.portlet.widgetData;
-                        if(Array.isArray($scope.content) &&  $scope.content.length == 0) {
-                            $scope.isEmpty = true;
-                        } else if($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
-                            && eval($scope.portlet.widgetConfig.evalString)) {
-                            //ideally this would do a check on an embedded object for emptiness
-                            //example : '$scope.content.report.length === 0'
-                            $scope.isEmpty = true;
-                        }
-                    } else {
-                        console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
-                        $scope.isEmpty = true;
-                    }
-                });
-            }
-        };
-      
-        $scope.filteredArray = function (array, objectVar, strings) {
-          return array.filter(function (letter) {
-            for(var i = 0; i < strings.length ; i++) {
-              if(letter[objectVar].indexOf(strings[i]) != -1) {
-                return true;
-              }
-            }
-          });
-        };
+	app.controller('WeatherController', ['$scope', 'layoutService', function($scope, layoutService){
+		$scope.weatherData = [];
+		$scope.loading = false;
+		$scope.showMetric = false;
+		$scope.tempInC1 = 0;
+		$scope.tempInC2 = 0;
+		$scope.celsiusForecasts = [];
+		$scope.dailyHigh = 0;
+		$scope.dailyLow = 0;
+		$scope.currentlyImperial = true;
+		var populateWidgetContent = function() {
+			if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+				$scope.loading = true;
+				//fetch portlet widget json
+				$scope.portlet.widgetData = [];
+				layoutService.getWidgetJson($scope.portlet).then(function(data) {
+					$scope.loading = false;
+					if(data) {
+						console.log(data);
+						$scope.portlet.widgetData = data.weathers;
+						$scope.weatherData = $scope.portlet.widgetData;
+					} else {
+						$scope.error = true;
+						console.warn("Got nothing back from widget fetch");
+					}
+				}, function(){
+					$scope.loading = false;
+					$scope.error = true;
+				});
+			}
+		};
+		$scope.changeToC = function(){
+			if ($scope.currentlyImperial){
+				for (var i = 0; i < $scope.weatherData.length; i++){
+					$scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature-32)*(5/9);
+					
+					for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
+						$scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature-32)*(5/9)
+						$scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature-32)*(5/9)
+					}
+				}
+				$scope.currentlyImperial = false;
+			}
+		};
+		$scope.changeToF = function(){
+			if (!$scope.currentlyImperial){
+				for (var i = 0; i < $scope.weatherData.length; i++){
+					$scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature)*(9/5) +32;
+					
+					for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
+						$scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature)*(9/5) + 32;
+						$scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature)*(9/5) + 32;
+					}
+				}
+				$scope.currentlyImperial = true;
+			}
+		}
+		console.log("Config: " + $scope.portlet.widgetConfig);
+		populateWidgetContent();
+		$scope.details=false;
+	}]);
 
-        if($scope.portlet.widgetTemplate) {
-            $scope.content = [];
-            $scope.template =  $scope.portlet.widgetTemplate;
-            $scope.isEmpty = false;
-            $scope.portlet.widgetData = [];
-            console.log("Config for "+ $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
-            populateWidgetContent();
-        } else {
-            console.error($scope.portlet.fname + " said its a widget, but no template defined.");
-            $scope.isEmpty = true;
-        }
-    }]);
-    
-    app.controller("RSSWidgetController", ['$scope', 'layoutService', function($scope, layoutService){
-      var init = function(){
-        $scope.loading = true;
-        if($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
-          if(!$scope.config) {
-            $scope.config = {};
-          }
-          
-          if(!$scope.config.lim) {
-            $scope.config.lim = 5;
-          }
-          var successFn = function(result){
-            $scope.loading = false;
-            $scope.data = result.data;
-            if($scope.data.responseStatus != 200) {
-              $scope.error = true;
-            } else if(!$scope.data.responseData 
-              || !$scope.data.responseData.feed 
-              || $scope.data.responseData.feed.entries.length == 0) {
-              $scope.isEmpty = true;
-            }
-          };
-          var errorFn = function(data){
-            $scope.error = true;
-            $scope.isEmpty = true;
-            $scope.loading = false;
-          };
-          
-          layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn,errorFn);
-        } else {
-          $scope.loading = false;
-          $scope.error = true;
-        }
-      }
-      
-      init();
-      
-    }]);
+	app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService){
+		var populateWidgetContent = function() {
+			if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+				//fetch portlet widget json
+				layoutService.getWidgetJson($scope.portlet).then(function(data) {
+					if(data) {
+						console.log(data);
+						$scope.portlet.widgetData = data;
+						$scope.content = $scope.portlet.widgetData;
+						if(Array.isArray($scope.content) &&  $scope.content.length == 0) {
+							$scope.isEmpty = true;
+						} else if($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
+								&& eval($scope.portlet.widgetConfig.evalString)) {
+							//ideally this would do a check on an embedded object for emptiness
+							//example : '$scope.content.report.length === 0'
+							$scope.isEmpty = true;
+						}
+					} else {
+						console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
+						$scope.isEmpty = true;
+					}
+				});
+			}
+		};
+		$scope.filteredArray = function (array, objectVar, strings) {
+			return array.filter(function (letter) {
+				for(var i = 0; i < strings.length ; i++) {
+					if(letter[objectVar].indexOf(strings[i]) != -1) {
+						return true;
+					}
+				}
+			});
+		};
+		if($scope.portlet.widgetTemplate) {
+			$scope.content = [];
+			$scope.template =  $scope.portlet.widgetTemplate;
+			$scope.isEmpty = false;
+			$scope.portlet.widgetData = [];
+			console.log("Config for "+ $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
+			populateWidgetContent();
+		} else {
+			console.error($scope.portlet.fname + " said its a widget, but no template defined.");
+			$scope.isEmpty = true;
+		}
+	}]);
 
-    return app;
+	app.controller("RSSWidgetController", ['$scope', 'layoutService', function($scope, layoutService){
+		var init = function(){
+			$scope.loading = true;
+			if($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
+				if(!$scope.config) {
+					$scope.config = {};
+				}
+
+				if(!$scope.config.lim) {
+					$scope.config.lim = 5;
+				}
+				var successFn = function(result){
+					$scope.loading = false;
+					$scope.data = result.data;
+					if($scope.data.responseStatus != 200) {
+						$scope.error = true;
+					} else if(!$scope.data.responseData 
+							|| !$scope.data.responseData.feed 
+							|| $scope.data.responseData.feed.entries.length == 0) {
+						$scope.isEmpty = true;
+					}
+				};
+				var errorFn = function(data){
+					$scope.error = true;
+					$scope.isEmpty = true;
+					$scope.loading = false;
+				};
+
+				layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn,errorFn);
+			} else {
+				$scope.loading = false;
+				$scope.error = true;
+			}
+		}
+
+		init();
+
+	}]);
+
+	return app;
 
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -1,13 +1,5 @@
 
-<!--     <div class="weather-dropdown" dropdown is-open="status.isopen"> -->
-<!--       <button id="single-button" type="button" class="btn btn-primary rounded" dropdown-toggle ng-disabled="disabled"> -->
-<!--        <i class="fa fa-wrench "></i> -->
-<!--       </button> -->
-<!--       <ul class="dropdown-menu" role="menu" aria-labelledby="single-button"> -->
-<!--         <li role="menuitem"><a href="" ng-click="showMetric=false; changeToF()">Fahrenheit</a></li> -->
-<!--         <li role="menuitem"><a href="" ng-click="showMetric=true; changeToC()">Celsius</a></li> -->
-<!--       </ul> -->
-<!--     </div> -->
+
 <div class="weather-dropdown">
   <button class="weather-not-clicked btn btn-default btn-xs active" ng-show="showMetric" href=""
     ng-click="showMetric=false; changeToF()">&degF</button> 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -1,3 +1,14 @@
+
+    <div class="weather-dropdown" dropdown is-open="status.isopen">
+      <button id="single-button" type="button" class="btn btn-primary rounded" dropdown-toggle ng-disabled="disabled">
+       <i class="fa fa-wrench "></i>
+      </button>
+      <ul class="dropdown-menu" role="menu" aria-labelledby="single-button">
+        <li role="menuitem"><a href="" ng-click="showMetric=false; changeToF()">Imperial</a></li>
+        <li role="menuitem"><a href="" ng-click="showMetric=true; changeToC()">Metric</a></li>
+      </ul>
+    </div>
+
 <div>
 
     <div ng-if="weatherData && weatherData.length == 0 && !loading && !error">
@@ -26,13 +37,16 @@
                         <div class="col-xs-3 day">
                           <p>Now</p>
                           <img ng-src="{{config.iconPrefix}}{{weather.currentWeather.imgName}}{{config.iconPostfix}}" title="{{weather.currentWeather.condition}}" alt="{{weather.currentWeather.condition}}">
-                          <p>{{weather.currentWeather.temperature}}&deg; {{weather.temperatureUnit}}</p>
+                          <p ng-show="!showMetric" >{{weather.currentWeather.temperature | number:0}}&deg; {{weather.temperatureUnit}}</p>
+                          <p ng-show="showMetric">{{weather.currentWeather.temperature | number:0}}&deg; C</p>
+                          
+                                                   
                         </div>
                         <div class='col-xs-3 day' ng-repeat="forecast in weather.forecast">
                             <p>{{forecast.day}}</p>
                             <img ng-src="{{config.iconPrefix}}{{forecast.imgName}}{{config.iconPostfix}}" title="{{forecast.condition}}" alt="{{forecast.condition}}">
-                            <p>H: {{forecast.highTemperature}}&deg;</p>
-                            <p>L: {{forecast.lowTemperature}}&deg;</p>
+                            <p >H: {{forecast.highTemperature | number: 0}}&deg;</p>
+                            <p >L: {{forecast.lowTemperature | number: 0}}&deg;</p>
                         </div>
                     </div>
                 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/weather.html
@@ -1,61 +1,88 @@
 
-    <div class="weather-dropdown" dropdown is-open="status.isopen">
-      <button id="single-button" type="button" class="btn btn-primary rounded" dropdown-toggle ng-disabled="disabled">
-       <i class="fa fa-wrench "></i>
-      </button>
-      <ul class="dropdown-menu" role="menu" aria-labelledby="single-button">
-        <li role="menuitem"><a href="" ng-click="showMetric=false; changeToF()">Imperial</a></li>
-        <li role="menuitem"><a href="" ng-click="showMetric=true; changeToC()">Metric</a></li>
-      </ul>
-    </div>
+<!--     <div class="weather-dropdown" dropdown is-open="status.isopen"> -->
+<!--       <button id="single-button" type="button" class="btn btn-primary rounded" dropdown-toggle ng-disabled="disabled"> -->
+<!--        <i class="fa fa-wrench "></i> -->
+<!--       </button> -->
+<!--       <ul class="dropdown-menu" role="menu" aria-labelledby="single-button"> -->
+<!--         <li role="menuitem"><a href="" ng-click="showMetric=false; changeToF()">Fahrenheit</a></li> -->
+<!--         <li role="menuitem"><a href="" ng-click="showMetric=true; changeToC()">Celsius</a></li> -->
+<!--       </ul> -->
+<!--     </div> -->
+<div class="weather-dropdown">
+  <button class="weather-not-clicked btn btn-default btn-xs active" ng-show="showMetric" href=""
+    ng-click="showMetric=false; changeToF()">&degF</button> 
+  <button class=" btn btn-default btn-xs weather-clicked" ng-show="!showMetric" href="">&degF</button>
+  <button class="btn btn-default btn-xs weather-not-clicked" ng-show="!showMetric" href=""
+    ng-click="showMetric=true; changeToC()">&degC</button>
+  <button class=" btn btn-default btn-xs weather-clicked" ng-show="showMetric" href="">&degC</button>
+</div>
 
 <div>
+  <div
+    ng-if="weatherData && weatherData.length == 0 && !loading && !error">
+    <div>
+      <i class="fa fa-exclamation-triangle" aria-label='Warning'></i>
+      <div class="warning-message-weather-widget">Hold up! You
+        haven't set any weather locations yet. Launch the full app to
+        select your weather locations.</div>
+    </div>
+  </div>
 
-    <div ng-if="weatherData && weatherData.length == 0 && !loading && !error">
+  <div ng-if="loading" id="loading">
+    <loading-gif data-object='weatherData'></loading-gif>
+  </div>
+
+  <div ng-if="error">
+    <p class='error-message-weather-widget'>
+      <i class="fa fa-frown-o" aria-label="Error"></i><br />Oops! The
+      weather service seems to be down. <a
+        href="http://www.ssec.wisc.edu/localweather/" target="_blank">Try
+        clicking here for Madison weather.</a>
+    </p>
+  </div>
+
+  <ul class="widget-list">
+    <li ng-repeat="weather in weatherData | limitTo:2"><a
+      href="{{weather.moreInformationLink}}" target='_blank'>
+        <p class="bold">{{weather.location.city}},
+          {{weather.location.stateOrCountry}}</p>
         <div>
-            <i class="fa fa-exclamation-triangle" aria-label='Warning'></i>
-            <div class="warning-message-weather-widget">Hold up! You haven't set any weather locations yet. Launch the full app to select your weather locations.</div>
-        </div>
-    </div>
-    
-    <div ng-if="loading" id="loading">
-       <loading-gif data-object='weatherData'></loading-gif>
-   </div>
+          <div class="forecast">
+            <div class='row'>
+              <div class="col-xs-3 day">
+                <p>Now</p>
+                <img
+                  ng-src="{{config.iconPrefix}}{{weather.currentWeather.imgName}}{{config.iconPostfix}}"
+                  title="{{weather.currentWeather.condition}}"
+                  alt="{{weather.currentWeather.condition}}">
+                <p ng-show="!showMetric">{{weather.currentWeather.temperature
+                  | number:0}}&deg; {{weather.temperatureUnit}}</p>
+                <p ng-show="showMetric">{{weather.currentWeather.temperature
+                  | number:0}}&deg; C</p>
 
-    <div ng-if="error">
-        <p class='error-message-weather-widget'><i class="fa fa-frown-o" aria-label="Error"></i><br/>Oops! The weather service seems to be down. <a href="http://www.ssec.wisc.edu/localweather/" target="_blank">Try clicking here for Madison weather.</a></p>
-    </div>
-    
-    <ul class="widget-list">
-        <li ng-repeat="weather in weatherData | limitTo:2">
-          <a href="{{weather.moreInformationLink}}" target='_blank'>
-            <p class="bold">{{weather.location.city}}, {{weather.location.stateOrCountry}}
-            </p>
-            <div>
-                <div class="forecast">
-                    <div class='row'>
-                        <div class="col-xs-3 day">
-                          <p>Now</p>
-                          <img ng-src="{{config.iconPrefix}}{{weather.currentWeather.imgName}}{{config.iconPostfix}}" title="{{weather.currentWeather.condition}}" alt="{{weather.currentWeather.condition}}">
-                          <p ng-show="!showMetric" >{{weather.currentWeather.temperature | number:0}}&deg; {{weather.temperatureUnit}}</p>
-                          <p ng-show="showMetric">{{weather.currentWeather.temperature | number:0}}&deg; C</p>
-                          
-                                                   
-                        </div>
-                        <div class='col-xs-3 day' ng-repeat="forecast in weather.forecast">
-                            <p>{{forecast.day}}</p>
-                            <img ng-src="{{config.iconPrefix}}{{forecast.imgName}}{{config.iconPostfix}}" title="{{forecast.condition}}" alt="{{forecast.condition}}">
-                            <p >H: {{forecast.highTemperature | number: 0}}&deg;</p>
-                            <p >L: {{forecast.lowTemperature | number: 0}}&deg;</p>
-                        </div>
-                    </div>
-                </div>
+
+              </div>
+              <div class='col-xs-3 day'
+                ng-repeat="forecast in weather.forecast">
+                <p>{{forecast.day}}</p>
+                <img
+                  ng-src="{{config.iconPrefix}}{{forecast.imgName}}{{config.iconPostfix}}"
+                  title="{{forecast.condition}}"
+                  alt="{{forecast.condition}}">
+                <p>H: {{forecast.highTemperature | number: 0}}&deg;</p>
+                <p>L: {{forecast.lowTemperature | number: 0}}&deg;</p>
+              </div>
             </div>
-          </a>
-        </li>
-    </ul>
+          </div>
+        </div>
+    </a></li>
+  </ul>
 
-    
-    <p class="credit">Weather provided by <a href="http://www.worldweatheronline.com/" target='_blank'>World Weather Online</a></p>
+
+  <p class="credit">
+    Weather provided by <a href="http://www.worldweatheronline.com/"
+      target='_blank'>World Weather Online</a>
+  </p>
 </div>
-<a class="btn btn-default launch-app-button" href="{{::portlet.url}}" aria-label="go to Weather">Launch full app</a>
+<a class="btn btn-default launch-app-button" href="{{::portlet.url}}"
+  aria-label="go to Weather">Launch full app</a>

--- a/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
@@ -1,5 +1,26 @@
 {
    "layout":[
+   
+      {
+		   "nodeId":"n777",
+		   "title":"Weather",
+		   "description":"Access the latest weather conditions and 5-day forecasts for the cities you select.",
+		   "url":"/web/samples/weather.json",
+		   "iconUrl":null,
+		   "faIcon":"fa-sun-o",
+		   "fname":"weather",
+		   "target":null,
+		   "widgetURL":"/web/samples/weather-multiple.json",
+		   "widgetType":"weather",
+		   "widgetTemplate":null,
+		   "widgetConfig":{
+		      "iconPrefix":"/WeatherPortlet/images/accuweather/",
+		      "iconPostfix":".png"
+		   },
+		   "staticContent":null,
+		   "pithyStaticContent":null,
+		   "altMaxUrl":false
+		},
       {
          "nodeId":"u23l1n28",
          "title":"Manager Time and Approval",


### PR DESCRIPTION
I think I broke the old pull request for this, so I created another one.

Continuation from https://github.com/UW-Madison-DoIT/angularjs-portal/pull/316

Added a dropdown button that, when clicked, gives the user the choice for weather in imperial units or metric units. 

The code I added is in the weather widget controller (between lines 46-106 of controllers.js). The functions on lines 77 and 90 are called when the user clicks an item on the dropdown menu, and that does the calculations from Fahrenheit to Celsius, and from Celsius to Fahrenheit.


Temperature in degrees Fahrenheit
![weather widget](https://cloud.githubusercontent.com/assets/7268126/9614688/dddba394-50b8-11e5-8ce4-a908a23b28e0.png)

Dropdown button is clicked.
![weather widget2](https://cloud.githubusercontent.com/assets/7268126/9614764/68022804-50b9-11e5-9c2f-77adc417241f.png)

Temperature is now in degrees Celsius
![weather widget3](https://cloud.githubusercontent.com/assets/7268126/9614767/6d016784-50b9-11e5-9164-deb882391911.png)

The reason the images are not showing is because I was running this locally on the angular-mock portal, and I think that's also why the temperature is getting cut off at the bottom.


**UPDATED SCREENSHOTS:**


User now has the ability to toggle between Celsius and Fahrenheit
![updated weather widget](https://cloud.githubusercontent.com/assets/7268126/9668503/7e182fe6-5247-11e5-8ee5-bb10411d6c03.png)

Button fades out if the user tries to click Celsius when they're already viewing the temperature in Celsius.
![updated weather widget 2](https://cloud.githubusercontent.com/assets/7268126/9668505/8222562a-5247-11e5-82f1-84507227c247.png)

