### PR TITLE
MUMMNG-1667: Fix font on Help page from Font Awesome to Helvetica

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/uw-portlet.less
+++ b/angularjs-portal-home/src/main/webapp/css/uw-portlet.less
@@ -7,6 +7,7 @@
     margin:0px;
     text-rendering: auto;
     display: inline-block;
+    font: normal normal normal 14px/1 Helvetica;
     li {
       font-size:18px;
       padding:7px 0px;

--- a/angularjs-portal-home/src/main/webapp/css/uw-portlet.less
+++ b/angularjs-portal-home/src/main/webapp/css/uw-portlet.less
@@ -7,7 +7,6 @@
     margin:0px;
     text-rendering: auto;
     display: inline-block;
-    font: normal normal normal 14px/1 FontAwesome;
     li {
       font-size:18px;
       padding:7px 0px;


### PR DESCRIPTION
Good catch @keirserrie. Removed font style so the Help page takes Helvetica, not FontAwesome.