### PR TITLE
MUMUP-2155 : Friendly zero search results

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -356,6 +356,9 @@ input:focus,span:focus {
     }
   }
 }
+.no-results {
+  padding:10px 15px;
+}
 .marketplace-load-more {
   text-align:center;
   padding:20px;

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -47,7 +47,8 @@ define(['angular'], function(angular) {
         .constant('MISC_URLS',{
             'feedbackURL' : '/portal/p/feedback',
             'back2ClassicURL' : '/portal/Login?profile=default',
-            'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181'
+            'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
+            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/'
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -49,7 +49,8 @@ define(['angular'], function(angular) {
             'back2ClassicURL' : '/portal/Login?profile=default',
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
             'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
-            'webSearchURL' : 'http://www.wisc.edu/search/?q='
+            'webSearchURL' : 'http://www.wisc.edu/search/?q=',
+            'directorySearchURL' : 'http://www.wisc.edu/directories/?q='
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -50,6 +50,7 @@ define(['angular'], function(angular) {
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
             'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
             'webSearchURL' : 'http://www.wisc.edu/search/?q=',
+            'webSearchDomain' : "wisc.edu",
             'directorySearchURL' : 'http://www.wisc.edu/directories/?q=',
             'kbSearchURL' : 'https://kb.wisc.edu/search.php?q='
         })

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -48,7 +48,8 @@ define(['angular'], function(angular) {
             'feedbackURL' : '/portal/p/feedback',
             'back2ClassicURL' : '/portal/Login?profile=default',
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
-            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/'
+            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
+            'webSearchURL' : 'http://www.wisc.edu/search/?q='
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -50,7 +50,8 @@ define(['angular'], function(angular) {
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
             'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
             'webSearchURL' : 'http://www.wisc.edu/search/?q=',
-            'directorySearchURL' : 'http://www.wisc.edu/directories/?q='
+            'directorySearchURL' : 'http://www.wisc.edu/directories/?q=',
+            'kbSearchURL' : 'https://kb.wisc.edu/search.php?q='
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -43,7 +43,8 @@ define(['angular'], function(angular) {
             'whatsNewURL' : null,
             'helpdeskURL' : null,
             'webSearchURL' : null,
-            'directorySearchURL' : null
+            'directorySearchURL' : null,
+            'kbSearchURL' : null
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -41,7 +41,8 @@ define(['angular'], function(angular) {
             'feedbackURL' : '/uPortal/p/feedback',
             'back2ClassicURL' : null,
             'whatsNewURL' : null,
-            'helpdeskURL' : null
+            'helpdeskURL' : null,
+            'webSearchURL' : null
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -42,7 +42,8 @@ define(['angular'], function(angular) {
             'back2ClassicURL' : null,
             'whatsNewURL' : null,
             'helpdeskURL' : null,
-            'webSearchURL' : null
+            'webSearchURL' : null,
+            'directorySearchURL' : null
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -43,6 +43,7 @@ define(['angular'], function(angular) {
             'whatsNewURL' : null,
             'helpdeskURL' : null,
             'webSearchURL' : null,
+            'webSearchDomain' = null,
             'directorySearchURL' : null,
             'kbSearchURL' : null
         })

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -40,7 +40,8 @@ define(['angular'], function(angular) {
         .constant('MISC_URLS',{
             'feedbackURL' : '/uPortal/p/feedback',
             'back2ClassicURL' : null,
-            'whatsNewURL' : null
+            'whatsNewURL' : null,
+            'helpdeskURL' : null
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -123,6 +123,7 @@ define(['angular', 'jquery'], function(angular, $) {
                 $scope.showAll = !$scope.showAll;
             };
             
+            $scope.webSearchUrl = MISC_URLS.webSearchURL;
             $scope.feedbackUrl = MISC_URLS.feedbackURL;
             $scope.helpdeskUrl = MISC_URLS.helpdeskURL;
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -122,6 +122,8 @@ define(['angular', 'jquery'], function(angular, $) {
             $scope.toggleShowAll = function() {
                 $scope.showAll = !$scope.showAll;
             };
+            
+            $scope.feedbackUrl = MISC_URLS.feedbackURL;
 
             var initFilter = false;
             //delay on the filter

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -124,6 +124,8 @@ define(['angular', 'jquery'], function(angular, $) {
             };
             
             $scope.webSearchUrl = MISC_URLS.webSearchURL;
+            $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
+
             $scope.feedbackUrl = MISC_URLS.feedbackURL;
             $scope.helpdeskUrl = MISC_URLS.helpdeskURL;
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -124,6 +124,7 @@ define(['angular', 'jquery'], function(angular, $) {
             };
             
             $scope.webSearchUrl = MISC_URLS.webSearchURL;
+            $scope.webSearchDomain = MISC_URLS.webSearchDomain;
             $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
             $scope.kbSearchUrl = MISC_URLS.kbSearchURL;
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -7,10 +7,10 @@ define(['angular', 'jquery'], function(angular, $) {
     app.controller('MarketplaceController', [
         '$sessionStorage', '$modal', '$timeout', '$rootScope', '$window',
         '$http', '$scope', '$location', '$routeParams', 'marketplaceService',
-        'layoutService','miscService', 'mainService',
+        'layoutService','miscService', 'mainService', 'MISC_URLS',
         function($sessionStorage, $modal, $timeout, $rootScope, $window,
                  $http, $scope, $location, $routeParams, marketplaceService,
-                 layoutService, miscService, mainService) {
+                 layoutService, miscService, mainService, MISC_URLS) {
 
             //init variables
             var store = this;

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -124,6 +124,7 @@ define(['angular', 'jquery'], function(angular, $) {
             };
             
             $scope.feedbackUrl = MISC_URLS.feedbackURL;
+            $scope.helpdeskUrl = MISC_URLS.helpdeskURL;
 
             var initFilter = false;
             //delay on the filter

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -125,6 +125,7 @@ define(['angular', 'jquery'], function(angular, $) {
             
             $scope.webSearchUrl = MISC_URLS.webSearchURL;
             $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
+            $scope.kbSearchUrl = MISC_URLS.kbSearchURL;
 
             $scope.feedbackUrl = MISC_URLS.feedbackURL;
             $scope.helpdeskUrl = MISC_URLS.helpdeskURL;

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -37,6 +37,23 @@
     ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0" 
     class="no-results">
     <p>No matching MyUW content.</p>
+    <p>Maybe try:</p>
+    <ul>
+      <li>
+        <a href="http://www.wisc.edu/directories/"
+           target="_blank">Search the directory</a> (of people and offices) instead.</li>
+      <li>
+        <a href="http://www.wisc.edu/search/"
+           target="_blank">Search the wisc.edu domain on the Web</a> instead.</li>
+      <li>
+        <a href="https://kb.wisc.edu/"
+           target="_blank">Search the KnowledgeBase</a> instead.</li>
+      <li>
+        <a href="https://kb.wisc.edu/helpdesk/"
+           target="_blank">Ask the Helpdesk</a> for help.</li>
+      <li>
+        <a href="/portal/p/feedback">Give feedback</a> about search.</li>
+    </ul>
   </div>
   
   <rating-modal-template></rating-modal-template>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -50,8 +50,8 @@
       <li ng-if="webSearchUrl">
         <a ng-href="{{webSearchUrl}}{{searchText}}"
            target="_blank">Search the wisc.edu domain on the Web</a> instead.</li>
-      <li>
-        <a ng-href="https://kb.wisc.edu/search.php?q={{searchText}}"
+      <li ng-if="kbSearchUrl">
+        <a ng-href="{{kbSearchUrl}}{{searchText}}"
            target="_blank">Search the KnowledgeBase</a> instead.</li>
       <li ng-if="helpdeskUrl">
         <a ng-href="{{helpdeskUrl}}"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -45,7 +45,7 @@
         ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
          <a href="#" ng-click="toggleShowAll()">Show matching MyUW content even though it is not launchable</a>.</li>
       <li>
-        <a href="http://www.wisc.edu/directories/"
+        <a ng-href="http://www.wisc.edu/directories/?q={{searchText}}"
            target="_blank">Search the directory</a> (of people and offices) instead.</li>
       <li>
         <a href="http://www.wisc.edu/search/"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -53,8 +53,8 @@
       <li>
         <a ng-href="https://kb.wisc.edu/search.php?q={{searchText}}"
            target="_blank">Search the KnowledgeBase</a> instead.</li>
-      <li>
-        <a href="https://kb.wisc.edu/helpdesk/"
+      <li ng-if="helpdeskUrl">
+        <a ng-href="{{helpdeskUrl}}"
            target="_blank">Ask the Helpdesk</a> for help.</li>
       <li ng-if="feedbackUrl">
         <a ng-href="{{feedbackUrl}}">Give feedback</a> about search.</li>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -44,8 +44,8 @@
       <li 
         ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
          <a href="#" ng-click="toggleShowAll()">Show matching MyUW content even though it is not launchable</a>.</li>
-      <li>
-        <a ng-href="http://www.wisc.edu/directories/?q={{searchText}}"
+      <li ng-if="directorySearchUrl">
+        <a ng-href="{{directorySearchUrl}}{{searchText}}"
            target="_blank">Search the directory</a> (of people and offices) instead.</li>
       <li ng-if="webSearchUrl">
         <a ng-href="{{webSearchUrl}}{{searchText}}"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -47,8 +47,8 @@
       <li>
         <a ng-href="http://www.wisc.edu/directories/?q={{searchText}}"
            target="_blank">Search the directory</a> (of people and offices) instead.</li>
-      <li>
-        <a ng-href="http://www.wisc.edu/search/?q={{searchText}}"
+      <li ng-if="webSearchUrl">
+        <a ng-href="{{webSearchUrl}}{{searchText}}"
            target="_blank">Search the wisc.edu domain on the Web</a> instead.</li>
       <li>
         <a ng-href="https://kb.wisc.edu/search.php?q={{searchText}}"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -39,6 +39,9 @@
     <p>No matching MyUW content.</p>
     <p>Maybe try:</p>
     <ul>
+      <li 
+        ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
+        Some MyUW content that you are not permitted to launch matches your search query. Click the &quot;Show all&quot; checkbox to show these results.</li>
       <li>
         <a href="http://www.wisc.edu/directories/"
            target="_blank">Search the directory</a> (of people and offices) instead.</li>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -51,7 +51,7 @@
         <a ng-href="http://www.wisc.edu/search/?q={{searchText}}"
            target="_blank">Search the wisc.edu domain on the Web</a> instead.</li>
       <li>
-        <a href="https://kb.wisc.edu/"
+        <a ng-href="https://kb.wisc.edu/search.php?q={{searchText}}"
            target="_blank">Search the KnowledgeBase</a> instead.</li>
       <li>
         <a href="https://kb.wisc.edu/helpdesk/"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -15,7 +15,7 @@
   </div>
   <div class="show-all-div">
     <p>Showing {{ (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length }} of {{ portlets.length }} results in {{NAMES.title}}.</p>
-    <div><p><input type="checkbox" ng-click="toggleShowAll()">Show all<span popover="Show all apps, even if I don't have access" popover-append-to-body="true" popover-placement="left" popover-trigger="mouseenter"><i class="fa fa-question-circle" ></i></span></p></input></div>
+    <div><p><input type="checkbox" ng-click="toggleShowAll()" ng-checked="showAll">Show all<span popover="Show all apps, even if I don't have access" popover-append-to-body="true" popover-placement="left" popover-trigger="mouseenter"><i class="fa fa-question-circle" ></i></span></p></input></div>
   </div>
   <div ng-show="showCategories" class="show-categories">
     <p>Categories:</p><a ng-repeat="category in categories" href="" class="category-links" ng-click="selectFilter('category',category)" ng-class="{true: 'selected-category'}[categoryToShow === category]">{{category}}</a>
@@ -41,7 +41,7 @@
     <ul>
       <li 
         ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
-        Some MyUW content that you are not permitted to launch matches your search query. Click the &quot;Show all&quot; checkbox to show these results.</li>
+         <a href="#" ng-click="toggleShowAll()">Show matching MyUW content even though it is not launchable</a>.</li>
       <li>
         <a href="http://www.wisc.edu/directories/"
            target="_blank">Search the directory</a> (of people and offices) instead.</li>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -48,7 +48,7 @@
         <a ng-href="http://www.wisc.edu/directories/?q={{searchText}}"
            target="_blank">Search the directory</a> (of people and offices) instead.</li>
       <li>
-        <a href="http://www.wisc.edu/search/"
+        <a ng-href="http://www.wisc.edu/search/?q={{searchText}}"
            target="_blank">Search the wisc.edu domain on the Web</a> instead.</li>
       <li>
         <a href="https://kb.wisc.edu/"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -39,6 +39,8 @@
     <p>No matching MyUW content.</p>
     <p>Maybe try:</p>
     <ul>
+      <li ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll).length > 0">
+        <a href="#" ng-click="selectFilter('az','')">Show matching content beyond the &quot;{{categoryToShow}}&quot; category</a>.</li>
       <li 
         ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
          <a href="#" ng-click="toggleShowAll()">Show matching MyUW content even though it is not launchable</a>.</li>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -32,5 +32,12 @@
             ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length > searchResultLimit"
            >Load More</button>
   </div>
+  
+  <div 
+    ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0" 
+    class="no-results">
+    <p>No matching MyUW content.</p>
+  </div>
+  
   <rating-modal-template></rating-modal-template>
 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -49,7 +49,7 @@
            target="_blank">Search the directory</a> (of people and offices) instead.</li>
       <li ng-if="webSearchUrl">
         <a ng-href="{{webSearchUrl}}{{searchText}}"
-           target="_blank">Search the wisc.edu domain on the Web</a> instead.</li>
+           target="_blank">Search <span ng-if="webSearchDomain">the {{webSearchDomain}} domain on</span> the Web</a> instead.</li>
       <li ng-if="kbSearchUrl">
         <a ng-href="{{kbSearchUrl}}{{searchText}}"
            target="_blank">Search the KnowledgeBase</a> instead.</li>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -56,8 +56,8 @@
       <li>
         <a href="https://kb.wisc.edu/helpdesk/"
            target="_blank">Ask the Helpdesk</a> for help.</li>
-      <li>
-        <a href="/portal/p/feedback">Give feedback</a> about search.</li>
+      <li ng-if="feedbackUrl">
+        <a ng-href="{{feedbackUrl}}">Give feedback</a> about search.</li>
     </ul>
   </div>
   

--- a/angularjs-portal-mock-portal/src/main/webapp/web/marketplace/entries.json
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/marketplace/entries.json
@@ -12189,7 +12189,7 @@
         "type" : "Portlet",
         "userRated" : 0
       },
-      { "canAdd" : true,
+      { "canAdd" : false,
         "categories" : [  ],
         "description" : "Bucky theme instance of configuration and script rendering for Google Analytics.",
         "faIcon" : "fa-bar-chart",
@@ -14243,7 +14243,7 @@
         "type" : "Portlet",
         "userRated" : 0
       },
-      { "canAdd" : true,
+      { "canAdd" : false,
         "categories" : [  ],
         "description" : null,
         "faIcon" : "fa-area-chart",


### PR DESCRIPTION
When the user searches and finds zero search results, 

 * Clearly state that no results matched
 * Suggest ways to recover

Suggestions implemented in this changeset:

 * dropping the category filter, iff matching results are hidden by the category filter, 
 * showing non-launchable matches,  iff matching results are hidden by the "Show all" filter
 * searching in the directory, with a link that carries along the active query string
 * searching in UW Madison web search, with a link that carries along the active query string
 * searching in the KB, with a link that carries along the query string
 * asking the Helpdesk for help
 * submitting feedback about MyUW search

## Configurable and degrades gracefully

The external search URLs are configured in `app-config.js`, in that

 * Directory search URL is configurable; if not set this option is not shown.
 * Web search URL is configurable; if not set this option is not shown.  The UI label for the domain over which this searches is also configurable; if not set it just says Web.
 * KB search URL is configurable; if not set this option is not shown.

Honors pre-existing feedback URL configuration; if not set that option is not shown.  Adds new helpdesk URL configuration; if not set that option is not shown.

# Screenshots

## Basic suggestions

![search for vertein no resutls](https://cloud.githubusercontent.com/assets/952283/10384691/44092592-6e05-11e5-9da4-c403ba75c1a2.png)

## When Show all would help, suggest it

![google analy](https://cloud.githubusercontent.com/assets/952283/10384707/9060b676-6e05-11e5-888c-41d15efac03a.png)

## When All Categories would help, suggest it

![suggest looking beyond the selected category](https://cloud.githubusercontent.com/assets/952283/10384724/bffd9b88-6e05-11e5-9836-fe41e35defc5.png)

(this screenshot is messed up somehow, but this feature does work.)

## When no domain is configured for web search

![no search domain- no worries](https://cloud.githubusercontent.com/assets/952283/10405700/5d28a192-6ea0-11e5-9391-01ce44621081.png)

