### PR TITLE
Only show no-results content after portlet registry loads.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -34,7 +34,7 @@
   </div>
   
   <div 
-    ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0" 
+    ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0" 
     class="no-results">
     <p>No matching MyUW content.</p>
     <p>Maybe try:</p>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -14,7 +14,8 @@
     </div>
   </div>
   <div class="show-all-div">
-    <p>Showing {{ (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length }} of {{ portlets.length }} results in {{NAMES.title}}.</p>
+    <p><span ng-if="portlets.length > 0">Showing {{ (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length }} of {{ portlets.length }} results in {{NAMES.title}}.</span>
+    <span ng-if="portlets.length == 0">Loading...</span></p>
     <div><p><input type="checkbox" ng-click="toggleShowAll()" ng-checked="showAll">Show all<span popover="Show all apps, even if I don't have access" popover-append-to-body="true" popover-placement="left" popover-trigger="mouseenter"><i class="fa fa-question-circle" ></i></span></p></input></div>
   </div>
   <div ng-show="showCategories" class="show-categories">


### PR DESCRIPTION
Only show the no-search-results recovery content after the array of portlets available for filtering is non-empty.

While loading:

![now with clever loading goodness](https://cloud.githubusercontent.com/assets/952283/10496273/875358ca-7285-11e5-883c-d49ff61c9b7c.png)

After loading:

![loaded](https://cloud.githubusercontent.com/assets/952283/10496298/ab67b350-7285-11e5-83b7-262e6e0bcaf7.png)


Tested locally using Chrome dev tools throttling, which is pretty cool.