### PR TITLE
MUMUP-2163 Add events search as a recover option

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -52,7 +52,8 @@ define(['angular'], function(angular) {
             'webSearchURL' : 'http://www.wisc.edu/search/?q=',
             'webSearchDomain' : "wisc.edu",
             'directorySearchURL' : 'http://www.wisc.edu/directories/?q=',
-            'kbSearchURL' : 'https://kb.wisc.edu/search.php?q='
+            'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',
+            'eventsSearchURL' : 'https://today.wisc.edu/events/search?term='
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -45,7 +45,8 @@ define(['angular'], function(angular) {
             'webSearchURL' : null,
             'webSearchDomain' = null,
             'directorySearchURL' : null,
-            'kbSearchURL' : null
+            'kbSearchURL' : null,
+            'eventsSearchURL' : null
         })
         ;
 

--- a/angularjs-portal-home/src/main/webapp/js/master-app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-app-config.js
@@ -42,7 +42,7 @@ define(['angular'], function(angular) {
             'back2ClassicURL' : null,
             'whatsNewURL' : null,
             'helpdeskURL' : null,
-            'webSearchURL' : null,
+            'webSearchURL' : 'http://www.google.com/search?q=',
             'webSearchDomain' = null,
             'directorySearchURL' : null,
             'kbSearchURL' : null,

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -145,6 +145,7 @@ define(['angular', 'jquery'], function(angular, $) {
             $scope.webSearchDomain = MISC_URLS.webSearchDomain;
             $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
             $scope.kbSearchUrl = MISC_URLS.kbSearchURL;
+            $scope.eventsSearchUrl = MISC_URLS.eventsSearchURL;
 
             $scope.feedbackUrl = MISC_URLS.feedbackURL;
             $scope.helpdeskUrl = MISC_URLS.helpdeskURL;

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -54,6 +54,9 @@
       <li ng-if="kbSearchUrl">
         <a ng-href="{{kbSearchUrl}}{{searchText}}"
            target="_blank">Search the KnowledgeBase</a> instead.</li>
+      <li ng-if="eventsSearchUrl">
+        <a ng-href="{{eventsSearchUrl}}{{searchText}}"
+          target="_blank">Search for events</a> instead.</li>
       <li ng-if="helpdeskUrl">
         <a ng-href="{{helpdeskUrl}}"
            target="_blank">Ask the Helpdesk</a> for help.</li>


### PR DESCRIPTION
Adds "Search for events instead" as another no-search-results recovery option.

This tweak is intended to be responsive to a request around content in MyUW supporting the [AAU Survey Student Engagement Sessions](https://today.wisc.edu/events/search?utf8=%E2%9C%93&term=AAU+Survey+Student+Engagement+Session&commit=Search) without committing MyUW to adding a `portlet-definition`, widget, entry in the directory of apps, notification, etc., supporting these three point-in-time events.

The specific zero-search-results search that raised the concern was a search for "sexual assault" and concern that this yields no search results. The compromise initial response is "we're not able to immediately make that search term directly yield useful content, but if people were searching for this event, they'll see a search recovery option that looks like a next step for looking for an event."

![search for events instead](https://cloud.githubusercontent.com/assets/952283/10520506/01cc85ea-7330-11e5-9db4-5a2bd805e9a4.png)
