### PR TITLE
use ng-switch for widget selection

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -2,8 +2,6 @@
 
 define(['angular', 'jquery'], function(angular, $) {
 
-    var portletTypeCount = 0;
-
     var app = angular.module('my-app.layout.controllers', []);
 
     app.controller('DefaultViewController', [
@@ -137,7 +135,6 @@ define(['angular', 'jquery'], function(angular, $) {
             }
 
             this.portletType = function portletType(portlet) {
-                console.log("portletType count : " + ++portletTypeCount);
                 if (portlet.widgetType) {
                     if('option-link' === portlet.widgetType) {
                         return "OPTION_LINK";

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -2,6 +2,8 @@
 
 define(['angular', 'jquery'], function(angular, $) {
 
+    var portletTypeCount = 0;
+
     var app = angular.module('my-app.layout.controllers', []);
 
     app.controller('DefaultViewController', [
@@ -135,6 +137,7 @@ define(['angular', 'jquery'], function(angular, $) {
             }
 
             this.portletType = function portletType(portlet) {
+                console.log("portletType count : " + ++portletTypeCount);
                 if (portlet.widgetType) {
                     if('option-link' === portlet.widgetType) {
                         return "OPTION_LINK";
@@ -219,7 +222,7 @@ define(['angular', 'jquery'], function(angular, $) {
             return date >= today;
         }
     }]);
-    
+
     app.controller('GoToAppsController', ['$location',function($location){
       this.redirectToApps = function(){$location.path("/apps");};
     }]);

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -30,52 +30,56 @@
     <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch full app</a>
   </div>
 
-  <div ng-if="'OPTION_LINK' === widgetCtrl.portletType(portlet)">
-    <option-link app="portlet" config="portlet.widgetConfig"></option-link>
-  </div>
+  <div ng-switch='widgetCtrl.portletType(portlet)'>
 
-  <div ng-if="'WEATHER' === widgetCtrl.portletType(portlet)">
-    <weather app="portlet" config="portlet.widgetConfig"></weather>
-  </div>
-
-  <div ng-if="'RSS' === widgetCtrl.portletType(portlet)">
-    <rss app="portlet" config="portlet.widgetConfig"></rss>
-  </div>
-  
-  <div ng-if="'LOL' === widgetCtrl.portletType(portlet)">
-    <lol app="portlet" config="portlet.widgetConfig"></lol>
-  </div>
-
-  <div ng-if="'GENERIC' === widgetCtrl.portletType(portlet)">
-    <div ng-controller="GenericWidgetController as genericWidgetCtrl">
-        <div ng-if="loading" id="loading">
-            <loading-gif data-object='content' data-empty='isEmpty'></loading-gif>
-        </div>
-        <content-item ng-if="!loading"></content-item>
+    <div ng-switch-when="OPTION_LINK">
+      <option-link app="portlet" config="portlet.widgetConfig"></option-link>
     </div>
+
+    <div ng-switch-when="WEATHER">
+      <weather app="portlet" config="portlet.widgetConfig"></weather>
+    </div>
+
+    <div ng-switch-when="RSS">
+      <rss app="portlet" config="portlet.widgetConfig"></rss>
+    </div>
+
+    <div ng-switch-when="LOL">
+      <lol app="portlet" config="portlet.widgetConfig"></lol>
+    </div>
+
+    <!-- For pithy content, display the pithy content -->
+    <div ng-switch-when="PITHY">
+      <div class="portlet-content">
+         <div ng-bind-html="portlet.pithyStaticContent"></div>
+      </div>
+      <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch full app</a>
+    </div>
+
+    <div ng-switch-when="GENERIC">
+      <div ng-controller="GenericWidgetController as genericWidgetCtrl">
+          <div ng-if="loading" id="loading">
+              <loading-gif data-object='content' data-empty='isEmpty'></loading-gif>
+          </div>
+          <content-item ng-if="!loading"></content-item>
+      </div>
+    </div>
+
+    <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
+    <a tabindex="-1" ng-switch-when="NORMAL" href="{{::portlet.url}}" target="{{::portlet.target}}">
+      <div class="widget-icon-container">
+        <portlet-icon></portlet-icon>
+      </div>
+      <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
+    </a>
+
+    <!-- For simple content portlets, show only an icon -->
+    <a tabindex="-1" ng-switch-when="SIMPLE" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="simple-content-container">
+      <div class="widget-icon-container">
+        <portlet-icon></portlet-icon>
+      </div>
+      <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
+    </a>
+
   </div>
-
-  <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
-  <a tabindex="-1" ng-if="'NORMAL' === widgetCtrl.portletType(portlet)" href="{{::portlet.url}}" target="{{::portlet.target}}">
-    <div class="widget-icon-container">
-      <portlet-icon></portlet-icon>
-    </div>
-    <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
-  </a>
-
-  <!-- For pithy content, display the pithy content -->
-  <div ng-if="'PITHY' === widgetCtrl.portletType(portlet)">
-    <div class="portlet-content">
-       <div ng-bind-html="portlet.pithyStaticContent"></div>
-    </div>
-    <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch full app</a>
-  </div>
-
-  <!-- For simple content portlets, show only an icon -->
-  <a tabindex="-1" ng-if="'SIMPLE' === widgetCtrl.portletType(portlet)" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="simple-content-container">
-    <div class="widget-icon-container">
-      <portlet-icon></portlet-icon>
-    </div>
-    <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
-  </a>
 </div>


### PR DESCRIPTION
Read about `ng-switch` and thought this would be a good case to use it. Did a little logging, for someone that has a single widget on there page, it reduces the amount of calls to `widgetCtrl.portletType(portlet)` from 188 to 42. Decent improvement.