### PR TITLE
MUMUP-2245 : Search with links Template

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -146,6 +146,8 @@ define(['angular', 'jquery'], function(angular, $) {
                         return "RSS";
                     } else if('list-of-links' === portlet.widgetType) {
                         return "LOL";
+                    } else if ('search-with-links' === portlet.widgetType) {
+                        return "SWL";
                     } else {
                         return "WIDGET";
                     }

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -3,7 +3,7 @@
 define(['angular'], function(angular){
 
   var app = angular.module('my-app.layout.widget.controllers', []);
-  
+
   app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService){
 
     var configInit = function(){
@@ -144,7 +144,7 @@ define(['angular'], function(angular){
         return [];
       }
     };
-    
+
     if($scope.portlet.widgetTemplate) {
       $scope.content = [];
       $scope.template =  $scope.portlet.widgetTemplate;
@@ -159,7 +159,7 @@ define(['angular'], function(angular){
   }]);
 
   app.controller("RSSWidgetController", ['$scope', 'layoutService', function($scope, layoutService){
-      
+
       $scope.getPrettyDate = function(dateString) {
         var dte;
         if(dateString) {
@@ -169,30 +169,30 @@ define(['angular'], function(angular){
         }
         return dte;
       };
-      
+
       var init = function(){
         $scope.loading = true;
         if($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
           if(!$scope.config) {
             $scope.config = {};
           }
-          
+
           if(!$scope.config.lim) {
             $scope.config.lim = 5;
           }
-          
+
           if(!$scope.config.showShowing) {
             //default must be false as falsy is weird
             $scope.config.showShowing = false;
           }
-          
+
           var successFn = function(result){
             $scope.loading = false;
             $scope.data = result.data;
             if($scope.data.responseStatus != 200) {
               $scope.error = true;
-            } else if(!$scope.data.responseData 
-              || !$scope.data.responseData.feed 
+            } else if(!$scope.data.responseData
+              || !$scope.data.responseData.feed
               || $scope.data.responseData.feed.entries.length == 0) {
               $scope.isEmpty = true;
             }
@@ -202,18 +202,22 @@ define(['angular'], function(angular){
             $scope.isEmpty = true;
             $scope.loading = false;
           };
-          
+
           layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn,errorFn);
         } else {
           $scope.loading = false;
           $scope.error = true;
         }
       }
-      
+
       init();
-      
+
     }]);
 
+    //SearchWithLinksController
+    app.controller("SearchWithLinksController", ['$scope', '$sce', function($scope, $sce){
+      $scope.secureURL = $sce.trustAsResourceUrl($scope.config.actionURL);
+    }]);;
 
   return app;
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
@@ -37,7 +37,7 @@ define(['angular', 'require'], function(angular, require) {
             controller: 'WeatherController'
         }
     });
-    
+
     app.directive('lol', function () {
         return {
             restrict: 'E',
@@ -48,7 +48,18 @@ define(['angular', 'require'], function(angular, require) {
             templateUrl: require.toUrl('./partials/lol.html')
         }
     });
-    
+
+    app.directive('swl', function () {
+        return {
+            restrict: 'E',
+            scope: {
+                portlet: '=app',
+                config: '=config'
+            },
+            templateUrl: require.toUrl('./partials/search-with-links.html')
+        }
+    });
+
     /**
      <rss></rss> is an rss widget card that will show your info in a view
      app     : A layout portlet object from uPortal

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
@@ -56,7 +56,8 @@ define(['angular', 'require'], function(angular, require) {
                 portlet: '=app',
                 config: '=config'
             },
-            templateUrl: require.toUrl('./partials/search-with-links.html')
+            templateUrl: require.toUrl('./partials/search-with-links.html'),
+            controller: 'SearchWithLinksController'
         }
     });
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
@@ -1,6 +1,6 @@
 <div class='widget-body'>
-  <form action='{{config.actionURL}}' target='{{config.actionTarget}}'>
-     <div class='input-group'><input type='text' name='{{config.searchParameter}}' class='form-control' placeholder='{{config.searchPlaceholder}}'><span class='input-group-btn'><button class='btn btn-primary' type='submit'><i class='fa fa-search'></i></button></span></div>
+  <form action='{{secureURL}}' target='{{config.actionTarget}}'>
+     <div class='input-group'><input type='text' name='{{config.actionParameter}}' class='form-control' placeholder='{{config.searchPlaceholder}}'><span class='input-group-btn'><button class='btn btn-primary' type='submit'><i class='fa fa-search'></i></button></span></div>
   </form>
    <!-- Links -->
    <div class='row'>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
@@ -1,0 +1,19 @@
+<div class='widget-body'>
+  <form action='{{config.actionURL}}' target='{{config.actionTarget}}'>
+     <div class='input-group'><input type='text' name='{{config.searchParameter}}' class='form-control' placeholder='{{config.searchPlaceholder}}'><span class='input-group-btn'><button class='btn btn-primary' type='submit'><i class='fa fa-search'></i></button></span></div>
+  </form>
+   <!-- Links -->
+   <div class='row'>
+     <div ng-show="config.links.length == 1">
+  		 <div class='col-xs-6 col-xs-offset-3 center' ng-repeat='item in config.links'>
+  				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}'></circle-button>
+       </div>
+  	 </div>
+  	 <div ng-show="config.links.length == 2">
+  		 <div class='col-xs-6 center' ng-repeat='item in config.links'>
+  				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}'></circle-button>
+       </div>
+  	 </div>
+   </div>
+</div>
+<a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="_blank">{{config.launchText}}</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -48,6 +48,10 @@
       <lol app="portlet" config="portlet.widgetConfig"></lol>
     </div>
 
+    <div ng-switch-when="SWL">
+      <swl app="portlet" config="portlet.widgetConfig"></swl>
+    </div>
+
     <!-- For pithy content, display the pithy content -->
     <div ng-switch-when="PITHY">
       <div class="portlet-content">

--- a/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
@@ -2,16 +2,16 @@
    "layout":[
    {
       "nodeId":"u23l1n11",
-      "title":"Search with the Google",
+      "title":"Search with the Bing",
       "description":"Testing out widget template swl.",
-      "url":"www.google.com",
+      "url":"https://www.bing.com/",
       "iconUrl":null,
-      "faIcon":"fa-google",
-      "fname":"google-search",
+      "faIcon":"fa-windows",
+      "fname":"bing-search",
       "target":null,
       "widgetURL":null,
       "widgetType":"search-with-links",
-      "widgetConfig": { "actionURL" : "https://www.google.com", "actionTarget" : "_blank", "actionParameter" : "q", "launchText":"Launch Google","links": [{"title":"Interweb Search", "href":"http://www.google.com", "icon":"fa-search","target":"_blank"}, {"title":"Image Search", "href":"https://www.google.com/imghp", "icon":"fa-camera","target":"_blank"}]},
+      "widgetConfig": { "actionURL" : "https://www.bing.com", "actionTarget" : "_blank", "actionParameter" : "q", "launchText":"Launch Bing","links": [{"title":"Interweb Search", "href":"http://www.bing.com", "icon":"fa-search","target":"_blank"}, {"title":"Image Search", "href":"https://www.bing.com/images", "icon":"fa-camera","target":"_blank"}]},
       "staticContent":null,
       "pithyStaticContent":null,
       "altMaxUrl":false

--- a/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/layoutDoc
@@ -1,6 +1,21 @@
 {
    "layout":[
-
+   {
+      "nodeId":"u23l1n11",
+      "title":"Search with the Google",
+      "description":"Testing out widget template swl.",
+      "url":"www.google.com",
+      "iconUrl":null,
+      "faIcon":"fa-google",
+      "fname":"google-search",
+      "target":null,
+      "widgetURL":null,
+      "widgetType":"search-with-links",
+      "widgetConfig": { "actionURL" : "https://www.google.com", "actionTarget" : "_blank", "actionParameter" : "q", "launchText":"Launch Google","links": [{"title":"Interweb Search", "href":"http://www.google.com", "icon":"fa-search","target":"_blank"}, {"title":"Image Search", "href":"https://www.google.com/imghp", "icon":"fa-camera","target":"_blank"}]},
+      "staticContent":null,
+      "pithyStaticContent":null,
+      "altMaxUrl":false
+   },
       {
 		   "nodeId":"n777",
 		   "title":"Weather",


### PR DESCRIPTION
+ Creates SWL directive for a search with links widget template
+ If you set widgetType = 'search-with-links'
+ and provide proper config
```json
{
   "actionURL":"https://www.bing.com",
   "actionTarget":"_blank",
   "actionParameter":"q",
   "launchText":"Launch Bing",
   "links":[
      {
         "title":"Interweb Search",
         "href":"http://www.bing.com",
         "icon":"fa-search",
         "target":"_blank"
      },
      {
         "title":"Image Search",
         "href":"https://www.bing.com/images",
         "icon":"fa-camera",
         "target":"_blank"
      }
   ]
}
```

note: links is limited to 2, but does handle if there are 1 or non.