### PR TITLE
Make list-of-links widget type more responsive

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -93,4 +93,8 @@ weather {
     color:@color1;
     padding-right:10px;
   }
+  .col-xs-6 {
+    height:95px;
+    padding:0px !important;
+  }
 }

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/lol.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/lol.html
@@ -24,7 +24,7 @@
 	 <div ng-show="config.links.length > 4">
 		 <ul class="widget-list">
 			 <li ng-repeat='item in config.links | limitTo: 7' class="link-icon">
-				 <i class="fa {{item.icon}}"></i><a href="{{item.href}}" target="{{item.target}}">{{item.title}}</a>
+				 <i class="fa {{item.icon}}"></i><a href="{{item.href}}" target="{{item.target}}">{{item.title | truncate:5}}</a>
 			 </li>
 		 </ul>
 	 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/lol.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/lol.html
@@ -24,7 +24,7 @@
 	 <div ng-show="config.links.length > 4">
 		 <ul class="widget-list">
 			 <li ng-repeat='item in config.links | limitTo: 7' class="link-icon">
-				 <i class="fa {{item.icon}}"></i><a href="{{item.href}}" target="{{item.target}}">{{item.title | truncate:5}}</a>
+				 <i class="fa {{item.icon}}"></i><a href="{{item.href}}" target="{{item.target}}">{{item.title | truncate:24}}</a>
 			 </li>
 		 </ul>
 	 </div>


### PR DESCRIPTION
Three things were done:
1. Remove bootstrap padding on columns in list-of-links widgets
2. Define height of 95px
3. Truncate after 24 characters (code change in uw-frame)

Before:
![image](https://cloud.githubusercontent.com/assets/1919535/11096058/c88dae4c-885d-11e5-899f-e54808cc3539.png)


After:
![image](https://cloud.githubusercontent.com/assets/1919535/11096034/a7111f7e-885d-11e5-8651-7a4b02a74c83.png)
