### PR TITLE
Brand Help Desk correctly (rather than Helpdesk).

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -59,7 +59,7 @@
           target="_blank">Search for events</a> instead.</li>
       <li ng-if="helpdeskUrl">
         <a ng-href="{{helpdeskUrl}}"
-           target="_blank">Ask the Helpdesk</a> for help.</li>
+           target="_blank">Ask the Help Desk</a> for help.</li>
       <li ng-if="feedbackUrl">
         <a ng-href="{{feedbackUrl}}">Give feedback</a> about search.</li>
     </ul>


### PR DESCRIPTION
The no-search-results recovery link about asking for help didn't match the Help Desk's [branding as Help Desk](https://kb.wisc.edu/helpdesk/). This fixes that.