### PR TITLE
MUMUP-2196: Redesign search results

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/my-app.less
+++ b/angularjs-portal-home/src/main/webapp/css/my-app.less
@@ -5,5 +5,6 @@
   @import "widget.less";
   @import "uw-portlet.less";
   @import "marketplace.less";
+  @import "search-results.less";
 }
 

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -1,0 +1,25 @@
+.search-results {
+	.result {
+		padding:20px 0px 0px 20px;
+		h4 {
+			color:@color1;
+			font-weight:400;
+			margin-bottom:0px;
+		}
+		p {
+			margin:0px;
+		}
+		a.add {
+			margin-right:15px;
+			&:hover {
+				cursor:pointer;
+			}
+		}
+		.added {
+			margin-right:15px;
+		}
+		.rating {
+			margin-left:20px;
+		}
+	}
+}

--- a/angularjs-portal-home/src/main/webapp/my-app/main.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/main.js
@@ -53,7 +53,7 @@ define([
         $routeProvider.
             when('/apps', marketplaceRoutes.main).
             when('/apps/details/:fname', marketplaceRoutes.details).
-            when('/apps/search/:initFilter', marketplaceRoutes.main).
+            when('/apps/search/:initFilter', marketplaceRoutes.search).
             when('/compact', listRoute).
             when('/expanded', widgetRoute).
             when('/notifications', notificationsRoute).

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/search-results.html
@@ -1,0 +1,76 @@
+<div class="row portlet-frame col-xs-12 col-md-12 no-padding search-results" ng-controller="MarketplaceController as marketplaceCtrl">
+	<div class="inner-nav-container">
+		<ul class="inner-nav">
+			<li class="active">
+				<a>All Results ({{ results.length }})</a>
+			</li>
+			<!-- <li>
+				<a>MyUW (# results)</a>
+			</li>
+			<li>
+				<a>Directory (# results)</a>
+			</li>
+			<li>
+				<a>Wisc.edu (# results)</a>
+			</li> -->
+		</ul>
+	</div>
+
+
+  <!-- <loading-gif data-object='portlets'></loading-gif> -->
+  <div ng-repeat="portlet in results = ( portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow | orderBy:sortParameter | limitTo:searchResultLimit)" class="result">
+		<h4><a href="{{::portlet.maxUrl}}" target="{{::portlet.target}}">{{ portlet.name }}</a></h4>
+		<p>{{ portlet.description }}</p>
+		<p>
+			<a ng-click="marketplaceCtrl.addToHome($index , portlet)"
+		ng-if="portlet.canAdd && !portlet.hasInLayout" class="add">
+				<i class="fa fa-plus"></i> Add to home
+			</a>
+			<span ng-if="portlet.canAdd && portlet.hasInLayout" class="added">
+				<i class="fa fa-check"></i> Added to home
+			</span>
+			<a href="apps/details/{{::portlet.fname}}">Details</a>
+			<span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
+		</p>
+				
+  </div>
+  <div class="marketplace-load-more">
+    <button class="btn btn-primary btn-lg"
+            ng-click="searchResultLimit = searchResultLimit + 20;"
+            hide-while-loading
+            ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length > searchResultLimit"
+           >Load More</button>
+  </div>
+  
+  <div 
+    ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0" 
+    class="no-results">
+    <p>No matching MyUW content.</p>
+    <p>Maybe try:</p>
+    <ul>
+      <li ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll).length > 0">
+        <a href="#" ng-click="selectFilter('az','')">Show matching content beyond the &quot;{{categoryToShow}}&quot; category</a>.</li>
+      <li 
+        ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
+         <a href="#" ng-click="toggleShowAll()">Show matching MyUW content even though it is not launchable</a>.</li>
+      <li ng-if="directorySearchUrl">
+        <a ng-href="{{directorySearchUrl}}{{searchText}}"
+           target="_blank">Search the directory</a> (of people and offices) instead.</li>
+      <li ng-if="webSearchUrl">
+        <a ng-href="{{webSearchUrl}}{{searchText}}"
+           target="_blank">Search <span ng-if="webSearchDomain">the {{webSearchDomain}} domain on</span> the Web</a> instead.</li>
+      <li ng-if="kbSearchUrl">
+        <a ng-href="{{kbSearchUrl}}{{searchText}}"
+           target="_blank">Search the KnowledgeBase</a> instead.</li>
+      <li ng-if="eventsSearchUrl">
+        <a ng-href="{{eventsSearchUrl}}{{searchText}}"
+          target="_blank">Search for events</a> instead.</li>
+      <li ng-if="helpdeskUrl">
+        <a ng-href="{{helpdeskUrl}}"
+           target="_blank">Ask the Help Desk</a> for help.</li>
+      <li ng-if="feedbackUrl">
+        <a ng-href="{{feedbackUrl}}">Give feedback</a> about search.</li>
+    </ul>
+  </div>
+  
+</div>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/search-results.html
@@ -17,8 +17,8 @@
 	</div>
 
 
-  <!-- <loading-gif data-object='portlets'></loading-gif> -->
-  <div ng-repeat="portlet in results = ( portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow | orderBy:sortParameter | limitTo:searchResultLimit)" class="result">
+  <loading-gif data-object='portlets'></loading-gif>
+  <div ng-repeat="portlet in results = ( portlets | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)" class="result">
 		<h4><a href="{{::portlet.maxUrl}}" target="{{::portlet.target}}">{{ portlet.name }}</a></h4>
 		<p>{{ portlet.description }}</p>
 		<p>
@@ -38,20 +38,18 @@
     <button class="btn btn-primary btn-lg"
             ng-click="searchResultLimit = searchResultLimit + 20;"
             hide-while-loading
-            ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length > searchResultLimit"
+            ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll).length > searchResultLimit"
            >Load More</button>
   </div>
   
   <div 
-    ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length == 0" 
+    ng-show="portlets.length > 0 && (portlets | filter:searchTermFilter | showApplicable:showAll).length == 0" 
     class="no-results">
     <p>No matching MyUW content.</p>
     <p>Maybe try:</p>
     <ul>
-      <li ng-show="(portlets | filter:searchTermFilter | showApplicable:showAll).length > 0">
-        <a href="#" ng-click="selectFilter('az','')">Show matching content beyond the &quot;{{categoryToShow}}&quot; category</a>.</li>
       <li 
-        ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
+        ng-show="(portlets | filter:searchTermFilter).length > 0">
          <a href="#" ng-click="toggleShowAll()">Show matching MyUW content even though it is not launchable</a>.</li>
       <li ng-if="directorySearchUrl">
         <a ng-href="{{directorySearchUrl}}{{searchText}}"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/routes.js
@@ -4,6 +4,9 @@ define(['require'], function(require){
         main: {
             templateUrl: require.toUrl('./partials/marketplace.html')
         },
+        search: {
+            templateUrl: require.toUrl('./partials/search-results.html')
+        },
         details: {
             templateUrl: require.toUrl('./partials/marketplace-details.html')
         }


### PR DESCRIPTION
Search results a la @keirserrie mockups. Clean, simple, googley.

Holding off on Directory and Wisc.edu tabs until we have those in place. With this PR, new search results page is shippable. 

Also note this is a new and separate page from the Browse page. The Browse page will stand as is until we decide what to do with it.

Search: 'email'
![image](https://cloud.githubusercontent.com/assets/1919535/11639581/518a70d2-9cf3-11e5-8a41-9864cbf72d2f.png)

Search: 'time'
![image](https://cloud.githubusercontent.com/assets/1919535/11639620/884097e6-9cf3-11e5-9011-4a06e1d34fbd.png)

Search: 'sched'
![image](https://cloud.githubusercontent.com/assets/1919535/11639694/eeb70762-9cf3-11e5-8751-23bcd4b4d9ce.png)

Search in action (it's blazingly fast :fire:):
![screen recording 2015-12-07 at 03 07 pm](https://cloud.githubusercontent.com/assets/1919535/11639742/3a129082-9cf4-11e5-86bc-7452bb8a4343.gif)
