### PR TITLE
MUMUP-2288 : Bye sidebar

### DIFF
--- a/angularjs-portal-home/pom.xml
+++ b/angularjs-portal-home/pom.xml
@@ -22,7 +22,7 @@
       <groupId>edu.wisc.my.apps</groupId>
       <artifactId>uw-frame</artifactId>
       <type>war</type>
-      <version>1.4.1-SNAPSHOT</version>
+      <version>2.0.0-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->

--- a/angularjs-portal-home/src/main/webapp/css/home.less
+++ b/angularjs-portal-home/src/main/webapp/css/home.less
@@ -134,7 +134,7 @@ div.table-cell {
 
 .tile-list { 
   list-style-type: none; 
-  margin: 5px; 
+  margin: 15px auto; 
   padding: 0px;
   max-width:1200px; 
 }

--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -372,6 +372,7 @@ input:focus,span:focus {
 }
 .portlet-details-page {
   padding-bottom:0px;
+  background: white;
   .portlet-title {
     padding-left:5px;
   }

--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -151,33 +151,35 @@
   padding-left:0px;
 }
 .mp-header {
-  height:200px;
+  height:100px;
+  background-image: url('../img/terrace.jpg');
 }
 .mp-opaque {
-  height:40px;
+  height:35px;
   background-color:rgba(256,256,256,0.8);
+  ul {
+    padding:0;
+    margin-bottom: 0;
+    li {
+      float:left;
+      width:33.333%;
+      border-right:1px solid @grayscale4;
+      border-bottom:1px solid @grayscale4;
+      border-top:0px solid @grayscale4;
+      padding:10px 0px;
+      text-align:center;
+      box-sizing:border-box;
+      :hover {
+        background-color:rgba(210,210,210,0.5);
+        cursor:pointer;
+        border-top:3px solid @color1;
+        border-bottom:none;
+        padding:7px 0px;
+      }
+    }
+  }
 }
-.mp-opaque ul {
-  padding:0;
-}
-.mp-opaque li {
-  float:left;
-  width:33.333%;
-  border-right:1px solid @grayscale4;
-  border-bottom:1px solid @grayscale4;
-  border-top:0px solid @grayscale4;
-  height:40px;
-  padding:10px 0px;
-  text-align:center;
-  box-sizing:border-box;
-}
-.mp-opaque li:hover {
-  background-color:rgba(210,210,210,0.5);
-  cursor:pointer;
-  border-top:3px solid @color1;
-  border-bottom:none;
-  padding:7px 0px;
-}
+
 #browse-by {
   background-color:inherit;
   border-bottom:1px solid @grayscale4;

--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -153,6 +153,9 @@
 .mp-header {
   height:100px;
   background-image: url('../img/terrace.jpg');
+  background-size:100%;
+  box-shadow:inset 0 0 0 2000px rgba(0,0,0,0.4);
+  padding:25px;
 }
 .mp-opaque {
   height:35px;

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -1,25 +1,26 @@
 .search-results {
-	.result {
-		padding:20px 0px 0px 20px;
-		h4 {
-			color:@color1;
-			font-weight:400;
-			margin-bottom:0px;
-		}
-		p {
-			margin:0px;
-		}
-		a.add {
-			margin-right:15px;
-			&:hover {
-				cursor:pointer;
-			}
-		}
-		.added {
-			margin-right:15px;
-		}
-		.rating {
-			margin-left:20px;
-		}
-	}
+  background-color: @white;
+  .result {
+    padding:20px 0px 0px 20px;
+    h4 {
+      color:@color1;
+      font-weight:400;
+      margin-bottom:0px;
+    }
+    p {
+      margin:0px;
+    }
+    a.add {
+      margin-right:15px;
+      &:hover {
+        cursor:pointer;
+      }
+    }
+    .added {
+      margin-right:15px;
+    }
+    .rating {
+      margin-left:20px;
+    }
+  }
 }

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -57,7 +57,8 @@ define(['angular'], function(angular) {
             'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',
             'eventsSearchURL' : 'https://today.wisc.edu/events/search?term=',
             'loginURL' : '/portal/Login?profile=bucky',
-            'logoutURL' : '/portal/Logout'
+            'logoutURL' : '/portal/Logout',
+            'rootURL' : '/web'
         })
         .constant('FOOTER_URLS', [
           { "url" : "static/myuw-help",

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -59,21 +59,29 @@ define(['angular'], function(angular) {
             'loginURL' : '/portal/Login?profile=bucky',
             'logoutURL' : '/portal/Logout'
         })
-        .constant('APP_BETA_FEATURES', [
-          {
-            "id" : "sidebarQuicklinks",
-            "title" : "Sidebar Quicklinks",
-            "description" : "Shows quicklinks to various campus sites in sidebar"
+        .constant('FOOTER_URLS', [
+          { "url" : "static/myuw-help",
+            "target" : "_blank",
+            "title" : "Help"
           },
+          { "url" : "https://my.wisc.edu/portal/p/feedback",
+            "target" : "_blank",
+            "title" : "Feedback"
+          },
+          { "url" : "features",
+            "target" : "",
+            "title" : "What's New"
+          },
+          { "url" : "/portal/Login?profile=default",
+            "target" : "",
+            "title" : "Old MyUW"
+          },
+        ])
+        .constant('APP_BETA_FEATURES', [
           {
             "id" : "webPortletRender",
             "title" : "/web portlet rendering",
             "description" : "Renders portlets via /web's exclusive page, but only as launched from compact-mode widgets"
-          },
-          {
-            "id" : "myProfileOption",
-            "title" : "My Profile Option in Menu",
-            "description" : "Enable/Disable the option to jump to my profile in the sidebar"
           },
           {
             "id" : "showKeywordsInMarketplace",

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -22,7 +22,6 @@ define(['angular'], function(angular) {
             'base'        : '/portal/web/',
             'layout'      : 'layoutDoc?tab=UW Bucky Home',
             'layoutTab' : 'UW Bucky Home',
-            'addToHomeLink' : '/portal/web/layout?action=addPortlet&tabName=UW%20Bucky%20Home&fname=',
             'marketplace' : {
                 'base' : 'marketplace/',
                 'entry' : 'entry/',

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -22,6 +22,7 @@ define(['angular'], function(angular) {
             'base'        : '/portal/web/',
             'layout'      : 'layoutDoc?tab=UW Bucky Home',
             'layoutTab' : 'UW Bucky Home',
+            'addToHomeLink' : '/portal/web/layout?action=addPortlet&tabName=UW%20Bucky%20Home&fname=',
             'marketplace' : {
                 'base' : 'marketplace/',
                 'entry' : 'entry/',
@@ -39,7 +40,7 @@ define(['angular'], function(angular) {
             'sublogo' : ''
         })
         .constant('SEARCH',{
-            
+
         })
         .constant('NOTIFICATION', {
             'enabled' : true,

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -236,6 +236,10 @@ define(['angular', 'jquery'], function(angular, $) {
                               $location,
                               miscService,
                               APP_FLAGS){
+            $scope.MODES = {
+              EXPANDED : "expanded",
+              COMPACT : "compact"
+            }
             //scope functions
             $scope.switchMode = function(mode) {
                 $localStorage.layoutMode = mode;
@@ -250,6 +254,7 @@ define(['angular', 'jquery'], function(angular, $) {
             //local functions
             this.init = function() {
                 $scope.toggle = APP_FLAGS.enableToggle;
+                $scope.$storage = localStorage;
                 if($localStorage.layoutMode
                     && $location.url().indexOf($localStorage.layoutMode) == -1) {
                     //opps, we are in the wrong mode, switch!

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -1,39 +1,17 @@
-<div ng-controller="ToggleController">
-  <script type="text/ng-template" id="toggle-modes.html">
-    <div>
-      <a href="javascript:;" ng-click="switchMode('compact')">Show compact mode</a>
+<script type="text/ng-template" id="toggle-modes.html">
+  <div ng-controller="ToggleController">
+    <div ng-if='modeIs(MODES.EXPANDED)'>
+      <a href="javascript:;" ng-click="switchMode(MODES.COMPACT)">Show compact mode</a>
     </div>
-    <div>
-      <a href="javascript:;" ng-click="switchMode('expanded')">Show expanded mode</a>
+    <div ng-if='modeIs(MODES.COMPACT)'>
+      <a href="javascript:;" ng-click="switchMode(MODES.EXPANDED)">Show expanded mode</a>
     </div>
-    <div ng-show='$storage.showFilterOption'>
-      <button class="btn btn-flat" ng-click='showHomeFilter=!showHomeFilter' style='margin: 4px 10px;'><i class="fa fa-filter"></i></button>
-    </div>
-  </script>
-  <app-header app-title="Home" 
-              app-icon="fa-home"
-              app-action-link-url='apps'
-              app-action-link-icon='fa-plus-square'
-              app-action-link-text='Add more to home'
-              app-option-template='toggle-modes.html'>
-  </app-header>
-  
-</div>
-
-<!-- <div class="inner-nav-container">
-  <ul class="inner-nav">
-    <li ng-controller='GoToAppsController as GoToAppsCtrl'>
-      <button
-       ng-click='GoToAppsCtrl.redirectToApps()'
-       aria-label="button to browse for more"
-       class='btn btn-flat to-apps-home-button'
-       style='margin: 4px 10px;'>
-      <i class='fa fa-plus hidden-xs'></i> Add more to home
-    </button>
-    </li>
-    <li ng-show='$storage.showFilterOption'>
-      <button class="btn btn-flat" ng-click='showHomeFilter=!showHomeFilter' style='margin: 4px 10px;'><i class="fa fa-filter"></i></button>
-    </li>
-    <home-toggle></home-toggle>
-  </ul>
-</div> -->
+  </div>
+</script>
+<app-header app-title="Home" 
+            app-icon="fa-home"
+            app-action-link-url='apps'
+            app-action-link-icon='fa-plus-square'
+            app-action-link-text='Add more to home'
+            app-option-template='toggle-modes.html'>
+</app-header>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -1,24 +1,25 @@
-<!-- <div role="banner" class="portlet-header">
-  <img ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
-    <h1>Home</h1>
-    <div ng-controller="NewStuffController as newStuffCtrl" class='new-stuff'>
-      <div ng-repeat="stuff in newStuffArray">
-          <div ng-if='newStuffCtrl.show(stuff)'  class="header-opaque new-stuff">
-              <div><p class="new">New</p></div>
-              <div><h3>{{::stuff.title}}</h3></div>
-              <div class="description"><p>{{::stuff.shortDesc}}<a ng-if="stuff.link !== null" href="{{::stuff.link}}">Find out more.</a></p></div>
-              <div class="second-description"><p>{{::stuff.secondDesc}}<span>{{::stuff.arrow}}</span></p></div>
-          </div>
-      </div>
+<div ng-controller="ToggleController">
+  <script type="text/ng-template" id="toggle-modes.html">
+    <div>
+      <a href="javascript:;" ng-click="switchMode('compact')">Show compact mode</a>
     </div>
-</div> -->
+    <div>
+      <a href="javascript:;" ng-click="switchMode('expanded')">Show expanded mode</a>
+    </div>
+  </script>
+  <app-header app-title="Home" 
+              app-image="{{$storage.homeImg}}" 
+              app-icon="home"
+              app-collapse='true'
+              app-action-link-url='/web/apps'
+              app-action-link-icon='plus-square'
+              app-action-link-text='Add more to home'
+              app-option-template='toggle-modes.html'>
+  </app-header>
+  
+</div>
 
-<portlet-header app-title="Home" 
-                app-image="{{$storage.homeImg}}" 
-                app-collapse='true'>
-</portlet-header>
-
-<div class="inner-nav-container">
+<!-- <div class="inner-nav-container">
   <ul class="inner-nav">
     <li ng-controller='GoToAppsController as GoToAppsCtrl'>
       <button
@@ -34,4 +35,4 @@
     </li>
     <home-toggle></home-toggle>
   </ul>
-</div>
+</div> -->

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -8,11 +8,9 @@
     </div>
   </script>
   <app-header app-title="Home" 
-              app-image="{{$storage.homeImg}}" 
-              app-icon="home"
-              app-collapse='true'
-              app-action-link-url='/web/apps'
-              app-action-link-icon='plus-square'
+              app-icon="fa-home"
+              app-action-link-url='apps'
+              app-action-link-icon='fa-plus-square'
               app-action-link-text='Add more to home'
               app-option-template='toggle-modes.html'>
   </app-header>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -6,6 +6,9 @@
     <div>
       <a href="javascript:;" ng-click="switchMode('expanded')">Show expanded mode</a>
     </div>
+    <div ng-show='$storage.showFilterOption'>
+      <button class="btn btn-flat" ng-click='showHomeFilter=!showHomeFilter' style='margin: 4px 10px;'><i class="fa fa-filter"></i></button>
+    </div>
   </script>
   <app-header app-title="Home" 
               app-icon="fa-home"

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
@@ -3,7 +3,7 @@
 define(['angular', 'jquery'], function(angular, $) {
 
     var app = angular.module('my-app.layout.static.controllers', []);
-    
+
     app.controller('ExclusiveContentController', ['$modal',
                                                   '$location',
                                                   '$sessionStorage',
@@ -33,7 +33,7 @@ define(['angular', 'jquery'], function(angular, $) {
             }
             return {};
         };
-        
+
         if (typeof $scope.portlet.fname === 'undefined' || $scope.portlet.fname !== $routeParams.fname) {
 
             if (typeof $rootScope.layout !== 'undefined' && $rootScope.layout != null) {
@@ -53,7 +53,7 @@ define(['angular', 'jquery'], function(angular, $) {
                 layoutService.getExclusiveMarkup($scope.portlet);
             }
 
-        } 
+        }
     }]);
 
     app.controller('StaticContentController', [
@@ -66,6 +66,7 @@ define(['angular', 'jquery'], function(angular, $) {
         'layoutService',
         'miscService',
         'sharedPortletService',
+        'SERVICE_LOC',
         function ($modal,
                   $location,
                   $sessionStorage,
@@ -74,7 +75,8 @@ define(['angular', 'jquery'], function(angular, $) {
                   $scope,
                   layoutService,
                   miscService,
-                  sharedPortletService) {
+                  sharedPortletService,
+                  SERVICE_LOC) {
 
             miscService.pushPageview();
             $scope.portlet = sharedPortletService.getProperty() || {};
@@ -110,7 +112,7 @@ define(['angular', 'jquery'], function(angular, $) {
             } else {
               $scope.loading = $scope.portlet;
             }
-            
+
             $scope.openRating = function (size, fname, name) {
                 var modalInstance = $modal.open({
                     templateUrl: 'ratingModal.html',
@@ -169,6 +171,7 @@ define(['angular', 'jquery'], function(angular, $) {
                             return e.fname === $routeParams.fname
                         });
                         $scope.inFavorites = portlets.length > 0; //change scope variable to trigger apply
+                        $scope.addToHomeLink = !$scope.inFavorites ? SERVICE_LOC.addToHomeLink + $routeParams.fname : null;
                     });
                 } else {
                     var portlets = $.grep($rootScope.layout, function (e) {
@@ -181,9 +184,9 @@ define(['angular', 'jquery'], function(angular, $) {
             };
 
             $scope.inFavorites = this.inLayout();
+            $scope.addToHomeLink = !$scope.inFavorites ? SERVICE_LOC.addToHomeLink + $routeParams.fname : null;
         }]);
 
     return app;
 
 });
-

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
@@ -66,7 +66,6 @@ define(['angular', 'jquery'], function(angular, $) {
         'layoutService',
         'miscService',
         'sharedPortletService',
-        'SERVICE_LOC',
         function ($modal,
                   $location,
                   $sessionStorage,
@@ -75,8 +74,7 @@ define(['angular', 'jquery'], function(angular, $) {
                   $scope,
                   layoutService,
                   miscService,
-                  sharedPortletService,
-                  SERVICE_LOC) {
+                  sharedPortletService) {
 
             miscService.pushPageview();
             $scope.portlet = sharedPortletService.getProperty() || {};
@@ -171,7 +169,6 @@ define(['angular', 'jquery'], function(angular, $) {
                             return e.fname === $routeParams.fname
                         });
                         $scope.inFavorites = portlets.length > 0; //change scope variable to trigger apply
-                        $scope.addToHomeLink = !$scope.inFavorites ? SERVICE_LOC.addToHomeLink + $routeParams.fname : null;
                     });
                 } else {
                     var portlets = $.grep($rootScope.layout, function (e) {
@@ -184,7 +181,6 @@ define(['angular', 'jquery'], function(angular, $) {
             };
 
             $scope.inFavorites = this.inLayout();
-            $scope.addToHomeLink = !$scope.inFavorites ? SERVICE_LOC.addToHomeLink + $routeParams.fname : null;
         }]);
 
     return app;

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
@@ -1,5 +1,5 @@
 <div class="row portlet-frame static-content"  ng-controller="ExclusiveContentController as exclusiveContentCtrl">
-  <div role="banner" class="portlet-header">
+  <div role="banner" class="app-header">
     <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
     <h1><span><portlet-icon></portlet-icon> {{::portlet.title }}</span></h1>
     <span class="dropdown" dropdown on-toggle="toggled(open)">

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-exclusive.html
@@ -1,21 +1,21 @@
 <div class="row portlet-frame static-content"  ng-controller="ExclusiveContentController as exclusiveContentCtrl">
-  <div role="banner" class="app-header">
-    <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
-    <h1><span><portlet-icon></portlet-icon> {{::portlet.title }}</span></h1>
-    <span class="dropdown" dropdown on-toggle="toggled(open)">
-      <a href class="dropdown-toggle" dropdown-toggle>
-        <i class="fa fa-cog"></i>
-      </a>
-      <ul class="dropdown-menu">
-        <li role="presentation" class="fname-{{::portlet.fname}}" ng-class='{hidden : inFavorites}'>
-            <a ng-click="exclusiveContentCtrl.addToHome(portlet)" href='javascript:;'><span>Add to home</span></a>
+  <script type="text/ng-template" id="static-content-options.html">
+    <div ng-controller="StaticContentController as staticContentCtrl">
+      <ul>
+        <li role="presentation" class="fname-{{::portlet.fname}}" ng-hide='inFavorites'>
+            <a ng-click="staticContentCtrl.addToHome(portlet)" href='javascript:;'><span>Add to home</span></a>
         </li>
         <li role="presentation">
             <a ng-click="openRating('sm',portlet.fname, portlet.title)" href='javascript:;'><span>Rate this App</span></a>
         </li>
       </ul>
-    </span>
-  </div>
+    </div>
+  </script>
+
+  <app-header-two-way-bind
+  app-title="portlet.title"
+  app-icon="portlet.faIcon"
+  app-option-template="'static-content-options.html'"></app-header-two-way-bind>
   <div role="main" class="col-xs-12 no-padding portlet-body">
     <div data-loading class='loading-gif abs-bottom-right'><img src="img/ajax-loader.gif" alt="Loading content, please wait"></div>
 	  <div ng-bind-html="portlet.exclusiveContent" class="up-portlet-content-wrapper" id="content-{{::portlet.nodeId}}">

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-max.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-max.html
@@ -1,11 +1,6 @@
 <div class="row portlet-frame static-content"  ng-controller="StaticContentController as staticContentCtrl">
-  <div role="banner" class="app-header">
-    <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
-    <h1><span><portlet-icon></portlet-icon> {{::portlet.title }}</span></h1>
-    <span class="dropdown" dropdown on-toggle="toggled(open)">
-      <a href class="dropdown-toggle" dropdown-toggle aria-label="Settings">
-        <i class="fa fa-cog"></i>
-      </a>
+  <script type="text/ng-template" id="static-content-options.html">
+    <div ng-controller="StaticContentController as staticContentCtrl">
       <ul class="dropdown-menu">
         <li role="presentation" class="fname-{{::portlet.fname}}" ng-class='{hidden : inFavorites}'>
             <a ng-click="staticContentCtrl.addToHome(portlet)" href='javascript:;'><span>Add to home</span></a>
@@ -14,8 +9,14 @@
             <a ng-click="openRating('sm',portlet.fname, portlet.title)" href='javascript:;'><span>Rate this App</span></a>
         </li>
       </ul>
-    </span>
-  </div>
+    </div>
+  </script>
+
+  <app-header-two-way-bind
+  app-title="portlet.title"
+  app-icon="portlet.faIcon"
+  app-option-template="'static-content-options.html'"></app-header-two-way-bind>
+
   <div role="main" class="col-xs-12 no-padding portlet-body">
     <loading-gif data-object='loading'></loading-gif>
 	  <div ng-bind-html="::portlet.staticContent" class="up-portlet-content-wrapper" id="content-{{::portlet.nodeId}}">

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-max.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-max.html
@@ -1,5 +1,5 @@
 <div class="row portlet-frame static-content"  ng-controller="StaticContentController as staticContentCtrl">
-  <div role="banner" class="portlet-header">
+  <div role="banner" class="app-header">
     <img class="header-image" ng-src="{{$storage.homeImg}}" alt="UW Campus cover image">
     <h1><span><portlet-icon></portlet-icon> {{::portlet.title }}</span></h1>
     <span class="dropdown" dropdown on-toggle="toggled(open)">

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-max.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/partials/static-content-max.html
@@ -1,8 +1,8 @@
 <div class="row portlet-frame static-content"  ng-controller="StaticContentController as staticContentCtrl">
   <script type="text/ng-template" id="static-content-options.html">
     <div ng-controller="StaticContentController as staticContentCtrl">
-      <ul class="dropdown-menu">
-        <li role="presentation" class="fname-{{::portlet.fname}}" ng-class='{hidden : inFavorites}'>
+      <ul>
+        <li role="presentation" class="fname-{{::portlet.fname}}"  ng-hide='inFavorites'>
             <a ng-click="staticContentCtrl.addToHome(portlet)" href='javascript:;'><span>Add to home</span></a>
         </li>
         <li role="presentation">

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -4,7 +4,7 @@
               app-icon="fa-home">
   </app-header>
   <div class="mp-header">
-    <span class="fa fa-search mp-search-icon"></span><input type="text" class="marketplace-search" placeholder="What are you looking for?" ng-model="searchText" select-on-page-load aria-label="Search bar enter the app you are looking for">
+    <input type="text" class="marketplace-search" placeholder="What are you looking for?" ng-model="searchText" select-on-page-load aria-label="Search bar enter the app you are looking for">
   </div>
   <div class="mp-opaque">
     <ul>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -1,6 +1,6 @@
 
 <div ng-controller="MarketplaceController as marketplaceCtrl" class="row portlet-frame marketplace col-xs-12 col-md-12 no-padding">
-  <div role="banner" class="portlet-header mp-header">
+  <div role="banner" class="app-header mp-header">
     <img class="header-image" src="img/terrace.jpg" alt="Chairs at the Union Terrace">
     <h1>Search<span class='hidden-xs'> and Browse</span> {{NAMES.title}}</h1>
     <p class="portlet-description"></p>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -1,17 +1,17 @@
 
 <div ng-controller="MarketplaceController as marketplaceCtrl" class="row portlet-frame marketplace col-xs-12 col-md-12 no-padding">
-  <div role="banner" class="app-header mp-header">
-    <img class="header-image" src="img/terrace.jpg" alt="Chairs at the Union Terrace">
-    <h1>Search<span class='hidden-xs'> and Browse</span> {{NAMES.title}}</h1>
-    <p class="portlet-description"></p>
+  <app-header app-title="Browse {{NAMES.title}}" 
+              app-icon="fa-home">
+  </app-header>
+  <div class="mp-header">
     <span class="fa fa-search mp-search-icon"></span><input type="text" class="marketplace-search" placeholder="What are you looking for?" ng-model="searchText" select-on-page-load aria-label="Search bar enter the app you are looking for">
-    <div class="header-opaque mp-opaque">
-      <ul>
-        <li ng-click="selectFilter('popular','')" ng-class="{true:'selected-filter'}[selectedFilter === 'popular']"><a href="#" aria-label="search from the most popular apps">Most Popular</a></li>
-        <li ng-click="selectFilter('az','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'az']"><a href="#" aria-label="search by alphabetical order">A-Z</a></li>
-        <li ng-click="selectFilter('category','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'category']"><a href="#" aria-label="search by categories">Categories</a></li>
-      </ul>
-    </div>
+  </div>
+  <div class="mp-opaque">
+    <ul>
+      <li ng-click="selectFilter('popular','')" ng-class="{true:'selected-filter'}[selectedFilter === 'popular']"><a href="#" aria-label="search from the most popular apps">Most Popular</a></li>
+      <li ng-click="selectFilter('az','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'az']"><a href="#" aria-label="search by alphabetical order">A-Z</a></li>
+      <li ng-click="selectFilter('category','')" ng-class="{true: 'selected-filter'}[selectedFilter === 'category']"><a href="#" aria-label="search by categories">Categories</a></li>
+    </ul>
   </div>
   <div class="show-all-div">
     <p><span ng-if="portlets.length > 0">Showing {{ (portlets | filter:searchTermFilter | showApplicable:showAll | showCategory:categoryToShow).length }} of {{ portlets.length }} results in {{NAMES.title}}.</span>

--- a/angularjs-portal-mock-portal/src/main/webapp/web/session.json
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/session.json
@@ -1,1 +1,1 @@
-{"person":{"userName":"bucky","sessionKey":"b5bkz6kb","serverName":"e8dedbcb38f4","displayName":"Bucky Badger","version":"4.1.1.24"}}
+{"person":{"firstName": "Bucky", "lastName": "Badger", "userName":"bucky","sessionKey":"b5bkz6kb","serverName":"e8dedbcb38f4","displayName":"Bucky Badger","version":"4.2.1.1"}}


### PR DESCRIPTION
https://github.com/UW-Madison-DoIT/uw-frame/pull/111 is required for this change. Please review that first.

This utilizes the new changes from `uw-frame`.

Changed the following pages to use the new app-header directive:
+ marketplace header 
+ home header
+ search results
+ static
+ exclusive

![http://goo.gl/rqMN4P](http://goo.gl/rqMN4P)
![http://goo.gl/MTHJuA](http://goo.gl/MTHJuA)
![http://goo.gl/RpqaIA](http://goo.gl/RpqaIA)
![http://goo.gl/hFK5Yb](http://goo.gl/hFK5Yb)
![http://goo.gl/bVJJEM](http://goo.gl/bVJJEM)

+ Note that the add to home action link doesn't work for the static page due to the way that was implemented. I added it to the options menu for now, we can make that better later.