### PR TITLE
MUMUP-2139 : angulartics impl for angularjs-portal

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -264,9 +264,6 @@ define(['angular', 'jquery'], function(angular, $) {
                         console.log("Something is weird, resetting to default layout view");
                         $scope.switchMode(APP_FLAGS.defaultView);
                     }
-                } else {
-                    //all is well, ga pageview, go
-                    miscService.pushPageview();
                 }
             };
             this.init();

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
@@ -11,7 +11,6 @@ define(['angular', 'jquery'], function(angular, $) {
                                                   '$rootScope',
                                                   '$scope',
                                                   'layoutService',
-                                                  'miscService',
                                                   'sharedPortletService',
                                                   function ($modal,
                                                             $location,
@@ -20,9 +19,7 @@ define(['angular', 'jquery'], function(angular, $) {
                                                             $rootScope,
                                                             $scope,
                                                             layoutService,
-                                                            miscService,
                                                             sharedPortletService) {
-        miscService.pushPageview();
         $scope.portlet = sharedPortletService.getProperty() || {};
         var that = this;
         that.getPortlet = function (fname, portlets) {
@@ -64,7 +61,6 @@ define(['angular', 'jquery'], function(angular, $) {
         '$rootScope',
         '$scope',
         'layoutService',
-        'miscService',
         'sharedPortletService',
         function ($modal,
                   $location,
@@ -73,10 +69,7 @@ define(['angular', 'jquery'], function(angular, $) {
                   $rootScope,
                   $scope,
                   layoutService,
-                  miscService,
                   sharedPortletService) {
-
-            miscService.pushPageview();
             $scope.portlet = sharedPortletService.getProperty() || {};
             $scope.loading = [];
             var that = this;

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -98,9 +98,6 @@ define(['angular', 'jquery'], function(angular, $) {
             marketplaceService.initialFilter("");
         }
         $scope.searchText = $scope.searchTerm;
-        //TODO : Needed so search term is published, but don't want double page view...
-        miscService.pushPageview($scope.searchTerm);
-
         var initFilter = false;
         //delay on the filter
         $scope.$watch('searchText', function (val) {

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -3,22 +3,22 @@
 define(['angular', 'jquery'], function(angular, $) {
 
     var app = angular.module('my-app.marketplace.controllers', []);
-    
-    app.controller('marketplaceCommonFunctions', 
-      ['layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage', 
+
+    app.controller('marketplaceCommonFunctions',
+      ['layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage',
        '$rootScope', '$scope', '$modal', '$routeParams', '$timeout',
-       function(layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage, 
+       function(layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage,
         $rootScope, $scope, $modal, $routeParams, $timeout){
       $scope.goToDetails = function(fname){
           $location.path("apps/" + fname );
       };
-      
+
       $scope.isStatic = function(portlet) {
         return portlet.maxUrl.indexOf('portal') !== -1 //max url is a portal hit
                 && portlet.portletName // there is a portletName
                 && portlet.portletName.indexOf('cms') != -1; //the portlet is static content portlet
       }
-      
+
       $scope.addToHome = function addToHome(portlet) {
           var fname = portlet.fname;
           var ret = layoutService.addToHome(portlet);
@@ -37,7 +37,7 @@ define(['angular', 'jquery'], function(angular, $) {
                   $('.fname-'+fname).parent().append('<span>Issue adding to home, please try again later</span>');
               });
       };
-      
+
       $scope.openRating = function (size, fname, name) {
           var modalInstance = $modal.open({
               templateUrl: 'ratingModal.html',
@@ -54,7 +54,7 @@ define(['angular', 'jquery'], function(angular, $) {
               console.log('Modal dismissed at: ' + new Date());
           });
       };
-      
+
       $scope.searchTermFilter = function(portlet) {
         return marketplaceService.portletMatchesSearchTerm(portlet, $scope.searchTerm, {
             searchDescription: true,
@@ -62,7 +62,7 @@ define(['angular', 'jquery'], function(angular, $) {
             defaultReturn : true
         });
       };
-      
+
       $scope.selectFilter = function (filter,category) {
           $scope.sortParameter = filter;
           $scope.categoryToShow = category;
@@ -80,15 +80,15 @@ define(['angular', 'jquery'], function(angular, $) {
               $scope.sortParameter = 'name';
               $scope.showCategories = true;
           }
-        
+
           miscService.pushGAEvent('Marketplace','Tab Select',filter);
 
       };
-      
+
       $scope.toggleShowAll = function() {
           $scope.showAll = !$scope.showAll;
       };
-      
+
       this.setupSearchTerm = function() {
         var tempFilterText = '', filterTextTimeout;
         $scope.searchTerm = marketplaceService.getInitialFilter();
@@ -98,8 +98,9 @@ define(['angular', 'jquery'], function(angular, $) {
             marketplaceService.initialFilter("");
         }
         $scope.searchText = $scope.searchTerm;
+        //TODO : Needed so search term is published, but don't want double page view...
         miscService.pushPageview($scope.searchTerm);
-        
+
         var initFilter = false;
         //delay on the filter
         $scope.$watch('searchText', function (val) {
@@ -116,7 +117,7 @@ define(['angular', 'jquery'], function(angular, $) {
             }, 250); // delay 250 ms
         });
       };
-      
+
       this.initializeConstants = function(){
         //initialize constants
         $scope.webSearchUrl = MISC_URLS.webSearchURL;
@@ -132,13 +133,13 @@ define(['angular', 'jquery'], function(angular, $) {
 
     var currentPage = 'market';
     var currentCategory = '';
-    
+
     app.controller('MarketplaceController', [
         '$scope', '$controller', 'marketplaceService',
         function($scope, $controller, marketplaceService) {
-            
+
             var base = $controller('marketplaceCommonFunctions', { $scope : $scope });
-            
+
             var init = function(){
               //init variables
               $scope.portlets = [];
@@ -146,11 +147,11 @@ define(['angular', 'jquery'], function(angular, $) {
                   $scope.portlets = data.portlets;
                   $scope.categories = data.categories;
               });
-              
+
               base.setupSearchTerm();
-              
+
               //initialize variables
-              
+
               $scope.searchResultLimit = 20;
               $scope.showAll = false;
               if(currentPage === 'details') {
@@ -178,10 +179,10 @@ define(['angular', 'jquery'], function(angular, $) {
                   // Hide category selection div by default
                   $scope.showCategories = false;
               }
-              
+
               base.initializeConstants();
             };
-            
+
             //run functions
             init();
         } ]);
@@ -216,9 +217,9 @@ define(['angular', 'jquery'], function(angular, $) {
     });
 
     app.controller('MarketplaceDetailsController', [
-        '$controller', '$scope', 'marketplaceService', 'miscService',
-        function($controller, $scope, marketplaceService, miscService) {
-          
+        '$controller', '$scope', 'marketplaceService',
+        function($controller, $scope, marketplaceService) {
+
           $controller('marketplaceCommonFunctions', { $scope : $scope });
 
           $scope.specifyCategory = function(category) {
@@ -227,7 +228,6 @@ define(['angular', 'jquery'], function(angular, $) {
           }
           // init
           var init = function(){
-            miscService.pushPageview();
             $scope.loading = true;
             $scope.obj = [];
             $scope.errorMessage = 'There was an issue loading details, please click back to apps.';

--- a/angularjs-portal-home/src/main/webapp/my-app/search/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/routes.js
@@ -3,7 +3,8 @@ define(['require'], function(require){
     return {
         search: {
             templateUrl: require.toUrl('./partials/search-results.html'),
-            controller: 'SearchResultController'
+            controller: 'SearchResultController',
+            searchParam: 'initFilter'
         }
     }
 

--- a/angularjs-portal-mock-portal/src/main/webapp/Login
+++ b/angularjs-portal-mock-portal/src/main/webapp/Login
@@ -1,0 +1,4 @@
+{
+  "status" : "success",
+  "username" : "bucky"
+}


### PR DESCRIPTION
Depends on https://github.com/UW-Madison-DoIT/uw-frame/pull/134 being merged.
+ Removes all `miscService.pushPageview` hits (this happens anytime the route changes now)
+ Configures the search result page to be successful for GA Site Search
+ Unrelated changes: white space (I blame atom), added a `/portal/Login` success page in mock so you don't get redirected to `/portal/Login` every time you hit `/web`