### PR TITLE
Wisc directory results

### DIFF
--- a/angularjs-portal-home/src/main/resources/endpoint.properties.example
+++ b/angularjs-portal-home/src/main/resources/endpoint.properties.example
@@ -45,3 +45,5 @@ uwmadisonreddit.uri=https://www.reddit.com/r/uwmadison/hot.json
 uwmadisonreddit.username=
 uwmadisonreddit.password=
 uwmadisonreddit.attributes=
+
+wiscdirectory.uri=http://www.wisc.edu/directories/json

--- a/angularjs-portal-home/src/main/resources/endpoint.properties.example
+++ b/angularjs-portal-home/src/main/resources/endpoint.properties.example
@@ -47,3 +47,5 @@ uwmadisonreddit.password=
 uwmadisonreddit.attributes=
 
 wiscdirectory.uri=http://www.wisc.edu/directories/json
+
+wiscedusearch.uri=http://ajax.googleapis.com/ajax/services/search/web

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -8,18 +8,17 @@
   hr {
     margin: 0;
   }
-  h4.header {
+  h4.header, .seeMoreResults {
     margin: 10px 0 1px;
   }
   .search-results-container {
     padding:20px 10px 0px 20px;
-  }
+  } 
   .result {
     
     padding: 5px 0 5px;
     
     h4 {
-      color:@color1;
       font-weight:400;
       margin-bottom:0px;
     }

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -13,6 +13,10 @@
   }
   .search-results-container {
     padding:20px 10px 0px 20px;
+
+    .moreDetails{
+      padding-top:5px;
+    }
   } 
   .result {
     

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -33,7 +33,8 @@ define(['angular'], function(angular) {
             'groupURL' : '/portal/api/groups',
             'kvURL' : '/storage/',
             'googleSearchURL' : '/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m',
-            'loginSilentURL' : '/portal/Login?silent=true'
+            'loginSilentURL' : '/portal/Login?silent=true',
+            'wiscDirectorySearchURL' : '/web/api/wiscdirectory'
         })
         .constant('NAMES', {
             'title' : 'MyUW',

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -41,8 +41,8 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
     }]);
     
     app.controller('SearchResultController', 
-     ['$scope', '$controller','marketplaceService', 'googleCustomSearchService',
-     function($scope, $controller,marketplaceService, googleCustomSearchService) {
+     ['$scope', '$controller','marketplaceService', 'googleCustomSearchService', 'wiscDirectorySearchService',
+     function($scope, $controller,marketplaceService, googleCustomSearchService, wiscDirectorySearchService) {
       var base = $controller('marketplaceCommonFunctions', {$scope : $scope});
 
       var initWiscEduSearch = function(){
@@ -56,10 +56,32 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         );
       };
 
+      var initWiscDirectorySearch = function(){
+          wiscDirectorySearchService.wiscDirectorySearch($scope.searchTerm).then(
+            function(results){
+              if(results){
+                if(results.records && results.count) {
+                  $scope.wiscDirectoryResults = results.records;
+                  $scope.wiscDirectoryResultCount = results.count;
+                }
+                if(results.errors && results.errors[0] && results.errors[0].code && results.errors[1] && results.errors[1].error_msg){
+                    if(results.errors[0].code == 4){
+                        $scope.wiscDirectoryTooManyResults = true;
+                    }
+                    $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
+                }
+              }
+            }
+          );
+        };
+
       var init = function(){
         $scope.sortParameter = ['-rating','-userRated'];
         $scope.myuwResults = [];
         $scope.googleResults = [];
+        $scope.wiscDirectoryResults = [];
+        $scope.wiscDirectoryResultCount = 0;
+        $scope.wiscDirectoryTooManyResults = false;
         $scope.googleResultsEstimatedCount = 0;
         $scope.totalCount = 0;
         $scope.searchResultLimit = 20;
@@ -78,12 +100,18 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           if($scope.myuwFilteredResults){
             $scope.totalCount+= parseInt($scope.myuwFilteredResults.length);
           }
+          if($scope.wiscDirectoryResultCount){
+              $scope.totalCount+= parseInt($scope.wiscDirectoryResultCount);
+            }
         });
       };
       init();
       if(googleCustomSearchService.googleSearchEnabled()){
         initWiscEduSearch();
       }
+      if(wiscDirectorySearchService.wiscDirectorySearchEnabled()){
+          initWiscDirectorySearch();
+        }
     }]);
 
     return app;

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -94,7 +94,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         marketplaceService.getPortlets().then(function(data) {
             $scope.myuwResults = data.portlets;
         });
-        $scope.$watchGroup(['googleResultsEstimatedCount','myuwFilteredResults.length'], function(){
+        $scope.$watchGroup(['googleResultsEstimatedCount','myuwFilteredResults.length', 'wiscDirectoryResultCount'], function(){
           $scope.totalCount = 0;
           if($scope.googleResultsEstimatedCount) {
             $scope.totalCount+= parseInt($scope.googleResultsEstimatedCount);

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -50,30 +50,32 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           function(results){
             if(results && results.responseData && results.responseData.results) {
               $scope.googleResults = results.responseData.results;
-              $scope.googleResultsEstimatedCount = results.responseData.cursor.estimatedResultCount;
+              if(results.responseData.cursor.estimatedResultCount){
+                $scope.googleResultsEstimatedCount = results.responseData.cursor.estimatedResultCount;
+              }
             }
           }
         );
       };
 
       var initWiscDirectorySearch = function(){
-          wiscDirectorySearchService.wiscDirectorySearch($scope.searchTerm).then(
-            function(results){
-              if(results){
-                if(results.records && results.count) {
-                  $scope.wiscDirectoryResults = results.records;
-                  $scope.wiscDirectoryResultCount = results.count;
+        wiscDirectorySearchService.wiscDirectorySearch($scope.searchTerm).then(
+          function(results){
+            if(results){
+              if(results.records && results.count) {
+                $scope.wiscDirectoryResults = results.records;
+                $scope.wiscDirectoryResultCount = results.count;
+              }
+              if(results.errors && results.errors[0] && results.errors[0].code && results.errors[1] && results.errors[1].error_msg){
+                if(results.errors[0].code == 4){
+                  $scope.wiscDirectoryTooManyResults = true;
                 }
-                if(results.errors && results.errors[0] && results.errors[0].code && results.errors[1] && results.errors[1].error_msg){
-                    if(results.errors[0].code == 4){
-                        $scope.wiscDirectoryTooManyResults = true;
-                    }
-                    $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
-                }
+                $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
               }
             }
-          );
-        };
+          }
+        );
+      };
 
       var init = function(){
         $scope.sortParameter = ['-rating','-userRated'];
@@ -101,8 +103,8 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
             $scope.totalCount+= parseInt($scope.myuwFilteredResults.length);
           }
           if($scope.wiscDirectoryResultCount){
-              $scope.totalCount+= parseInt($scope.wiscDirectoryResultCount);
-            }
+            $scope.totalCount+= parseInt($scope.wiscDirectoryResultCount);
+          }
         });
       };
       init();
@@ -110,8 +112,8 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         initWiscEduSearch();
       }
       if(wiscDirectorySearchService.wiscDirectorySearchEnabled()){
-          initWiscDirectorySearch();
-        }
+        initWiscDirectorySearch();
+      }
     }]);
 
     return app;

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -7,9 +7,9 @@
       <li>
         <a>MyUW ({{myuwFilteredResults.length}})</a>
       </li>
-      <!-- <li>
-        <a>Directory (#)</a>
-      </li> -->
+      <li>
+        <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
+      </li>
       <li>
         <a>Wisc.edu ({{googleResultsEstimatedCount}})</a>
       </li>
@@ -44,6 +44,30 @@
              >Load More MyUW Results</button>
     </div>
   </div>
+  
+  <!--wisc directory results-->
+  <div id="wisc-edu-results" class='search-results-container' ng-show="(wiscDirectoryResults && wiscDirectoryResults.length > 0) || wiscDirectoryTooManyResults">
+    <h4 class='header'>Directory</h4>
+    <hr>
+    <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryTooManyResults'></loading-gif>
+    <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">
+      <h4>{{item.fullName}}</h4>
+      <p>
+        <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
+        <span ng-if="item.formalName">Also known as {{item.formalName}}</span>
+      </p>
+    </div>
+    <div class="seeMoreResults">
+      <p ng-if="wiscDirectoryResultCount>0">
+        <a href="#">See all {{wiscDirectoryResultCount}} directory results</a>
+      </p>
+      <p ng-if="wiscDirectoryTooManyResults">
+          {{wiscDirectoryErrorMessage}}
+        </p>
+    </div>
+        
+  </div>
+  
   <!--wisc.edu results-->
   <div id="wisc-edu-results" class='search-results-container' ng-show="googleResults && googleResults.length > 0">
     <h4 class='header'>Wisc.edu</h4>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -52,16 +52,38 @@
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryTooManyResults'></loading-gif>
     <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">
       <h4>{{item.fullName}}</h4>
+      <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
       <p>
-        <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
-        <span ng-if="item.formalName">Also known as {{item.formalName}}</span>
+        <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a> 
+        <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
       </p>
+      <div ng-if="showingDetails" class="result">
+        <div ng-if="item.address" class="moreDetails">
+          <p>{{item.address.room}}</p>
+          <p>{{item.address.streetAddress}}</p>
+          <p>{{item.address.cityStateZip}}</p>
+        </div>
+        <div ng-repeat="title in item.titles" class="moreDetails">
+          <p>Title: {{title.title}}</p>
+          <p>Division: {{title.division}}</p>
+          <p>Department: {{title.department}}</p>
+          <p>Unit: {{title.subdepartment}}</p>
+        </div>
+      </div>
+      <div ng-click="showingDetails=!showingDetails">
+        <p>
+          <a href="javascript:;" ng-if="item.titles[0] || item.address">
+            <span ng-if="!showingDetails">See More</span>
+            <span ng-if="showingDetails">See Less</span>
+          </a>
+        </p>
+      </div>
     </div>
     <div class="seeMoreResults">
       <p ng-if="wiscDirectoryResultCount>0">
         <a href="#">See all {{wiscDirectoryResultCount}} directory results</a>
       </p>
-      <p ng-if="wiscDirectoryTooManyResults">
+      <p ng-if="wiscDirectoryErrorMessage">
           {{wiscDirectoryErrorMessage}}
         </p>
     </div>
@@ -85,4 +107,24 @@
       <h4><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on wisc.edu</a></h4>
     </div>
   </div>
+
+  
+  <!-- No search results found -->
+  <div id="no-results" class="search-results-container" ng-show="totalCount === 0">
+    <p><strong>No matches.</strong></p>
+    <p>Suggestions:</p>
+    <p ng-if="kbSearchUrl">
+      Search the <a ng-href="{{kbSearchUrl}}{{searchText}}" target="_blank">KnowledgeBase</a>
+    </p>
+    <p ng-if="eventsSearchUrl">
+      Look for <a ng-href="{{eventsSearchUrl}}{{searchText}}" target="_blank">events</a>
+    </p>
+    <p ng-if="helpdeskUrl">
+      Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank">Help Desk</a>
+    </p>
+    <p ng-if="feedbackUrl">
+      <a ng-href="{{feedbackUrl}}" target="_blank">Give feedback </a>on MyUW search
+    </p>
+  </div>
 </div>
+>>>>>>> 3990580... Adds a see more for more details on initial page

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -46,7 +46,7 @@
   </div>
   
   <!--wisc directory results-->
-  <div id="wisc-edu-results" class='search-results-container' ng-show="(wiscDirectoryResults && wiscDirectoryResults.length > 0) || wiscDirectoryTooManyResults">
+  <div id="wisc-directory-results" class='search-results-container' ng-show="(wiscDirectoryResults && wiscDirectoryResults.length > 0) || wiscDirectoryTooManyResults">
     <h4 class='header'>Directory</h4>
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryTooManyResults'></loading-gif>
@@ -107,7 +107,6 @@
       <h4><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on wisc.edu</a></h4>
     </div>
   </div>
-
   
   <!-- No search results found -->
   <div id="no-results" class="search-results-container" ng-show="totalCount === 0">
@@ -127,4 +126,3 @@
     </p>
   </div>
 </div>
->>>>>>> 3990580... Adds a see more for more details on initial page

--- a/angularjs-portal-home/src/main/webapp/my-app/search/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/services.js
@@ -33,4 +33,33 @@ define(['angular', 'jquery'], function(angular, $) {
       
     }]);
     
+    app.factory('wiscDirectorySearchService', ['$http', 'miscService', 'SERVICE_LOC', function($http, miscService, SERVICE_LOC){
+        
+        function wiscDirectorySearch(term) {
+          return $http.get(SERVICE_LOC.wiscDirectorySearchURL + "/?name=" + term).then(
+            function(response){
+              return response.data;
+            },
+            function(response){
+              console.log("error searching the wisc diretory: " +  response.status);
+            }
+          );
+        }
+        
+        function wiscDirectorySearchEnabled() {
+          if(SERVICE_LOC.wiscDirectorySearchURL) {
+            return true;
+          } else {
+            return false;
+          }
+        }
+        
+        return {
+          wiscDirectorySearch : wiscDirectorySearch,
+          wiscDirectorySearchEnabled : wiscDirectorySearchEnabled
+        };
+        
+        
+      }]);
+    
 });


### PR DESCRIPTION
## With Directory Results
### With no directory results present
![image](https://cloud.githubusercontent.com/assets/5521429/12678583/161c4e1c-c665-11e5-8c23-98adc9b41987.png)
### With some directory results present
![image](https://cloud.githubusercontent.com/assets/5521429/12678607/3693041a-c665-11e5-8e8c-070f21debaf7.png)
### With some directory results present and MyUW Results
![image](https://cloud.githubusercontent.com/assets/5521429/12678928/ee446ed6-c666-11e5-87ee-7761a6e07fe1.png)
### See more link
So I changed the order of the display items a little bit from the [mockups](https://docs.google.com/presentation/d/18OzygRCY4npTOu_tnBgUogLitto0kjWMRRz1t7Cn8dQ/edit#slide=id.g74158e4a7_0_30) and I added in a see more link.  Both things that we can change @keirserrie 
![image](https://cloud.githubusercontent.com/assets/5521429/12678964/1ca7fd9c-c667-11e5-89a4-f4fd02dbf2dc.png)

## Added the zero search result state
### Before
Also fixed the bug where zero wisc domain results had empty number
![image](https://cloud.githubusercontent.com/assets/5521429/12679032/75b4d126-c667-11e5-96a1-db1749ae7d19.png)
### After
![image](https://cloud.githubusercontent.com/assets/5521429/12679050/9547168e-c667-11e5-9043-e396d3c2db89.png)