### PR TITLE
Filter search results

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -8,6 +8,11 @@
   hr {
     margin: 0;
   }
+  .inner-nav-container .inner-nav li {
+    &:focus {
+      outline:0;
+    }
+  }
   h4.header, .seeMoreResults {
     margin: 10px 0 1px;
   }

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -79,8 +79,6 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
       
       $scope.filterTo = function(filterName) {
         $('.search-results .inner-nav li').removeClass('active');
-        console.log('working');
-        console.log(filterName);
         if (filterName == 'all') {
           $('#all-selector').addClass('active');
           $('#myuw-results').show();

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -76,6 +76,33 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           }
         );
       };
+      
+      $scope.filterTo = function(filterName) {
+        $('.search-results .inner-nav li').removeClass('active');
+        console.log('working');
+        console.log(filterName);
+        if (filterName == 'all') {
+          $('#all-selector').addClass('active');
+          $('#myuw-results').show();
+          $('#wisc-directory-results').show();
+          $('#wisc-edu-results').show();
+        } else if (filterName == 'myuw') {
+          $('#myuw-selector').addClass('active');
+          $('#myuw-results').show();
+          $('#wisc-directory-results').hide();
+          $('#wisc-edu-results').hide();
+        } else if (filterName == 'directory') {
+          $('#directory-selector').addClass('active');
+          $('#wisc-directory-results').show();
+          $('#myuw-results').hide();
+          $('#wisc-edu-results').hide();
+        } else if (filterName == 'google') {
+          $('#google-selector').addClass('active');
+          $('#wisc-edu-results').show();
+          $('#myuw-results').hide();
+          $('#wisc-directory-results').hide();
+        }
+      };
 
       var init = function(){
         $scope.sortParameter = ['-rating','-userRated'];

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -1,16 +1,16 @@
 <div class="row search-results">
   <div class="inner-nav-container">
     <ul class="inner-nav">
-      <li class="active">
+      <li class="active" ng-click="filterTo('all')" id="all-selector">
         <a>All ({{ totalCount }})</a>
       </li>
-      <li>
+      <li ng-click="filterTo('myuw')" id="myuw-selector">
         <a>MyUW ({{myuwFilteredResults.length}})</a>
       </li>
-      <li>
+      <li ng-click="filterTo('directory')" id="directory-selector">
         <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
       </li>
-      <li>
+      <li ng-click="filterTo('google')" id="google-selector">
         <a>Wisc.edu ({{googleResultsEstimatedCount}})</a>
       </li>
     </ul>


### PR DESCRIPTION
Filters work on the search results page. I used jQuery to do this, because it seemed like the easiest option.

Room for improvement: 
- Loading state. Initial load takes 5-7 seconds to get results, but doesn't show the user that more results are coming. 
- We might want to show a 'No results' paragraph for each section, so that when you filter it to, say, MyUW results and there are none, it isn't blank.

We can try to get these improvements in before releasing tomorrow, but I think we should at least get this in.

![screen recording 2016-02-02 at 02 44 pm](https://cloud.githubusercontent.com/assets/1919535/12763710/8d693a1c-c9bb-11e5-8b76-c022161f595f.gif)
