### PR TITLE
Tweaks on search results polish

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -48,6 +48,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
       var initWiscEduSearch = function(){
         googleCustomSearchService.googleSearch($scope.searchTerm).then(
           function(results){
+            $scope.googleSearchLoading = false;
             if(results && results.responseData && results.responseData.results) {
               $scope.googleResults = results.responseData.results;
               if(results.responseData.cursor.estimatedResultCount){
@@ -61,6 +62,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
       var initWiscDirectorySearch = function(){
         wiscDirectorySearchService.wiscDirectorySearch($scope.searchTerm).then(
           function(results){
+            $scope.directorySearchLoading = false;
             if(results){
               if(results.records && results.count) {
                 $scope.wiscDirectoryResults = results.records;
@@ -139,9 +141,11 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
       };
       init();
       if(googleCustomSearchService.googleSearchEnabled()){
+        $scope.googleSearchLoading = true;
         initWiscEduSearch();
       }
       if(wiscDirectorySearchService.wiscDirectorySearchEnabled()){
+        $scope.directorySearchLoading = true;
         initWiscDirectorySearch();
       }
     }]);
@@ -149,4 +153,3 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
     return app;
 
 });
-

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -84,21 +84,25 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           $('#myuw-results').show();
           $('#wisc-directory-results').show();
           $('#wisc-edu-results').show();
+          $scope.activeFilter = "all";
         } else if (filterName == 'myuw') {
           $('#myuw-selector').addClass('active');
           $('#myuw-results').show();
           $('#wisc-directory-results').hide();
           $('#wisc-edu-results').hide();
+          $scope.activeFilter = "myuw";
         } else if (filterName == 'directory') {
           $('#directory-selector').addClass('active');
           $('#wisc-directory-results').show();
           $('#myuw-results').hide();
           $('#wisc-edu-results').hide();
+          $scope.activeFilter = "directory";
         } else if (filterName == 'google') {
           $('#google-selector').addClass('active');
           $('#wisc-edu-results').show();
           $('#myuw-results').hide();
           $('#wisc-directory-results').hide();
+          $scope.activeFilter = "google";
         }
       };
 
@@ -113,6 +117,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         $scope.totalCount = 0;
         $scope.searchResultLimit = 20;
         $scope.showAll = false;
+        $scope.activeFilter = "all";
         base.setupSearchTerm();
         base.initializeConstants();
         //get marketplace entries

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -23,7 +23,7 @@
     <hr ng-show="activeFilter == 'all'">
     <loading-gif data-object='myuwResults'></loading-gif>
     <div ng-show="myuwFilteredResults.length == 0" class='no-result'>
-      No MyUW results
+      No MyUW results. <a href="/web/apps">Try browsing instead?</a>
     </div>
     <div ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)" class="result">
       <h4><a href="{{::portlet.maxUrl}}" target="{{::portlet.target}}">{{ portlet.name }}</a></h4>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -20,7 +20,7 @@
     ng-show="myuwFilteredResults.length > 0 
     || activeFilter == 'myuw' ">
     <h4 class="header" ng-show="activeFilter == 'all'">MyUW</h4>
-    <hr>
+    <hr ng-show="activeFilter == 'all'">
     <loading-gif data-object='myuwResults'></loading-gif>
     <div ng-show="myuwFilteredResults.length == 0" class='no-result'>
       No MyUW results
@@ -56,7 +56,7 @@
     || wiscDirectoryTooManyResults 
     || activeFilter == 'directory'">
     <h4 class='header' ng-show="activeFilter == 'all'">Directory</h4>
-    <hr>
+    <hr ng-show="activeFilter == 'all'">
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
     <div ng-show="wiscDirectoryResults.length === 0 
                   && !wiscDirectoryTooManyResults" 
@@ -108,7 +108,7 @@
     ng-show="googleResults && googleResults.length > 0 
     || activeFilter == 'google'">
     <h4 class='header' ng-show="activeFilter == 'all'">Wisc.edu</h4>
-    <hr>
+    <hr ng-show="activeFilter == 'all'">
     <loading-gif data-object='googleResults'></loading-gif>
     <div ng-show="googleResults.length === 0" class='no-result'>
       No wisc.edu results

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -16,7 +16,9 @@
     </ul>
   </div>
 
-  <div id="myuw-results" class='search-results-container'>
+  <div id="myuw-results" class='search-results-container'
+    ng-show="myuwFilteredResults.length > 0 
+    || activeFilter == 'myuw' ">
     <h4 class="header">MyUW</h4>
     <hr>
     <loading-gif data-object='myuwResults'></loading-gif>
@@ -49,7 +51,10 @@
   </div>
 
   <!--wisc directory results-->
-  <div id="wisc-directory-results" class='search-results-container'>
+  <div id="wisc-directory-results" class='search-results-container'
+    ng-show="(wiscDirectoryResults && wiscDirectoryResults.length > 0) 
+    || wiscDirectoryTooManyResults 
+    || activeFilter == 'directory'">
     <h4 class='header'>Directory</h4>
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
@@ -97,7 +102,9 @@
   </div>
 
   <!--wisc.edu results-->
-  <div id="wisc-edu-results" class='search-results-container'>
+  <div id="wisc-edu-results" class='search-results-container'
+    ng-show="googleResults && googleResults.length > 0 
+    || activeFilter == 'google'">
     <h4 class='header'>Wisc.edu</h4>
     <hr>
     <loading-gif data-object='googleResults'></loading-gif>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -19,7 +19,7 @@
   <div id="myuw-results" class='search-results-container'
     ng-show="myuwFilteredResults.length > 0 
     || activeFilter == 'myuw' ">
-    <h4 class="header">MyUW</h4>
+    <h4 class="header" ng-show="activeFilter == 'all'">MyUW</h4>
     <hr>
     <loading-gif data-object='myuwResults'></loading-gif>
     <div ng-show="myuwFilteredResults.length == 0" class='no-result'>
@@ -55,7 +55,7 @@
     ng-show="(wiscDirectoryResults && wiscDirectoryResults.length > 0) 
     || wiscDirectoryTooManyResults 
     || activeFilter == 'directory'">
-    <h4 class='header'>Directory</h4>
+    <h4 class='header' ng-show="activeFilter == 'all'">Directory</h4>
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
     <div ng-show="wiscDirectoryResults.length === 0" class='no-result'>
@@ -105,7 +105,7 @@
   <div id="wisc-edu-results" class='search-results-container'
     ng-show="googleResults && googleResults.length > 0 
     || activeFilter == 'google'">
-    <h4 class='header'>Wisc.edu</h4>
+    <h4 class='header' ng-show="activeFilter == 'all'">Wisc.edu</h4>
     <hr>
     <loading-gif data-object='googleResults'></loading-gif>
     <div ng-show="googleResults.length === 0" class='no-result'>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -5,13 +5,16 @@
         <a>All ({{ totalCount }})</a>
       </li>
       <li ng-click="filterTo('myuw')" id="myuw-selector">
-        <a>MyUW ({{myuwFilteredResults.length}})</a>
+        <a>MyUW <span ng-hide="portletListLoading">({{myuwFilteredResults.length}})</span>
+        <i ng-show="portletListLoading" class="fa fa-spinner fa-pulse"></i></a>
       </li>
       <li ng-click="filterTo('directory')" id="directory-selector">
-        <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
+        <a>Directory <span ng-hide="directorySearchLoading">({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</span>
+        <i ng-show="directorySearchLoading" class="fa fa-spinner fa-pulse"></i></a>
       </li>
       <li ng-click="filterTo('google')" id="google-selector">
-        <a>Wisc.edu ({{googleResultsEstimatedCount}})</a>
+        <a>Wisc.edu <span ng-hide="googleSearchLoading">({{googleResultsEstimatedCount}})</span>
+        <i ng-show="googleSearchLoading" class="fa fa-spinner fa-pulse"></i></a>
       </li>
     </ul>
   </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -58,7 +58,9 @@
     <h4 class='header' ng-show="activeFilter == 'all'">Directory</h4>
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
-    <div ng-show="wiscDirectoryResults.length === 0" class='no-result'>
+    <div ng-show="wiscDirectoryResults.length === 0 
+                  && !wiscDirectoryTooManyResults" 
+         class='no-result'>
       No directory results
     </div>
     <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -46,7 +46,7 @@
               ng-click="searchResultLimit = searchResultLimit + 20;"
               hide-while-loading
               ng-show="myuwFilteredResults.length > searchResultLimit"
-             >Load More MyUW Results</button>
+             >Load more MyUW results</button>
     </div>
   </div>
 
@@ -86,8 +86,8 @@
       <div ng-click="showingDetails=!showingDetails">
         <p>
           <a href="javascript:;" ng-if="item.titles[0] || item.address">
-            <span ng-if="!showingDetails">See More</span>
-            <span ng-if="showingDetails">See Less</span>
+            <span ng-if="!showingDetails">See more</span>
+            <span ng-if="showingDetails">See less</span>
           </a>
         </p>
       </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -61,7 +61,7 @@
     <div ng-show="wiscDirectoryResults.length === 0 
                   && !wiscDirectoryTooManyResults" 
          class='no-result'>
-      No directory results
+      No directory results.
     </div>
     <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">
       <h4>{{item.fullName}}</h4>
@@ -111,7 +111,7 @@
     <hr ng-show="activeFilter == 'all'">
     <loading-gif data-object='googleResults'></loading-gif>
     <div ng-show="googleResults.length === 0" class='no-result'>
-      No wisc.edu results
+      No wisc.edu results.
     </div>
     <div ng-repeat="item in googleResults" class="result">
       <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>


### PR DESCRIPTION
Grab bag of tweaks to the pending #390 . Let's take the ones that seem to help.

# Show loading indicator in place of results count when loading

It's kind of subtle, but here's the gif

![loading indicator in search tab bar](https://cloud.githubusercontent.com/assets/952283/12767618/df7e4d06-c9cf-11e5-81d0-a36ff67545ae.gif)

# Suppress no-results search results sections on All tab

Show the search sections either when

1. They have results, or
2. They are the focused-upon search section.

That is, don't show them on the `all` tab when they have no results, since their presence in the search tabs is enough to let the user know what kinds of results had none.

![suppress empty results on all tab](https://cloud.githubusercontent.com/assets/952283/12766337/f6d1cf20-c9c8-11e5-9898-c8f64c4451bd.png)

# Show the inline heading and `<hr>` only on the All tab

So, 

![show heading on all tab](https://cloud.githubusercontent.com/assets/952283/12766375/2daa2812-c9c9-11e5-86f5-800ccff13c59.png)

but

![suppress heading](https://cloud.githubusercontent.com/assets/952283/12766364/1cdf6cae-c9c9-11e5-8f77-bc94674f5559.png)


# Suggest browse as a way to recover from no-results MyUW search

![suggest browsing to recover from no-results myuw search](https://cloud.githubusercontent.com/assets/952283/12766314/d8b03ed2-c9c8-11e5-9ad6-a5b196498394.png)
