### PR TITLE
Directory enhancements

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -84,21 +84,25 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           $('#myuw-results').show();
           $('#wisc-directory-results').show();
           $('#wisc-edu-results').show();
+          $('#wiscDirectorySeeMoreResults').show();
         } else if (filterName == 'myuw') {
           $('#myuw-selector').addClass('active');
           $('#myuw-results').show();
           $('#wisc-directory-results').hide();
           $('#wisc-edu-results').hide();
+          $('#wiscDirectorySeeMoreResults').hide();
         } else if (filterName == 'directory') {
           $('#directory-selector').addClass('active');
           $('#wisc-directory-results').show();
           $('#myuw-results').hide();
           $('#wisc-edu-results').hide();
+          $('#wiscDirectorySeeMoreResults').hide();
         } else if (filterName == 'google') {
           $('#google-selector').addClass('active');
           $('#wisc-edu-results').show();
           $('#myuw-results').hide();
           $('#wisc-directory-results').hide();
+          $('#wiscDirectorySeeMoreResults').hide();
         }
       };
 

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -85,6 +85,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           $('#wisc-directory-results').show();
           $('#wisc-edu-results').show();
           $('#wiscDirectorySeeMoreResults').show();
+          initwiscDirectoryResultLimit();
         } else if (filterName == 'myuw') {
           $('#myuw-selector').addClass('active');
           $('#myuw-results').show();
@@ -97,6 +98,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           $('#myuw-results').hide();
           $('#wisc-edu-results').hide();
           $('#wiscDirectorySeeMoreResults').hide();
+          $scope.wiscDirectoryResultLimit = 25;
         } else if (filterName == 'google') {
           $('#google-selector').addClass('active');
           $('#wisc-edu-results').show();
@@ -105,9 +107,14 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           $('#wiscDirectorySeeMoreResults').hide();
         }
       };
+      
+      var initwiscDirectoryResultLimit = function(){
+          $scope.wiscDirectoryResultLimit = 3;
+      }
 
       var init = function(){
         $scope.sortParameter = ['-rating','-userRated'];
+        initwiscDirectoryResultLimit();
         $scope.myuwResults = [];
         $scope.googleResults = [];
         $scope.wiscDirectoryResults = [];

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -53,7 +53,9 @@
     <h4 class='header'>Directory</h4>
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
-    <div ng-show="wiscDirectoryResults.length === 0" class='no-result'>
+    <div ng-show="wiscDirectoryResults.length === 0 
+                  && !wiscDirectoryTooManyResults" 
+         class='no-result'>
       No directory results
     </div>
     <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -56,7 +56,7 @@
     <div ng-show="wiscDirectoryResults.length === 0 && !wiscDirectoryTooManyResults" class='no-result'>
       No directory results
     </div>
-    <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">
+    <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
       <h4>{{item.fullName}}</h4>
       <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
       <p>
@@ -91,7 +91,7 @@
       </p>
       <p ng-if="wiscDirectoryErrorMessage">
           {{wiscDirectoryErrorMessage}}
-      </p>
+        </p>
     </div>
 
   </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -54,7 +54,7 @@
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
     <div ng-show="wiscDirectoryResults.length === 0 && !wiscDirectoryTooManyResults" class='no-result'>
-      No directory results
+      No directory results.
     </div>
     <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
       <h4>{{item.fullName}}</h4>
@@ -102,7 +102,7 @@
     <hr>
     <loading-gif data-object='googleResults'></loading-gif>
     <div ng-show="googleResults.length === 0" class='no-result'>
-      No wisc.edu results
+      No wisc.edu results.
     </div>
     <div ng-repeat="item in googleResults" class="result">
       <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -53,9 +53,7 @@
     <h4 class='header'>Directory</h4>
     <hr>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
-    <div ng-show="wiscDirectoryResults.length === 0 
-                  && !wiscDirectoryTooManyResults" 
-         class='no-result'>
+    <div ng-show="wiscDirectoryResults.length === 0 && !wiscDirectoryTooManyResults" class='no-result'>
       No directory results
     </div>
     <div ng-repeat="item in wiscDirectoryResults | limitTo:3" class="result">
@@ -88,12 +86,12 @@
       </div>
     </div>
     <div class="seeMoreResults">
-      <p ng-if="wiscDirectoryResultCount>0">
-        <a ng-href="{{$scope.directorySearchUrl + searchTerm}}">See all {{wiscDirectoryResultCount}} directory results</a>
+      <p ng-if="wiscDirectoryResultCount>0" id="wiscDirectorySeeMoreResults">
+        <a href="javascript:;" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
       </p>
       <p ng-if="wiscDirectoryErrorMessage">
           {{wiscDirectoryErrorMessage}}
-        </p>
+      </p>
     </div>
 
   </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -44,7 +44,7 @@
               ng-click="searchResultLimit = searchResultLimit + 20;"
               hide-while-loading
               ng-show="myuwFilteredResults.length > searchResultLimit"
-             >Load More MyUW Results</button>
+             >Load more MyUW results</button>
     </div>
   </div>
 
@@ -79,8 +79,8 @@
       <div ng-click="showingDetails=!showingDetails">
         <p>
           <a href="javascript:;" ng-if="item.titles[0] || item.address">
-            <span ng-if="!showingDetails">See More</span>
-            <span ng-if="showingDetails">See Less</span>
+            <span ng-if="!showingDetails">See more</span>
+            <span ng-if="showingDetails">See less</span>
           </a>
         </p>
       </div>


### PR DESCRIPTION
ONE. Takes Andrew's commit of Not showing "No Directory Results" when there are too many.

##### Before
![image](https://cloud.githubusercontent.com/assets/5521429/12786824/60d6500a-ca58-11e5-9a40-45e4e6ee5a6f.png)

##### After
![image](https://cloud.githubusercontent.com/assets/5521429/12786839/735b12a6-ca58-11e5-906f-33bdf3defccd.png)

TWO. Removes the see all directory results link when focused on directory tab.  Also the see all results directory link works and goes to the tab

##### Before
![image](https://cloud.githubusercontent.com/assets/5521429/12786920/c73195f8-ca58-11e5-9407-e834a4ccf9cd.png)

##### After
![image](https://cloud.githubusercontent.com/assets/5521429/12786900/b1532a58-ca58-11e5-8f5a-895722cd3610.png)

THREE. We now show all the search results (removes the limit) when focused on tab to align with mockups and link text

##### Before
![image](https://cloud.githubusercontent.com/assets/5521429/12786988/0ecbe74c-ca59-11e5-9a1d-e2d96be45628.png)


##### After
![allzaman](https://cloud.githubusercontent.com/assets/5521429/12787030/41ef438a-ca59-11e5-97b5-1daa3f738e6e.gif)
