### PR TITLE
Removes the header from specific tabs on search results

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -84,19 +84,24 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         if (filterName == 'all') {
           $('#all-selector').addClass('active');
           $('#myuw-results').show();
+          $('#myuw-results-header').show();
           $('#wisc-directory-results').show();
+          $('#wisc-directory-results-header').show();
           $('#wisc-edu-results').show();
+          $('#wisc-edu-results-header').show();
           $('#wiscDirectorySeeMoreResults').show();
           initwiscDirectoryResultLimit();
         } else if (filterName == 'myuw') {
           $('#myuw-selector').addClass('active');
           $('#myuw-results').show();
+          $('#myuw-results-header').hide();
           $('#wisc-directory-results').hide();
           $('#wisc-edu-results').hide();
           $('#wiscDirectorySeeMoreResults').hide();
         } else if (filterName == 'directory') {
           $('#directory-selector').addClass('active');
           $('#wisc-directory-results').show();
+          $('#wisc-directory-results-header').hide();
           $('#myuw-results').hide();
           $('#wisc-edu-results').hide();
           $('#wiscDirectorySeeMoreResults').hide();
@@ -104,6 +109,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         } else if (filterName == 'google') {
           $('#google-selector').addClass('active');
           $('#wisc-edu-results').show();
+          $('#wisc-edu-results-header').hide();
           $('#myuw-results').hide();
           $('#wisc-directory-results').hide();
           $('#wiscDirectorySeeMoreResults').hide();

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -17,8 +17,10 @@
   </div>
 
   <div id="myuw-results" class='search-results-container'>
-    <h4 class="header">MyUW</h4>
-    <hr>
+    <div id="myuw-results-header">
+      <h4 class="header">MyUW</h4>
+      <hr>
+    </div>
     <loading-gif data-object='myuwResults'></loading-gif>
     <div ng-show="myuwFilteredResults.length == 0" class='no-result'>
       No MyUW results
@@ -50,8 +52,10 @@
 
   <!--wisc directory results-->
   <div id="wisc-directory-results" class='search-results-container'>
-    <h4 class='header'>Directory</h4>
-    <hr>
+    <div id="wisc-directory-results-header">
+      <h4 class='header'>Directory</h4>
+      <hr>
+    </div>
     <loading-gif data-object='wiscDirectoryResults' data-empty='wiscDirectoryResults'></loading-gif>
     <div ng-show="wiscDirectoryResults.length === 0 && !wiscDirectoryTooManyResults" class='no-result'>
       No directory results.
@@ -98,8 +102,10 @@
 
   <!--wisc.edu results-->
   <div id="wisc-edu-results" class='search-results-container'>
-    <h4 class='header'>Wisc.edu</h4>
-    <hr>
+    <div id="wisc-edu-results-header">
+      <h4 class='header'>Wisc.edu</h4>
+      <hr>
+    </div>
     <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
     <div ng-show="googleResults.length === 0" class='no-result'>
       No wisc.edu results.


### PR DESCRIPTION
Took @apetro's good thought from https://github.com/UW-Madison-DoIT/angularjs-portal/pull/391 on removing the tab subheaders and combined it with @timlevett's good thought of untilizing the solution already in place.

#### Before
![yessubheader](https://cloud.githubusercontent.com/assets/5521429/12788740/74c93ca0-ca60-11e5-8935-d039bd7deab5.gif)


#### After
![nosubheader](https://cloud.githubusercontent.com/assets/5521429/12788687/2fa0508c-ca60-11e5-8704-5c722369b71d.gif)
