### PR TITLE
Removes see all directory is already showing all

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -86,7 +86,7 @@
       </div>
     </div>
     <div class="seeMoreResults">
-      <p ng-if="wiscDirectoryResultCount>0" id="wiscDirectorySeeMoreResults">
+      <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit" id="wiscDirectorySeeMoreResults">
         <a href="javascript:;" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
       </p>
       <p ng-if="wiscDirectoryErrorMessage">


### PR DESCRIPTION
Removes the see all # directory results if the number of results shown is equal or less than the limit.

So, you don't see the 'see all link' for [0,3]