### PR TITLE
Loading indicators in search result tabs.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -56,6 +56,10 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
                 $scope.googleEmptyResults = true;
               }
             }
+            $scope.googleResultsLoading = false;
+          },
+          function(results){
+            $scope.googleResultsLoading = false;
           }
         );
       };
@@ -75,6 +79,10 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
                 $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
               }
             }
+            $scope.wiscDirectoryResultsLoading = false;
+          },
+          function(results){
+            $scope.wiscDirectoryResultsLoading = false;
           }
         );
       };
@@ -125,7 +133,9 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         initwiscDirectoryResultLimit();
         $scope.myuwResults = [];
         $scope.googleResults = [];
+        $scope.googleResultsLoading = true;
         $scope.wiscDirectoryResults = [];
+        $scope.wiscDirectoryResultsLoading = true;
         $scope.wiscDirectoryResultCount = 0;
         $scope.wiscDirectoryTooManyResults = false;
         $scope.googleResultsEstimatedCount = 0;

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -5,13 +5,22 @@
         <a>All ({{ totalCount }})</a>
       </li>
       <li ng-click="filterTo('myuw')" id="myuw-selector">
-        <a>MyUW ({{myuwFilteredResults.length}})</a>
+        <a>MyUW 
+          <span ng-hide="portletListLoading">
+            ({{myuwFilteredResults.length}})</span>
+        <i ng-show="portletListLoading" class="fa fa-spinner fa-pulse"></i></a>
       </li>
       <li ng-click="filterTo('directory')" id="directory-selector">
-        <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
+        <a>Directory 
+          <span ng-hide="wiscDirectoryResultsLoading">
+            ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</span>
+          <i ng-show="wiscDirectoryResultsLoading" class="fa fa-spinner fa-pulse"></i></a>
       </li>
       <li ng-click="filterTo('google')" id="google-selector">
-        <a>Wisc.edu ({{googleResultsEstimatedCount}})</a>
+        <a>Wisc.edu 
+          <span ng-hide="googleResultsLoading">
+            ({{googleResultsEstimatedCount}})</span>
+        <i ng-show="googleResultsLoading" class="fa fa-spinner fa-pulse"></i></a>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Adds loading indicators to search result tabs.

Before:

![before](https://cloud.githubusercontent.com/assets/952283/12795674/aeb2d230-ca80-11e5-9f1d-b1d11943a939.gif)


After:

![loading indicators on search tabs](https://cloud.githubusercontent.com/assets/952283/12795517/2694beea-ca80-11e5-8f4c-8bb3ff8c7895.gif)

(Screencasts from a throttled connection.)

I like that it helps users understand what search results they're waiting for, clearly differentiating zero results from dunno-how-many-results-yet, allowing them to decide whether to keep waiting or to start investigating what's come back, for edge cases where search results return slowly.

(History: this is another shot from an idea in #392 , #391. Note comment at https://github.com/UW-Madison-DoIT/angularjs-portal/pull/391#discussion_r51722530 . )