### PR TITLE
MUMUP-2366 : Details page back to x

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -95,7 +95,8 @@
 .category-links {
   background-color:@white;
   color:#066999;
-  border:1px solid #066999;
+  border-color: #066999;
+  margin: 10px 3px;
 }
 .category-links:hover {
   text-decoration:none;

--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -95,15 +95,7 @@
 .category-links {
   background-color:@white;
   color:#066999;
-  text-decoration:none;
-  border-radius:3px;
-  font-size:0.8em;
-  font-weight:400;
-  padding:4px 8px;
-  margin:3px;
-  opacity:0.8;
   border:1px solid #066999;
-  display:inline-block;
 }
 .category-links:hover {
   text-decoration:none;
@@ -228,28 +220,28 @@
   padding:0px;
   display:inline-block;
   border-left:1px solid #ddd;
-  
+
   ul {
     margin:0px;
     padding:0px 0px 0px 20px;
   }
-  
+
   ul.enlarge{
   	list-style-type:none;
   }
-  
+
   ul.enlarge li{
   	display:inline-block;
   	position: relative;
   	z-index: 0;
   	margin: 10px 40px 0 20px;
   }
-  
+
   ul.enlarge span img{
   	padding: 2px;
   	width:100%;
   }
-  
+
   ul.enlarge span{
   	position:fixed;
     left:9000px;
@@ -268,11 +260,11 @@
   	z-index: 50;
   	cursor:pointer;
   }
-  
+
   img{
   		width:100%;
   }
-  
+
   @media only screen and (min-width: 768px){
   	ul.enlarge li:hover span{
 
@@ -294,7 +286,7 @@
     border-width: 1px;
     border-color: #dddddd;
   }
-  
+
   img {
     max-width:100%;
   }

--- a/angularjs-portal-home/src/main/webapp/my-app/main.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/main.js
@@ -55,6 +55,7 @@ define([
         $locationProvider.html5Mode(true);
         $routeProvider.
             when('/apps', marketplaceRoutes.main).
+            when('/apps/browse/:initFilter', marketplaceRoutes.main).
             when('/apps/details/:fname', marketplaceRoutes.details).
             when('/apps/search/:initFilter', searchRoutes.search).
             when('/compact', listRoute).

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -6,11 +6,13 @@ define(['angular', 'jquery'], function(angular, $) {
 
     app.controller('marketplaceCommonFunctions',
       ['layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage',
-       '$localStorage','$rootScope', '$scope', '$modal', '$routeParams', '$timeout',
+       '$localStorage','$rootScope', '$scope', '$modal', '$routeParams', '$timeout', '$location',
        function(layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage,
-        $localStorage, $rootScope, $scope, $modal, $routeParams, $timeout){
-      $scope.goToDetails = function(fname){
-          $location.path("apps/" + fname );
+        $localStorage, $rootScope, $scope, $modal, $routeParams, $timeout, $location){
+
+      $scope.navToDetails = function(marktetplaceEntry, location) {
+        marketplaceService.setFromInfo("Browse", $scope.searchTerm);
+        $location.path("apps/details/"+ marktetplaceEntry.fname);
       };
 
       $scope.isStatic = function(portlet) {
@@ -239,9 +241,33 @@ define(['angular', 'jquery'], function(angular, $) {
               currentCategory=category;
               currentPage='details';
           }
+
+          var figureOutBackStuff = function() {
+            var fromInfo = marketplaceService.getFromInfo();
+            if(fromInfo.term) {
+              //from somewhere
+              if("Search" === fromInfo.searchOrBrowse && fromInfo.term) {
+                //if from search and term is populated, return to search
+                $scope.backText = "Search Results for " + fromInfo.term;
+                $scope.backURL = "apps/search/" + fromInfo.term;
+              } else {
+                //assuming from browse
+                $scope.backText = "Browse";
+                $scope.backURL = "apps/browse/" + fromInfo.term;
+              }
+
+              //reset services
+              marketplaceService.setFromInfo(undefined,undefined);
+            } else {
+              //direct hit, will go back to browse
+              $scope.backURL="apps";
+              $scope.backText="Browse";
+            }
+          }
           // init
-          var init = function(){
+          var init = function() {
             $scope.loading = true;
+            figureOutBackStuff();
             $scope.obj = [];
             $scope.errorMessage = 'There was an issue loading details, please click back to apps.';
             marketplaceService.getPortlet($routeParams.fname).then(function(result) {

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -11,7 +11,7 @@ define(['angular', 'jquery'], function(angular, $) {
         $localStorage, $rootScope, $scope, $modal, $routeParams, $timeout, $location){
 
       $scope.navToDetails = function(marktetplaceEntry, location) {
-        marketplaceService.setFromInfo("Browse", $scope.searchTerm);
+        marketplaceService.setFromInfo(location, $scope.searchTerm);
         $location.path("apps/details/"+ marktetplaceEntry.fname);
       };
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -17,7 +17,7 @@
 		    <portlet-icon></portlet-icon>
 		    <span class="portlet-title">{{::portlet.title}} Details</span>
 		  </h2>
-		  <a href="apps" class="back-to-home"><i class="fa fa-arrow-circle-o-left"></i> Back to Search and Browse</a>
+		  <a ng-href="{{backURL}}" class="back-to-home"><i class="fa fa-arrow-circle-o-left"></i> Back to {{backText}}</a>
   	</div>
 
 		<div class="col-xs-12 col-lg-6">
@@ -82,7 +82,7 @@
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center">
 			<h3 tabindex="0">Categories</h3>
-			<a ng-repeat="category in portlet.categories" href="apps" ng-click="specifyCategory(category)" class="category-links">{{::category}}</a>
+			<a ng-repeat="category in portlet.categories" href="apps" ng-click="specifyCategory(category)" class="btn btn-outline btn-sm category-links">{{::category}}</a>
 		</div>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item center" ng-if="$storage.showKeywordsInMarketplace">
 			<h3>Keywords</h3>
@@ -106,7 +106,7 @@
 
 	<div class="portlet-footer left">
 	 	<ul>
-	 		<li><a href="apps"><i class="fa fa-arrow-circle-o-left"></i> Back to Search and Browse</a></li>
+	 		<li><a ng-href="{{backURL}}"><i class="fa fa-arrow-circle-o-left"></i> Back to {{backText}}</a></li>
 	 	</ul>
 	</div>
 	<rating-modal-template></rating-modal-template>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -50,11 +50,19 @@
   </span>
   <span ng-hide="GuestMode"> | <button ng-click="openRating('sm',portlet.fname, portlet.title)" class="btn btn-default">Rate</button></span>
   <p tabindex="0">{{::portlet.description}}</p>
-  <div class="category-list">
-    <a ng-repeat="category in portlet.categories" href="" ng-click="selectFilter('category',category)" class="category-links">{{::category}}</a>
-    <div class="portlet-details">
-      <a href="apps/details/{{::portlet.fname}}">Details</a>
+  <div class="category-list container-fluid row">
+    <div class="col-xs-8">
+      <a ng-repeat="category in portlet.categories"
+         href=""
+         ng-click="selectFilter('category',category)"
+         class="btn btn-outline btn-sm category-links">
+          {{::category}}
+       </a>
     </div>
+    <div class="col-xs-4">
+      <a title='See more about {{portlet.name}}' ng-click='navToDetails(portlet, "Browse")' class="btn btn-outline btn-sm pull-right">Details</a>
+    </div>
+
   </div>
 
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -22,7 +22,7 @@
       </ul>
     </div>
     <div ng-show="showCategories" class="show-categories">
-      <p>Categories:</p><a ng-repeat="category in categories" href="" class="category-links" ng-click="selectFilter('category',category)" ng-class="{true: 'selected-category'}[categoryToShow === category]">{{category}}</a>
+      <p>Categories:</p><a ng-repeat="category in categories" href="" class="btn btn-outline btn-sm category-links" ng-click="selectFilter('category',category)" ng-class="{true: 'selected-category'}[categoryToShow === category]">{{category}}</a>
     </div>
 
     <loading-gif data-object='portlets'></loading-gif>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/services.js
@@ -8,6 +8,8 @@ define(['angular', 'jquery'], function(angular, $) {
         var marketplacePromise;
         //local variables
         var filter = "";
+        var fromSearchTerm = "";
+        var fromSearchOrBrowse = "";
 
         //public functions
 
@@ -18,6 +20,20 @@ define(['angular', 'jquery'], function(angular, $) {
         var getInitialFilter = function(){
             return filter;
         };
+
+        /**
+         * Sets the information about where they came from
+         */
+        var setFromInfo = function(searchOrBrowse, term) {
+          fromSearchTerm = term;
+          fromSearchOrBrowse = searchOrBrowse;
+        }
+        /**
+         * Gets the information about where they came from
+         */
+        var getFromInfo = function() {
+          return {term: fromSearchTerm, searchOrBrowse : fromSearchOrBrowse};
+        }
 
         var checkMarketplaceCache = function() {
             var userPromise = mainService.getUser();
@@ -225,7 +241,9 @@ define(['angular', 'jquery'], function(angular, $) {
             getUserRating : getUserRating,
             saveRating : saveRating,
             filterPortletsBySearchTerm: filterPortletsBySearchTerm,
-            portletMatchesSearchTerm: portletMatchesSearchTerm
+            portletMatchesSearchTerm: portletMatchesSearchTerm,
+            setFromInfo : setFromInfo,
+            getFromInfo : getFromInfo
         };
 
     }]);

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -41,8 +41,8 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
     }]);
 
     app.controller('SearchResultController',
-     ['$rootScope', '$scope', '$controller','marketplaceService', 'googleCustomSearchService', 'wiscDirectorySearchService',
-     function($rootScope, $scope, $controller,marketplaceService, googleCustomSearchService, wiscDirectorySearchService) {
+     ['$location', '$rootScope', '$scope', '$controller','marketplaceService', 'googleCustomSearchService', 'wiscDirectorySearchService',
+     function($location, $rootScope, $scope, $controller,marketplaceService, googleCustomSearchService, wiscDirectorySearchService) {
       var base = $controller('marketplaceCommonFunctions', {$scope : $scope});
 
       var initWiscEduSearch = function(){
@@ -85,7 +85,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           }
         );
       };
-      
+
       $scope.filterTo = function(filterName) {
         $('.search-results .inner-nav li').removeClass('active');
         if (filterName == 'all') {
@@ -122,7 +122,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
           $('#wiscDirectorySeeMoreResults').hide();
         }
       };
-      
+
       var initwiscDirectoryResultLimit = function(){
           $scope.wiscDirectoryResultLimit = 3;
       }
@@ -141,6 +141,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         $scope.searchResultLimit = 20;
         $scope.showAll = $rootScope.GuestMode || false;
         base.setupSearchTerm();
+        $rootScope.portalSearchTerm = $scope.searchTerm; //in case the search field is not set for whatever reason, reset it
         base.initializeConstants();
         //get marketplace entries
         marketplaceService.getPortlets().then(function(data) {
@@ -171,4 +172,3 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
     return app;
 
 });
-

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -41,8 +41,8 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
     }]);
 
     app.controller('SearchResultController',
-     ['$location', '$rootScope', '$scope', '$controller','marketplaceService', 'googleCustomSearchService', 'wiscDirectorySearchService',
-     function($location, $rootScope, $scope, $controller,marketplaceService, googleCustomSearchService, wiscDirectorySearchService) {
+     ['$location', '$rootScope', '$scope', '$controller','marketplaceService', 'googleCustomSearchService', 'wiscDirectorySearchService','PortalSearchService',
+     function($location, $rootScope, $scope, $controller,marketplaceService, googleCustomSearchService, wiscDirectorySearchService, PortalSearchService) {
       var base = $controller('marketplaceCommonFunctions', {$scope : $scope});
 
       var initWiscEduSearch = function(){
@@ -141,7 +141,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         $scope.searchResultLimit = 20;
         $scope.showAll = $rootScope.GuestMode || false;
         base.setupSearchTerm();
-        $rootScope.portalSearchTerm = $scope.searchTerm; //in case the search field is not set for whatever reason, reset it
+        PortalSearchService.setQuery($scope.searchTerm); //in case the search field is not set for whatever reason, reset it
         base.initializeConstants();
         //get marketplace entries
         marketplaceService.getPortlets().then(function(data) {

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -38,7 +38,7 @@
               class="added">
           <i class="fa fa-check"></i> Added to home
         </span>
-        <a href="apps/details/{{::portlet.fname}}">Details</a>
+        <button class='btn btn-link' style='padding:0;' title='See more about {{portlet.name}}' ng-click='navToDetails(portlet, "Search")'>Details</button>
         <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
       </p>
     </div>


### PR DESCRIPTION
### Main Change
+ If one searches for something, then reads about details, then clicks back, it goes back to there search result 

![http://goo.gl/jE2YHs](http://goo.gl/jE2YHs)
+ If one browses for something, then reads about details, then clicks back, it goes back to there browse session

![http://goo.gl/Mb9SqK](http://goo.gl/Mb9SqK)

### Minor cleanup on the marketplace-entry page
+ Changed from custom style for categories to use the outline button with some different coloring. 
+ Changed details link to be an outline button
+ Changed that bottom area to be a grid

##### Before
![before](http://goo.gl/5rhrVu)

##### After
![after](http://goo.gl/ymZvEk)

### Minor change to search result page
+ Now if you hit a search result from where ever it'll have the search term in the search box (this was done in https://github.com/UW-Madison-DoIT/uw-frame/pull/157 and https://github.com/UW-Madison-DoIT/uw-frame/pull/158)

##### Before
![before](http://goo.gl/4kMrqZ)

##### After
![after](http://goo.gl/5cGyLa)