### PR TITLE
MUMUP-2395 : Change wording on launch/login for guest

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -23,10 +23,8 @@ define(['angular', 'jquery'], function(angular, $) {
 
       $scope.getLaunchURL = function(marketplaceEntry) {
         var layoutObj = marketplaceEntry.layoutObject;
-        if($rootScope.GuestMode && !marketplaceEntry.canAdd) {
+        if($rootScope.GuestMode && !marketplaceEntry.hasInLayout) {
           return $scope.loginToAuthPage + '/web/apps/details/'+ marketplaceEntry.fname
-        } else if (!marketplaceEntry.canAdd) {
-          return; //they can't add aka render so don't give them a URL
         } else if(layoutObj.altMaxUrl == false && (layoutObj.renderOnWeb || $localStorage.webPortletRender)) {
           return 'exclusive/' + layoutObj.fname;
         } else if($scope.isStatic(marketplaceEntry)) {

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -56,8 +56,8 @@
        <!--GuestMode buttons-->
        <div class="action-buttons" ng-show="GuestMode">
          <a class="btn btn-outline" ng-href="{{getLaunchURL(portlet)}}" >
-           <span ng-if='portlet.canAdd'>Launch</span>
-           <span ng-if='!portlet.canAdd'>Login to use</span>
+           <span ng-if='portlet.hasInLayout'>Launch</span>
+           <span ng-if='!portlet.hasInLayout'>Login</span>
          </a>
        </div>
 		</div>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -38,9 +38,9 @@
   </div>
   <!--GuestMode buttons-->
   <div class="action-buttons" ng-show="GuestMode">
-    <a class="btn btn-outline" ng-href="{{getLaunchURL(portlet)}}" >
-      <span ng-if='portlet.canAdd'>Launch</span>
-      <span ng-if='!portlet.canAdd'>Login to use</span>
+    <a class="btn btn-outline" style='margin-right: 15px' ng-href="{{getLaunchURL(portlet)}}" >
+      <span ng-if='portlet.hasInLayout'>Launch</span>
+      <span ng-if='!portlet.hasInLayout'>Login</span>
     </a>
   </div>
 


### PR DESCRIPTION
+ Changed wording (based on feedback) to "Login".
+ Turns out that uPortal makes it so guest cannot add anything, so we only have the option of saying "you can launch the things that are on your home screen". I'd rather not play around with the render code :)
+ Also fixed margin so it aligned with the details button of the same styles

#### Before
![http://goo.gl/rc7bcM](http://goo.gl/rc7bcM)

#### After
![http://goo.gl/m4QIX7](http://goo.gl/m4QIX7)

_Note using mock data for after screenshot, so don't get too caught up with which ones you can launch vs. login_