### PR TITLE
Configurable google search results

### DIFF
--- a/angularjs-portal-home/src/main/resources/endpoint.properties.example
+++ b/angularjs-portal-home/src/main/resources/endpoint.properties.example
@@ -49,3 +49,5 @@ uwmadisonreddit.attributes=
 wiscdirectory.uri=http://www.wisc.edu/directories/json
 
 wiscedusearch.uri=http://ajax.googleapis.com/ajax/services/search/web
+
+uwrfsearch.uri=https://www.googleapis.com/customsearch/v1element

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -30,7 +30,6 @@ define(['angular'], function(angular) {
             'notificationsURL' : '/web/staticFeeds/notifications.json',
             'groupURL' : '/portal/api/groups',
             'kvURL' : '/storage',
-            'googleSearchURL' : '/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m',
             'loginSilentURL' : '/portal/Login?silent=true'
         })
         .value('NAMES', {
@@ -91,10 +90,11 @@ define(['angular'], function(angular) {
             "title" : "Old MyUW"
           },
         ])
-        .value('SEARCH_URLS', [
+        .value('SEARCH_CONFIG_URLS', [
           {
             "group" : "UW-Madison",
-            "directorySearchURL" : "/web/api/wiscdirectory"
+            "directorySearchURL" : "/web/api/wiscdirectory",
+            "googleSearchURL" : "/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m"
           }
         ])
         .value('APP_BETA_FEATURES', [

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -59,7 +59,6 @@ define(['angular'], function(angular) {
             'back2ClassicURL' : '/portal/Login?profile=default',
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
             'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
-            'webSearchURL' : 'http://www.wisc.edu/search/?q=',
             'webSearchDomain' : "wisc.edu",
             'directorySearchURL' : 'http://www.wisc.edu/directories/?q=',
             'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',
@@ -90,17 +89,19 @@ define(['angular'], function(angular) {
             "title" : "Old MyUW"
           },
         ])
-        .value('SEARCH_CONFIG_URLS', [
+        .value('SEARCH_CONFIG', [
           {
             "group" : "UW-Madison",
             "directorySearchURL" : "/web/api/wiscdirectory",
             "googleSearchURL" : "/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m",
-            "webSearchURL" : "http://www.wisc.edu/search/?q="
+            "webSearchURL" : "http://www.wisc.edu/search/?q=",
+            "domainResultsLabel" : "Wisc.edu"
           },
           {
             "group" : "UW System-River Falls",
             "googleSearchURL" : "/web/api/uwrfsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&hl=en&prettyPrint=false&source=gcsc&gss=.com&sig=432dd570d1a386253361f581254f9ca1&cx=004071655910512460416:8kmve-tofw8&googlehost=www.google.com&nocache=1456777578251&",
-            "webSearchURL" : "https://www.uwrf.edu/AboutUs/SearchResults.cfm?q="
+            "webSearchURL" : "https://www.uwrf.edu/AboutUs/SearchResults.cfm?q=",
+            "domainResultsLabel" : "UWRF.edu"
           }
         ])
         .value('APP_BETA_FEATURES', [

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -94,7 +94,13 @@ define(['angular'], function(angular) {
           {
             "group" : "UW-Madison",
             "directorySearchURL" : "/web/api/wiscdirectory",
-            "googleSearchURL" : "/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m"
+            "googleSearchURL" : "/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m",
+            "webSearchURL" : "http://www.wisc.edu/search/?q="
+          },
+          {
+            "group" : "UW System-River Falls",
+            "googleSearchURL" : "/web/api/uwrfsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&hl=en&prettyPrint=false&source=gcsc&gss=.com&sig=432dd570d1a386253361f581254f9ca1&cx=004071655910512460416:8kmve-tofw8&googlehost=www.google.com&nocache=1456777578251&",
+            "webSearchURL" : "https://www.uwrf.edu/AboutUs/SearchResults.cfm?q="
           }
         ])
         .value('APP_BETA_FEATURES', [

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -132,8 +132,11 @@ define(['angular', 'jquery'], function(angular, $) {
 
       this.initializeConstants = function(){
         //initialize constants
-        googleCustomSearchService.getWebSearchURL().then(function(webSearchURL){
+        googleCustomSearchService.getPublicWebSearchURL().then(function(webSearchURL){
             $scope.webSearchUrl = webSearchURL;
+        });
+        googleCustomSearchService.getDomainResultsLabel().then(function(domainResultsLabel){
+            $scope.domainResultsLabel = domainResultsLabel;
         });
         $scope.webSearchDomain = MISC_URLS.webSearchDomain;
         $scope.directorySearchUrl = MISC_URLS.directorySearchURL;

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -5,9 +5,9 @@ define(['angular', 'jquery'], function(angular, $) {
     var app = angular.module('my-app.marketplace.controllers', []);
 
     app.controller('marketplaceCommonFunctions',
-      ['layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage',
+      ['googleCustomSearchService', 'layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage',
        '$localStorage','$rootScope', '$scope', '$modal', '$routeParams', '$timeout', '$location',
-       function(layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage,
+       function(googleCustomSearchService, layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage,
         $localStorage, $rootScope, $scope, $modal, $routeParams, $timeout, $location){
 
       $scope.navToDetails = function(marktetplaceEntry, location) {
@@ -132,7 +132,9 @@ define(['angular', 'jquery'], function(angular, $) {
 
       this.initializeConstants = function(){
         //initialize constants
-        $scope.webSearchUrl = MISC_URLS.webSearchURL;
+        googleCustomSearchService.getWebSearchURL().then(function(webSearchURL){
+            $scope.webSearchUrl = webSearchURL;
+        });
         $scope.webSearchDomain = MISC_URLS.webSearchDomain;
         $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
         $scope.kbSearchUrl = MISC_URLS.kbSearchURL;

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -136,6 +136,7 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         $scope.wiscDirectoryResults = [];
         $scope.wiscDirectoryResultCount = 0;
         $scope.wiscDirectoryTooManyResults = false;
+        $scope.googleSearchEnabled = false;
         $scope.googleResultsEstimatedCount = 0;
         $scope.googleEmptyResults = false;
         $scope.totalCount = 0;
@@ -162,9 +163,13 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         });
       };
       init();
-      if(googleCustomSearchService.googleSearchEnabled()){
-        initWiscEduSearch();
-      }
+      
+      googleCustomSearchService.googleSearchEnabled().then(function(googleSearchEnabled){
+          $scope.googleSearchEnabled = googleSearchEnabled;
+          if(googleSearchEnabled){
+              initWiscEduSearch();
+          }
+      });
       directorySearchService.directorySearchEnabled().then(function(directoryEnabled){
           $scope.directoryEnabled = directoryEnabled;
           if(directoryEnabled){

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -47,13 +47,14 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
 
       var initWiscEduSearch = function(){
         googleCustomSearchService.googleSearch($scope.searchTerm).then(
-          function(results){
-            if(results && results.responseData && results.responseData.results) {
-              $scope.googleResults = results.responseData.results;
-              if(results.responseData.cursor.estimatedResultCount){
-                $scope.googleResultsEstimatedCount = results.responseData.cursor.estimatedResultCount;
-              }else{
-                $scope.googleEmptyResults = true;
+          function(data){
+            if(data && data.results) {
+              $scope.googleResults = data.results;
+              if(data.estimatedResultCount){
+                $scope.googleResultsEstimatedCount = data.estimatedResultCount;
+              }
+              if(!data.estimatedResultCount || data.estimatedResultCount == 0){
+                  $scope.googleEmptyResults = true;
               }
             }
           }

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -120,7 +120,7 @@
 
     </div>
     <div>
-      <h4 ng-hide='googleEmptyResults'><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on wisc.edu</a></h4>
+      <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on wisc.edu</a></h4>
     </div>
   </div>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -11,7 +11,7 @@
         <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
       </li>
       <li ng-show="googleSearchEnabled" ng-click="filterTo('google')" id="google-selector">
-        <a>Wisc.edu ({{googleResultsEstimatedCount}})</a>
+        <a>{{domainResultsLabel}} ({{googleResultsEstimatedCount}})</a>
       </li>
     </ul>
   </div>
@@ -101,15 +101,15 @@
 
   </div>
 
-  <!--wisc.edu results-->
+  <!--Campus Domain results-->
   <div ng-show="googleSearchEnabled" id="wisc-edu-results" class='search-results-container'>
     <div id="wisc-edu-results-header">
-      <h4 class='header'>Wisc.edu</h4>
+      <h4 class='header'>{{domainResultsLabel}}</h4>
       <hr>
     </div>
     <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
     <div ng-show="googleResults.length === 0" class='no-result'>
-      No wisc.edu results.
+      No {{domainResultsLabel}} results.
     </div>
     <div ng-repeat="item in googleResults" class="result">
       <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
@@ -120,7 +120,7 @@
 
     </div>
     <div>
-      <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on wisc.edu</a></h4>
+      <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
     </div>
   </div>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -1,5 +1,5 @@
 <div class="row search-results">
-  <div class="inner-nav-container">
+  <div ng-show="googleSearchEnabled || directoryEnabled" class="inner-nav-container">
     <ul class="inner-nav">
       <li class="active" ng-click="filterTo('all')" id="all-selector">
         <a>All ({{ totalCount }})</a>
@@ -10,7 +10,7 @@
       <li ng-show="directoryEnabled" ng-click="filterTo('directory')" id="directory-selector">
         <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
       </li>
-      <li ng-click="filterTo('google')" id="google-selector">
+      <li ng-show="googleSearchEnabled" ng-click="filterTo('google')" id="google-selector">
         <a>Wisc.edu ({{googleResultsEstimatedCount}})</a>
       </li>
     </ul>
@@ -102,7 +102,7 @@
   </div>
 
   <!--wisc.edu results-->
-  <div id="wisc-edu-results" class='search-results-container'>
+  <div ng-show="googleSearchEnabled" id="wisc-edu-results" class='search-results-container'>
     <div id="wisc-edu-results-header">
       <h4 class='header'>Wisc.edu</h4>
       <hr>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/services.js
@@ -4,38 +4,124 @@ define(['angular', 'jquery'], function(angular, $) {
 
     var app = angular.module('my-app.search.services', []);
     
-    app.factory('googleCustomSearchService', ['$http', 'miscService', 'SERVICE_LOC', function($http, miscService, SERVICE_LOC){
+    app.factory('googleCustomSearchService', ['$http', '$q', 'PortalGroupService', 'filterFilter', 'miscSearchService', 'miscService', 'SERVICE_LOC', 
+                                              function($http, $q, PortalGroupService, filterFilter, miscSearchService, miscService, SERVICE_LOC){
+        
+      var googleSearchURLPromise;
+      var googleSearchEnabledPromise;
       
       function googleSearch(term) {
-        return $http.get(SERVICE_LOC.googleSearchURL + "&q=" + term).then(
-          function(response){
-            return response.data;
-          },
-          function(response){
-            console.log("error searching the google status: " +  response.status);
-          }
-        )
+        return getGoogleSearchURL().then(function(googleSearchURL){
+          return $q(function(resolve, reject){
+            if(googleSearchURL){
+              return $http.get(googleSearchURL + "&q=" + term).then(
+                function(response){
+                  return resolve(response.data);
+                },
+                function(response){
+                  return reject("error searching the google status: " +  response.status);
+                }
+              );
+            }else{
+              return reject("User has no group for google URL search");
+            }
+          })
+        });
+      };
+      
+      /**
+       * Returns a promise that will return a googleSearchURL if any exist
+       * for a users group or null if one does not exists.
+       */
+      function getGoogleSearchURL() {
+        var successFn, errorFn;
+        
+        if(googleSearchURLPromise){
+          return googleSearchURLPromise;
+        }
+        
+        successFn = function(groups){
+          return miscSearchService.getSearchURLS(groups).then(function(result){
+            if(result && result.googleSearchURL){
+              return result.googleSearchURL;
+            }
+            else{
+              return null;
+            }
+          })
+        };
+        
+        errorFn = function(reason){
+          miscService.redirectUser(reason.status, 'Could not get appropriate google search url');
+        }
+        
+        googleSearchURLPromise = PortalGroupService.getGroups().then(successFn, errorFn);
+        
+        return googleSearchURLPromise;
       }
       
+      /**
+       * Returns promise that will return true or false if there exists
+       * a directorySearchURL for any of the users groups
+       */
       function googleSearchEnabled() {
-        if(SERVICE_LOC.googleSearchURL) {
-          return true;
-        } else {
+        var successFn, errorFn;
+        
+        if(googleSearchEnabledPromise){
+          return googleSearchEnabledPromise;
+        }
+        
+        successFn = function(googleSearchURL){
+          if(googleSearchURL){
+            return true;
+          }else{
+            return false;
+          }
+        }
+        
+        errorFn = function(response){
+          console.log("error determing if google search is enabled: " +  response.status);
           return false;
         }
-      }
+        
+        googleSearchEnabledPromise = getGoogleSearchURL().then(successFn, errorFn);
+        return googleSearchEnabledPromise;
+      };
       
       return {
         googleSearch : googleSearch,
         googleSearchEnabled : googleSearchEnabled
       };
+    }]);
+    
+    app.factory('miscSearchService', ['$q', '$sessionStorage', 'filterFilter', 'SEARCH_CONFIG_URLS', function($q, $sessionStorage, filterFilter, SEARCH_CONFIG_URLS){
+
+      function getSearchURLS(groups){
+        return $q(function(resolve, reject) {
+          if($sessionStorage.search){
+            resolve($sessionStorage.search);
+          }
+          for(var i = 0; i < SEARCH_CONFIG_URLS.length; i++){
+            var searchURLS = SEARCH_CONFIG_URLS[i];
+            var searchGroup = searchURLS.group;
+            var filterTest = filterFilter(groups, {name: searchGroup});
+            if(filterTest && filterTest.length >0){
+              $sessionStorage.search = searchURLS;
+              resolve(searchURLS);
+            }
+          }
+          resolve(null);
+        });
+      }
       
-      
+      return {
+          getSearchURLS: getSearchURLS
+      };
     }]);
     
     app.factory('directorySearchService', [
-         '$http', '$sessionStorage', '$q', 'PortalGroupService', 'SEARCH_URLS', 'filterFilter', 'miscService', 
-         function($http, $sessionStorage, $q, PortalGroupService, SEARCH_URLS, filterFilter, miscService){
+         '$http', '$q', 'PortalGroupService', 'miscSearchService', 'filterFilter', 'miscService', 
+         function($http, $q, PortalGroupService, miscSearchService, filterFilter, miscService){
         
         var directoryUrlPromise;
         var directorySearchEnabledPromise;
@@ -98,24 +184,15 @@ define(['angular', 'jquery'], function(angular, $) {
             return directoryUrlPromise;
           }
           
-          successFn = function(result){
-            if($sessionStorage.search && $sessionStorage.search.directorySearchURL){
-              return $sessionStorage.search.directorySearchURL;
-            }
-            
-            for(var i = 0; i < SEARCH_URLS.length; i++){
-              var searchURLS = SEARCH_URLS[i];
-              var searchGroup = searchURLS.group;
-              var filterTest = filterFilter(result, {name: searchGroup});
-              if(filterTest && filterTest.length >0){
-                $sessionStorage.search = searchURLS;
-                break;
-              }
-            }
-            if($sessionStorage.search && $sessionStorage.search.directorySearchURL){
-              return $sessionStorage.search.directorySearchURL;
-            }
-            return null;
+          successFn = function(groups){
+            return miscSearchService.getSearchURLS(groups).then(function(result){
+                if(result && result.directorySearchURL){
+                    return result.directorySearchURL;
+                }
+                else{
+                    return null;
+                }
+            })
           };
           
           errorFn = function(reason){


### PR DESCRIPTION
Only shows google search if the user is in a configured group.  Otherwise no search result section shows. 

Example for River Falls user with no google search configured:
![uwrfnosearchconfig](https://cloud.githubusercontent.com/assets/5521429/13441935/72faf53e-dfbf-11e5-92b5-6e32acc57414.gif)

Example for River Falls user with google search configured:
![uwrfgoogsearchconfig](https://cloud.githubusercontent.com/assets/5521429/13441851/fe54f284-dfbe-11e5-8bfd-aa6da28a3336.gif)

There is some work to do so that the `No Matches` suggestions are configurable.