### PR TITLE
Zero search result state

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -58,11 +58,8 @@ define(['angular'], function(angular) {
             'feedbackURL' : '/portal/p/feedback',
             'back2ClassicURL' : '/portal/Login?profile=default',
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
-            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
             'webSearchDomain' : "wisc.edu",
             'directorySearchURL' : 'http://www.wisc.edu/directories/?q=',
-            'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',
-            'eventsSearchURL' : 'https://today.wisc.edu/events/search?term=',
             'loginURL' : '/portal/Login?profile=bucky',
             'logoutURL' : '/portal/Logout',
             'rootURL' : '/web',
@@ -95,7 +92,10 @@ define(['angular'], function(angular) {
             "directorySearchURL" : "/web/api/wiscdirectory",
             "googleSearchURL" : "/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m",
             "webSearchURL" : "http://www.wisc.edu/search/?q=",
-            "domainResultsLabel" : "Wisc.edu"
+            "domainResultsLabel" : "Wisc.edu",
+            'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',
+            'eventsSearchURL' : 'https://today.wisc.edu/events/search?term=',
+            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/'
           },
           {
             "group" : "UW System-River Falls",

--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -58,8 +58,6 @@ define(['angular'], function(angular) {
             'feedbackURL' : '/portal/p/feedback',
             'back2ClassicURL' : '/portal/Login?profile=default',
             'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181',
-            'webSearchDomain' : "wisc.edu",
-            'directorySearchURL' : 'http://www.wisc.edu/directories/?q=',
             'loginURL' : '/portal/Login?profile=bucky',
             'logoutURL' : '/portal/Logout',
             'rootURL' : '/web',

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -147,7 +147,6 @@ define(['angular', 'jquery'], function(angular, $) {
         miscSearchService.getHelpDeskHelpURL().then(function(helpdeskURL){
             $scope.helpdeskUrl = helpdeskURL;
         });
-        $scope.webSearchDomain = MISC_URLS.webSearchDomain;
         $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
         $scope.feedbackUrl = MISC_URLS.feedbackURL;
         $scope.loginToAuthPage = MISC_URLS.myuwHome;

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -5,9 +5,9 @@ define(['angular', 'jquery'], function(angular, $) {
     var app = angular.module('my-app.marketplace.controllers', []);
 
     app.controller('marketplaceCommonFunctions',
-      ['googleCustomSearchService', 'layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage',
+      ['googleCustomSearchService', 'miscSearchService', 'layoutService', 'marketplaceService', 'miscService', 'MISC_URLS', '$sessionStorage',
        '$localStorage','$rootScope', '$scope', '$modal', '$routeParams', '$timeout', '$location',
-       function(googleCustomSearchService, layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage,
+       function(googleCustomSearchService, miscSearchService, layoutService, marketplaceService, miscService,MISC_URLS, $sessionStorage,
         $localStorage, $rootScope, $scope, $modal, $routeParams, $timeout, $location){
 
       $scope.navToDetails = function(marktetplaceEntry, location) {
@@ -138,12 +138,18 @@ define(['angular', 'jquery'], function(angular, $) {
         googleCustomSearchService.getDomainResultsLabel().then(function(domainResultsLabel){
             $scope.domainResultsLabel = domainResultsLabel;
         });
+        miscSearchService.getKBSearchURL().then(function(kbSearchURL){
+            $scope.kbSearchUrl = kbSearchURL;
+        });
+        miscSearchService.getEventSearchURL().then(function(eventsSearchURL){
+            $scope.eventsSearchUrl = eventsSearchURL;
+        });
+        miscSearchService.getHelpDeskHelpURL().then(function(helpdeskURL){
+            $scope.helpdeskUrl = helpdeskURL;
+        });
         $scope.webSearchDomain = MISC_URLS.webSearchDomain;
         $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
-        $scope.kbSearchUrl = MISC_URLS.kbSearchURL;
-        $scope.eventsSearchUrl = MISC_URLS.eventsSearchURL;
         $scope.feedbackUrl = MISC_URLS.feedbackURL;
-        $scope.helpdeskUrl = MISC_URLS.helpdeskURL;
         $scope.loginToAuthPage = MISC_URLS.myuwHome;
       }
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -53,7 +53,7 @@
              target="_blank">Search the directory</a> (of people and offices) instead.</li>
         <li ng-if="webSearchUrl">
           <a ng-href="{{webSearchUrl}}{{searchText}}"
-             target="_blank">Search <span ng-if="webSearchDomain">the {{webSearchDomain}} domain on</span> the Web</a> instead.</li>
+             target="_blank">Search <span ng-if="domainResultsLabel">the {{domainResultsLabel}} domain on</span> the Web</a> instead.</li>
         <li ng-if="kbSearchUrl">
           <a ng-href="{{kbSearchUrl}}{{searchText}}"
              target="_blank">Search the KnowledgeBase</a> instead.</li>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/services.js
@@ -162,7 +162,59 @@ define(['angular', 'jquery'], function(angular, $) {
       };
     }]);
     
-    app.factory('miscSearchService', ['$q', '$sessionStorage', 'filterFilter', 'SEARCH_CONFIG', function($q, $sessionStorage, filterFilter, SEARCH_CONFIG){
+    app.factory('miscSearchService', ['$q', '$sessionStorage', 'PortalGroupService', 'filterFilter', 'SEARCH_CONFIG', 
+                                      function($q, $sessionStorage, PortalGroupService, filterFilter, SEARCH_CONFIG){
+      
+      function getKBSearchURL(){
+        return PortalGroupService.getGroups().then(
+          function(groups){
+            return getSearchURLS(groups).then(
+              function(result){
+                if(result && result.kbSearchURL){
+                  return result.kbSearchURL;
+                }
+                else{
+                  return null;
+                }
+              }
+            );
+          }
+        );
+      }
+      
+      function getEventSearchURL(){
+        return PortalGroupService.getGroups().then(
+          function(groups){
+            return getSearchURLS(groups).then(
+              function(result){
+                if(result && result.eventsSearchURL){
+                  return result.eventsSearchURL;
+                }
+                else{
+                  return null;
+                }
+              }
+            );
+          }
+        );
+      }
+      
+      function getHelpDeskHelpURL(){
+        return PortalGroupService.getGroups().then(
+          function(groups){
+            return getSearchURLS(groups).then(
+              function(result){
+                if(result && result.helpdeskURL){
+                  return result.helpdeskURL;
+                }
+                else{
+                  return null;
+                }
+              }
+            );
+          }
+        );
+      }
 
       function getSearchURLS(groups){
         return $q(function(resolve, reject) {
@@ -183,7 +235,10 @@ define(['angular', 'jquery'], function(angular, $) {
       }
       
       return {
-          getSearchURLS: getSearchURLS
+          getSearchURLS: getSearchURLS,
+          getKBSearchURL: getKBSearchURL,
+          getEventSearchURL : getEventSearchURL,
+          getHelpDeskHelpURL : getHelpDeskHelpURL
       };
     }]);
     


### PR DESCRIPTION
Now when you get zero search results and you are not in the UW-Madison group, you'll only see the help that's configured.

Example of UWRF on search:
![image](https://cloud.githubusercontent.com/assets/5521429/13473687/137c131a-e080-11e5-93c8-560ba28d3995.png)

Example of UWRF on browse:
![image](https://cloud.githubusercontent.com/assets/5521429/13473729/3b99b8b6-e080-11e5-8471-8a09117b9e81.png)


But of course, at UW we have the whole collection configured:
![image](https://cloud.githubusercontent.com/assets/5521429/13473759/6ba702fc-e080-11e5-915b-002ab91683b8.png)

and
![image](https://cloud.githubusercontent.com/assets/5521429/13473781/8302e894-e080-11e5-8319-dba7a2113851.png)
