### PR TITLE
MUMUP-2439 Configure DoIT Help Desk URL as helpdeskURL for UW River Falls.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/app-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/app-config.js
@@ -99,7 +99,8 @@ define(['angular'], function(angular) {
             "group" : "UW System-River Falls",
             "googleSearchURL" : "/web/api/uwrfsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&hl=en&prettyPrint=false&source=gcsc&gss=.com&sig=432dd570d1a386253361f581254f9ca1&cx=004071655910512460416:8kmve-tofw8&googlehost=www.google.com&nocache=1456777578251&",
             "webSearchURL" : "https://www.uwrf.edu/AboutUs/SearchResults.cfm?q=",
-            "domainResultsLabel" : "UWRF.edu"
+            "domainResultsLabel" : "UWRF.edu",
+            'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/'
           }
         ])
         .value('APP_BETA_FEATURES', [


### PR DESCRIPTION
( [MUMUP-2439](https://jira.doit.wisc.edu/jira/browse/MUMUP-2439) , tweak on changes in #419 .)

Per [KB documentation](https://kb.wisc.edu/page.php?id=15303), the DoIT Help Desk is the right contact for non-username-or-password-related issues for `my.wisconsin.edu` portal users, including UW River Falls.

By the time one sees the UW-River-Falls-specific search config, one is logged in, so the not-username-or-password-related hurdle is already jumped.

So configure the same `helpdeskURL` for UWRF as is configured for Madison.