### PR TITLE
Remove console.log statement

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -144,7 +144,6 @@ define(['angular'], function(angular){
           layoutService.getWidgetJson($scope.portlet).then(function(data) {
             $scope.loading = false;
             if(data) {
-              console.log(data);
               $scope.portlet.widgetData = data;
               $scope.content = $scope.portlet.widgetData;
               if(Array.isArray($scope.content) &&  $scope.content.length == 0) {


### PR DESCRIPTION
This console.log statement clutters up the console, and started to bother me. Anyone need this in there?