### PR TITLE
angularjs-portal docs section

### DIFF
--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,6 @@
+FROM docker.doit.wisc.edu/myuw/uw-docs:latest
+
+MAINTAINER Tim Levett <tim.levett@wisc.edu>
+
+COPY override.js /data/js/override.js
+COPY markdown/ /data/markdown/

--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+docker build -t docker.doit.wisc.edu/myuw/ajsp-docs .
+
+docker stop ajsp-docs
+docker rm ajsp-docs
+docker run -d --name ajsp-docs -p 8010:8009 docker.doit.wisc.edu/myuw/ajsp-docs
+docker ps

--- a/docs/markdown/compact.md
+++ b/docs/markdown/compact.md
@@ -1,0 +1,1 @@
+#### TODO : Add documentation about compact mode

--- a/docs/markdown/expanded.md
+++ b/docs/markdown/expanded.md
@@ -1,0 +1,1 @@
+### TODO: Make documentation about expanded/widget mode

--- a/docs/markdown/home.md
+++ b/docs/markdown/home.md
@@ -1,0 +1,24 @@
+### AngularJS-Portal Documentation
+
+Thanks for visiting the documentation for [angularjs-portal](https://github.com/UW-Madison-DoIT/angularjs-portal). This documentation describes the features and implementation details of the angularjs-portal project, the new home of MyUW. angularjs-portal is based on uw-frame, if you want to learn about that I suggest looking at [that docs page](madison-doit.github.io/uw-frame/).
+
+#### Home Page Features
+
++ [Expanded Mode](#/md/expanded) - This is the home screen in expanded mode with widgets.
++ [Compact Mode](#/md/compact) - This mode is more compact, made for mobile view and minimalists.
++ [Widget Creator](https://tools.my.wisc.edu/widget-creator/#/default) - This tool helps you see your content before we add it to MyUW.
+
+#### Marketplace Features
++ Filtering by category
++ Details page
++ Deep Linking
++
+
+#### Search Features
++ App entries from uPortal
++ Google Custom Search formats
++ Directory search results
+
+#### Integration with uPortal
++ Overview
++ Customizations/Setup

--- a/docs/override.js
+++ b/docs/override.js
@@ -1,0 +1,24 @@
+define(['angular'], function(angular) {
+
+  /*Keep in sync with docs/mardown/configuration.md*/
+
+    var config = angular.module('override', []);
+    config
+        //see configuration.md for howto
+        .constant('OVERRIDE', {
+          'APP_FLAGS' : {
+            'showSearch' : false
+          },
+          'NAMES' : {
+            'title' : 'AngularJS-Portal Docs',
+            'fname' : 'ajsp-docs'
+          },
+          'MISC_URLS' : {
+            'rootURL' : '#/',
+            'loginURL' : 'https://github.com/UW-Madison-DoIT/angularjs-portal'
+          }
+        })
+
+    return config;
+
+});


### PR DESCRIPTION
Add in template for building out the documentation for angularjs-portal.  This uses https://github.com/UW-Madison-DoIT/uw-docs to generate a Docker container containing the markdown from this repo.  We will then post the Docker container on tools.my.wisc.edu/docs/angularjs-portal (or something like that).

![http://goo.gl/eVZ5hi](http://goo.gl/eVZ5hi)