### PR TITLE
MUMMNG-2404 Notify Portal Administrators that impersonate bugged.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/staticFeeds/notifications.json
+++ b/angularjs-portal-home/src/main/webapp/staticFeeds/notifications.json
@@ -41,6 +41,15 @@
         "actionURL" : "/portal/p/post-graduation-plans",
         "actionAlt" : "Access the post-graduation plans survey",
         "priority": false
-      }
+      },
+      {
+        "id"     : 7,
+        "groups" : ["Portal Administrators"],
+        "title"  : "User impersonation is currently bugged such that it does not work to impersonate users under HTML Responsive Design Profile aka Bucky aka New MyUW.  Impersonating other profiles will still work.",
+        "actionURL" : "https://jira.doit.wisc.edu/jira/browse/MUMUP-2454",
+        "actionAlt" : "MUMUP-2454 tracks the actual impersonation bug.",
+        "dismissable" : false,
+        "priority": true
+      },
     ]
 }


### PR DESCRIPTION
Use a Notification to notify Portal Administrators that user impersonation of Bucky profile is bugged.

Idea stems from @mrfarnham's understandable surprise that the feature was bugged, and thinking through how to effectively message about the issue in the context of its use.

`#dogfooding`. Effectively communicating this bug has some value, and there's also some value in the toy exercise of notifications.

If this idea goes forward, I'll add a sub-task to [MUMUP-2454](https://jira.doit.wisc.edu/jira/browse/MUMUP-2454)'s fixing of the bug to also expire out this notification.