### PR TITLE
Clarify that webPortletRender affects e.g. search results launch links.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/override.js
+++ b/angularjs-portal-home/src/main/webapp/js/override.js
@@ -68,7 +68,7 @@ define(['angular'], function(angular) {
             {
               "id" : "webPortletRender",
               "title" : "/web portlet rendering",
-              "description" : "Renders portlets via /web's exclusive page, but only as launched from compact-mode widgets"
+              "description" : "Renders portlets via /web's exclusive page, but not as launched from expanded widgets."
             },
             {
               "id" : "showKeywordsInMarketplace",


### PR DESCRIPTION
Adjust "/web portlet rendering" beta setting description to reflect that 

 * it's just expanded widgets that do not reflect `webPortletRender`, 
 * rather than just compact widgets that do reflect it.