### PR TITLE
MUMUP-2450: View more web search results should open in new tab

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -120,7 +120,7 @@
 
     </div>
     <div>
-      <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
+      <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}" target=_blank>View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
     </div>
   </div>
 


### PR DESCRIPTION
Open with new tab instead of  launch on the current page,using `target=_blank`