### PR TITLE
MUMUP-2346 : See all link in outages rss widgets should open new tab

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -377,7 +377,7 @@ define(['angular'], function(angular){
             widgetType : 'rss',
             title: 'RSS Widget',
             jsonSample: false,
-            widgetConfig : {lim : 6, showdate: true, titleLim: 40 , dateFormat: 'MM-dd-yyyy', showShowing: true},
+            widgetConfig : {lim : 6, target : '' ,showdate: true, titleLim: 40 , dateFormat: 'MM-dd-yyyy', showShowing: true},
             hasWidgetURL : true,
             widgetURL : ""
           },

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/rssfeed.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/rssfeed.html
@@ -18,4 +18,4 @@
       <li ng-if='isEmpty' class='no-highlight'>No information at this time.</li>
    </ul>
 </div>
-<a target='config.target' class='btn btn-default launch-app-button ng-scope' ng-href='{{portlet.url}}'>See all</a>
+<a target='{{config.target}}' class='btn btn-default launch-app-button ng-scope' ng-href='{{portlet.url}}'>See all</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/rssfeed.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/rssfeed.html
@@ -18,4 +18,4 @@
       <li ng-if='isEmpty' class='no-highlight'>No information at this time.</li>
    </ul>
 </div>
-<a class='btn btn-default launch-app-button ng-scope' ng-href='{{portlet.url}}'>See all</a>
+<a target='config.target' class='btn btn-default launch-app-button ng-scope' ng-href='{{portlet.url}}'>See all</a>


### PR DESCRIPTION
Adds the target attribute to be config.target, and then I will set the target to be equal to "_blank" in the outages entity files so that not all rss widgets are affected.