### PR TITLE
MUMUP-2548 Fixes wisc.edu google search

### DIFF
--- a/angularjs-portal-home/src/main/resources/endpoint.properties.example
+++ b/angularjs-portal-home/src/main/resources/endpoint.properties.example
@@ -48,7 +48,7 @@ uwmadisonreddit.attributes=
 
 wiscdirectory.uri=http://www.wisc.edu/directories/json
 
-wiscedusearch.uri=http://ajax.googleapis.com/ajax/services/search/web
+wiscedusearch.uri=https://www.googleapis.com/customsearch/v1element
 
 uwrfsearch.uri=https://www.googleapis.com/customsearch/v1element
 

--- a/angularjs-portal-home/src/main/webapp/js/web-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/web-config.js
@@ -5,7 +5,7 @@ define(['angular'], function(angular) {
       {
         "group" : "UW-Madison",
         "directorySearchURL" : "/web/api/wiscdirectory",
-        "googleSearchURL" : "/web/api/wiscedusearch?v=1.0&rsz=10&start=0&cx=001601028090761970182:2g0iwqsnk2m",
+        "googleSearchURL" : "/web/api/wiscedusearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&sig=b16e3ffbc96e4526fdc0cc8394bf713a&cx=001601028090761970182:uu2tbvfp4za&alt=json",
         "webSearchURL" : "http://www.wisc.edu/search/?q=",
         "domainResultsLabel" : "Wisc.edu",
         'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',


### PR DESCRIPTION
Alternative to https://github.com/UW-Madison-DoIT/angularjs-portal/pull/465

Updates wisc.edu search to up-to-date api.  Differs in https://github.com/UW-Madison-DoIT/angularjs-portal/pull/465 by not using the callback param, so no need to parse out comment.

After:
![image](https://cloud.githubusercontent.com/assets/5521429/15512584/447123ea-21a6-11e6-8b3d-7df88ab9dd55.png)
