### PR TITLE
MUMUP-2579 : Widget component

### DIFF
--- a/angularjs-portal-home/src/main/webapp/WEB-INF/web.xml
+++ b/angularjs-portal-home/src/main/webapp/WEB-INF/web.xml
@@ -97,6 +97,7 @@
       <url-pattern>/static/*</url-pattern>
       <url-pattern>/exclusive/*</url-pattern>
       <url-pattern>/widgets</url-pattern>
+      <url-pattern>/widget/*</url-pattern>
       <url-pattern>/list</url-pattern>
       <url-pattern>/expanded</url-pattern>
       <url-pattern>/compact</url-pattern>

--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -438,6 +438,16 @@ input:focus,span:focus {
     text-align: left;
     padding:0px 10px;
   }
+
+  .preview {
+    h2 {
+      text-align: center;
+    }
+    .middle {
+      width : 315px;
+      margin: auto;
+    }
+  }
 }
 
 @media (max-width:767px) {
@@ -500,5 +510,15 @@ input:focus,span:focus {
   .mp-opaque li {
     font-size:1em;
     padding:12px 0px;
+  }
+
+  .portlet-details-page .preview {
+    .middle {
+      width : 100%;
+
+      .fixed-width-widget {
+        width: inherit;
+      }
+    }
   }
 }

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -123,3 +123,12 @@ weather {
     }
   }
 }
+
+.fixed-width-widget {
+  width : 315px;
+}
+
+.widget-middle {
+  width : 315px;
+  margin : auto;
+}

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -111,8 +111,90 @@ define(['angular', 'jquery'], function(angular, $) {
 
         }]);
 
+   app.controller('BaseWidgetFunctionsController', [
+     '$scope',
+     '$location',
+     '$sessionStorage',
+     '$localStorage',
+     'sharedPortletService',
+     'layoutService',
+     'childController',
+     function($scope,
+              $location,
+              $sessionStorage,
+              $localStorage,
+              sharedPortletService,
+              layoutService,
+              childController) {
+       childController.portletType = function portletType(portlet) {
+           if (portlet.widgetType) {
+               if('option-link' === portlet.widgetType) {
+                   return "OPTION_LINK";
+               } else if('weather' === portlet.widgetType) {
+                   return "WEATHER";
+               } else if('generic' === portlet.widgetType) {
+                   return "GENERIC";
+               } else if('rss' === portlet.widgetType) {
+                   return "RSS";
+               } else if('list-of-links' === portlet.widgetType) {
+                   return "LOL";
+               } else if ('search-with-links' === portlet.widgetType) {
+                   return "SWL";
+               } else {
+                   return "WIDGET";
+               }
+
+           }else if(portlet.pithyStaticContent != null) {
+               return "PITHY";
+           } else if (portlet.staticContent != null
+               && portlet.altMaxUrl == false) {
+               return "SIMPLE";
+           } else {
+               return "NORMAL";
+           }
+       };
+
+       childController.renderURL = function renderURL(portlet) {
+         if(portlet.altMaxUrl == false && (portlet.renderOnWeb || $localStorage.webPortletRender)) {
+           return 'exclusive/' + portlet.fname;
+         } else {
+           return portlet.url;
+         }
+       }
+
+       childController.maxStaticPortlet = function gotoMaxStaticPortlet(portlet) {
+           sharedPortletService.setProperty(portlet);
+           $location.path('/static/'+portlet.fname);
+       };
+
+       childController.directToPortlet = function directToPortlet(url) {
+           $location.path(url);
+       };
+       childController.removePortlet = function removePortletFunction(nodeId, title) {
+           layoutService.removeFromHome(nodeId, title).success(function(){
+               $scope.$apply(function(request, text){
+                   var result = $.grep($scope.layout, function(e) { return e.nodeId === nodeId});
+                   var index = $.inArray(result[0], $scope.layout);
+                   //remove
+                   $scope.layout.splice(index,1);
+                   if($sessionStorage.marketplace != null) {
+                       var marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) { return e.fname === result[0].fname});
+                       if(marketplaceEntries.length > 0) {
+                           marketplaceEntries[0].hasInLayout = false;
+                       }
+                   }
+               });
+           }).error(
+           function(request, text, error){
+               alert('Issue deleting ' + title + ' from your list of favorites, try again later.');
+           });
+       };
+     }
+   ]);
+
 
     app.controller('WidgetController', [
+        '$controller',
         '$location',
         '$localStorage',
         '$sessionStorage',
@@ -121,7 +203,8 @@ define(['angular', 'jquery'], function(angular, $) {
         'layoutService',
         'miscService',
         'sharedPortletService',
-        function($location,
+        function($controller,
+                 $location,
                  $localStorage,
                  $sessionStorage,
                  $scope,
@@ -129,96 +212,36 @@ define(['angular', 'jquery'], function(angular, $) {
                  layoutService,
                  miscService,
                  sharedPortletService) {
-            if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
+        var base = $controller('BaseWidgetFunctionsController', { $scope : $scope, childController : this });
 
-                $rootScope.layout = [];
+        function init() {
+          if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
+            $rootScope.layout = [];
+            layoutService.getLayout().then(function(data){
+              $rootScope.layout = data.layout;
+              });
+           }
+         }
 
-                layoutService.getLayout().then(function(data){
-                    $rootScope.layout = data.layout;
-                });
-            }
+          $scope.sortableOptions = {
+              delay:250,
+              cursorAt : {top: 30, left: 30},
+              stop: function(e, ui) {
+                  if(ui.item.sortable.dropindex != ui.item.sortable.index) {
 
-            this.portletType = function portletType(portlet) {
-                if (portlet.widgetType) {
-                    if('option-link' === portlet.widgetType) {
-                        return "OPTION_LINK";
-                    } else if('weather' === portlet.widgetType) {
-                        return "WEATHER";
-                    } else if('generic' === portlet.widgetType) {
-                        return "GENERIC";
-                    } else if('rss' === portlet.widgetType) {
-                        return "RSS";
-                    } else if('list-of-links' === portlet.widgetType) {
-                        return "LOL";
-                    } else if ('search-with-links' === portlet.widgetType) {
-                        return "SWL";
-                    } else {
-                        return "WIDGET";
-                    }
-
-                }else if(portlet.pithyStaticContent != null) {
-                    return "PITHY";
-                } else if (portlet.staticContent != null
-                    && portlet.altMaxUrl == false) {
-                    return "SIMPLE";
-                } else {
-                    return "NORMAL";
-                }
-            };
-
-            this.renderURL = function renderURL(portlet) {
-              if(portlet.altMaxUrl == false && (portlet.renderOnWeb || $localStorage.webPortletRender)) {
-                return 'exclusive/' + portlet.fname;
-              } else {
-                return portlet.url;
-              }
-            }
-
-            this.maxStaticPortlet = function gotoMaxStaticPortlet(portlet) {
-                sharedPortletService.setProperty(portlet);
-                $location.path('/static/'+portlet.fname);
-            };
-
-            this.directToPortlet = function directToPortlet(url) {
-                $location.path(url);
-            };
-            this.removePortlet = function removePortletFunction(nodeId, title) {
-                layoutService.removeFromHome(nodeId, title).success(function(){
-                    $scope.$apply(function(request, text){
-                        var result = $.grep($scope.layout, function(e) { return e.nodeId === nodeId});
-                        var index = $.inArray(result[0], $scope.layout);
-                        //remove
-                        $scope.layout.splice(index,1);
-                        if($sessionStorage.marketplace != null) {
-                            var marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) { return e.fname === result[0].fname});
-                            if(marketplaceEntries.length > 0) {
-                                marketplaceEntries[0].hasInLayout = false;
-                            }
-                        }
-                    });
-                }).error(
-                function(request, text, error){
-                    alert('Issue deleting ' + title + ' from your list of favorites, try again later.');
-                });
-            };
-
-            $scope.sortableOptions = {
-                delay:250,
-                cursorAt : {top: 30, left: 30},
-                stop: function(e, ui) {
-                    if(ui.item.sortable.dropindex != ui.item.sortable.index) {
-
-                        var node = $scope.layout[ui.item.sortable.dropindex];
+                      var node = $scope.layout[ui.item.sortable.dropindex];
+                      if(console) {
                         console.log("Change happened, logging move of " + node.fname + " from " + ui.item.sortable.index + " to " + ui.item.sortable.dropindex);
-                        //index, length, movingNodeId, previousNodeId, nextNodeId
-                        var prevNodeId = ui.item.sortable.dropindex != 0 ? $scope.layout[ui.item.sortable.dropindex - 1].nodeId : "";
-                        var nextNodeId = ui.item.sortable.dropindex != $scope.layout.length - 1 ? $scope.layout[ui.item.sortable.dropindex + 1].nodeId : "";
-                        layoutService.moveStuff(ui.item.sortable.dropindex, $scope.layout.length, node.nodeId, prevNodeId, nextNodeId);
+                      }
+                      //index, length, movingNodeId, previousNodeId, nextNodeId
+                      var prevNodeId = ui.item.sortable.dropindex != 0 ? $scope.layout[ui.item.sortable.dropindex - 1].nodeId : "";
+                      var nextNodeId = ui.item.sortable.dropindex != $scope.layout.length - 1 ? $scope.layout[ui.item.sortable.dropindex + 1].nodeId : "";
+                      layoutService.moveStuff(ui.item.sortable.dropindex, $scope.layout.length, node.nodeId, prevNodeId, nextNodeId);
+                  }
+              }
+          };
 
-                    }
-                }
-            };
-
+          init();
         }]);
 
     app.controller('NewStuffController', ['$scope', 'layoutService', function ($scope, layoutService){

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
@@ -125,16 +125,12 @@ define(['angular', 'require'], function(angular, require) {
                 $scope.portlet = data.portlet;
                 if (typeof $scope.portlet === 'undefined' ||
                     typeof $scope.portlet.fname === 'undefined') {
-                    if(result.status === 403) {
-                      $scope.loaded = true;
-                      $scope.empty = false;
-                      $scope.portlet = {};
-                      $scope.portlet.title = 'Access Denied';
-                      $scope.portlet.faIcon = 'fa-exclamation-triangle';
-                      $scope.portlet.exclusiveContent = result.deniedTemplate;
-                    } else {
-                      $location.path('/');
-                    }
+                    $scope.loaded = true;
+                    $scope.empty = false;
+                    $scope.portlet = {};
+                    $scope.portlet.title = 'Widget Missing';
+                    $scope.portlet.faIcon = 'fa-exclamation-triangle';
+                    $scope.portlet.exclusiveContent = result.deniedTemplate;
                 } else {
                     $scope.loaded = true;
                 }

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
@@ -81,11 +81,69 @@ define(['angular', 'require'], function(angular, require) {
         }
     });
 
+    /**
+      Just the widget Card, gets the portlet from the scope.
+      Object must be in the portlet
+    **/
     app.directive('widgetCard', function(){
         return {
             restrict : 'E',
             templateUrl : require.toUrl('./partials/widget-card.html')
         }
+    });
+
+    /**
+      * Independent widget that does everything
+      * fname : the fname of the object you wish to display
+      */
+    app.component('widget', {
+      bindings : {
+        fname : '<'
+      },
+      templateUrl: require.toUrl('./partials/single-widget-component.html'),
+      controllerAs: 'widgetCtrl',
+      controller: function($scope,
+                           $controller,
+                           $location,
+                           layoutService) {
+        var that = this;
+        $scope.portlet = { title: 'loading...'};
+        $scope.removable = false;
+        this.$onInit = function() {
+          var base = $controller('BaseWidgetFunctionsController', { $scope : $scope, childController : that });
+        }
+
+        this.$onChanges = function(changesObj) {
+          if(changesObj
+              && changesObj.fname
+              && changesObj.fname.currentValue
+              && changesObj.fname.currentValue
+                  !== changesObj.fname.previousValue) {
+            var fname = changesObj.fname.currentValue;
+            layoutService.getApp(fname).then(function (result) {
+                var data = result.data;
+                $scope.portlet = data.portlet;
+                if (typeof $scope.portlet === 'undefined' ||
+                    typeof $scope.portlet.fname === 'undefined') {
+                    if(result.status === 403) {
+                      $scope.loaded = true;
+                      $scope.empty = false;
+                      $scope.portlet = {};
+                      $scope.portlet.title = 'Access Denied';
+                      $scope.portlet.faIcon = 'fa-exclamation-triangle';
+                      $scope.portlet.exclusiveContent = result.deniedTemplate;
+                    } else {
+                      $location.path('/');
+                    }
+                } else {
+                    $scope.loaded = true;
+                }
+            });
+          }
+        }
+
+
+      }
     });
 
     return app;

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/single-widget-component.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/single-widget-component.html
@@ -1,0 +1,3 @@
+<div class="fixed-width-widget">
+  <widget-card></widget-card>
+</div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -1,22 +1,22 @@
-<div class="widget-frame" id="portlet-id-{{::portlet.nodeId}}">
+<div class="widget-frame" id="portlet-id-{{portlet.nodeId}}">
   <div class="widget-header">
     <!-- Widget Chrome -->
     <div class='widget-info'>
       <i title="Info" class="fa fa-info-circle"
-      tooltip="{{::portlet.description}}"
+      tooltip="{{portlet.description}}"
       tooltip-trigger="mouseenter"
       tooltip-placement="top"
       tooltip-popup-delay="200"></i>
     </div>
-    <div class='widget-remove' ng-hide='GuestMode'>
+    <div class='widget-remove' ng-hide='GuestMode || !removable'>
       <i title="Remove" class="fa fa-times portlet-options" ng-click="widgetCtrl.removePortlet(portlet.nodeId, portlet.title)"><a aria-label="Remove this app" href="#"></a></i>
     </div>
 
     <div class="widget-title">
-      <h4 id="appTitle_portlet.title-{{::portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{::portlet.nodeId}}" tabindex="0">{{ ::portlet.title }}</h4>
+      <h4 id="appTitle_portlet.title-{{portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">{{portlet.title }}</h4>
     </div>
   </div>
-  <sub class="sr-only" id="goToApps-{{::portlet.nodeId}}">go to</sub>
+  <sub class="sr-only" id="goToApps-{{portlet.nodeId}}">go to</sub>
   <!-- For widgets, show fancy markup! -->
   <div ng-if="'WIDGET' === widgetCtrl.portletType(portlet)">
     <div class="widget-content">
@@ -27,7 +27,7 @@
        </div>
        <div ng-bind-html="portlet.widgetContent"></div>
     </div>
-    <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch full app</a>
+    <a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
   </div>
 
   <div ng-switch='widgetCtrl.portletType(portlet)'>
@@ -57,7 +57,7 @@
       <div class="portlet-content">
          <div ng-bind-html="portlet.pithyStaticContent"></div>
       </div>
-      <a class="btn btn-default launch-app-button" href="{{::portlet.url}}" target="{{::portlet.target}}">Launch full app</a>
+      <a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
     </div>
 
     <div ng-switch-when="GENERIC">
@@ -79,11 +79,11 @@
     </div>
 
     <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
-    <a tabindex="-1" ng-switch-when="NORMAL" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{::portlet.target}}">
+    <a tabindex="-1" ng-switch-when="NORMAL" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}">
       <div class="widget-icon-container">
         <portlet-icon></portlet-icon>
       </div>
-      <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
+      <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
     </a>
 
     <!-- For simple content portlets, show only an icon -->
@@ -91,7 +91,7 @@
       <div class="widget-icon-container">
         <portlet-icon></portlet-icon>
       </div>
-      <button aria-labelledby="goToApps-{{::portlet.nodeId}} appTitle_portlet.title-{{::portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
+      <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
     </a>
 
   </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/routes.js
@@ -2,6 +2,12 @@ define(['require'], function(require){
 
     return {
       widgetView : {templateUrl: require.toUrl('./partials/home-widget-view.html')},
+      widgetFullScreen : {
+                           template: '<div class="widget-middle"><widget fname="$routeParams.fname"></widget></div>',
+                           controller: function($routeParams, $scope){
+                             $scope.$routeParams = $routeParams;
+                           }
+                         },
       widgetCreator : {templateUrl: require.toUrl('./partials/widget-creator.html')}
     }
 

--- a/angularjs-portal-home/src/main/webapp/my-app/main.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/main.js
@@ -68,6 +68,7 @@ define([
             when('/features', featuresRoute).
             when('/static/:fname', staticRoutes.staticMax).
             when('/exclusive/:fname', staticRoutes.exclusiveMax).
+            when('/widget/:fname', widgetRoutes.widgetFullScreen).
             when('/about', aboutRoute).
             when('/widget-creator', widgetRoutes.widgetCreator).
             otherwise(layoutRoute);

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -62,7 +62,7 @@
        </div>
 		</div>
 	</div>
-	<div class="row no-margin"  ng-if='!loading && !error'>
+	<div class="row no-margin details-header"  ng-if='!loading && !error'>
 		<div class="col-xs-12 col-sm-4 col-lg-3 desc-item">
 			<h3 tabindex="0" class="center">Description</h3>
 			<p tabindex="0" class="app-description">{{::portlet.description}}</p>
@@ -103,6 +103,13 @@
 	    </ul>
 		</div>
 	</div>
+
+  <div class='preview'>
+    <h2>Widget Preview</h2>
+    <div class='middle'>
+      <widget fname="portlet.fname"></widget>
+    </div>
+  </div>
 
 	<div class="portlet-footer left">
 	 	<ul>

--- a/angularjs-portal-mock-portal/src/main/webapp/web/portlet/wisc-mail.json
+++ b/angularjs-portal-mock-portal/src/main/webapp/web/portlet/wisc-mail.json
@@ -1,0 +1,25 @@
+{
+  "portlet": {
+             "nodeId":"u47l1n6",
+             "title":"Email",
+             "description":"Access your UW email account (Office 365, WiscMail, and WiscMail Plus).",
+             "url":"/portal/f/u47l1s4/p/wisc-mail.u47l1n6/max/render.uP",
+             "iconUrl":null,
+             "faIcon":"fa-envelope",
+             "fname":"wisc-mail",
+             "target":null,
+             "widgetURL":"/web/staticFeeds/wiscmail-accounts.json",
+             "widgetType":"option-link",
+             "widgetTemplate":null,
+             "widgetConfig":{
+                "value":"uri",
+                "display":"email",
+                "arrayName":"linked",
+                "singleElement":true
+             },
+             "staticContent":null,
+             "pithyStaticContent":"\n        <div>\n        <p><a class=\"btn btn-default\"\n  href=\"https://wiscmail.wisc.edu/login/\" target=\"_blank\"\n  title=\"Launch email and calendar\">Launch email and calendar</a></p>\n        </div>\n        ",
+             "altMaxUrl":false,
+             "renderOnWeb":false
+          }
+}


### PR DESCRIPTION
+ Refactored a lot of the widget functions into a base controller
+ Adds `<widget fname="fname"></widget>` component. fname is one way bound using the new component. This then calls for the meta data of that widget, and then processes the portlet.
+ Adds a full screen widget view at `/web/widget/:fname`. Currently nothing links to that.
![http://goo.gl/NGFwM2](http://goo.gl/NGFwM2)
+ Adds a widget preview section to the details page.
![http://goo.gl/K8rIsi](http://goo.gl/K8rIsi)
