### PR TITLE
List-of-links with single link should fall back to normal display

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -142,13 +142,20 @@ define(['angular', 'jquery'], function(angular, $) {
                } else if('rss' === portlet.widgetType) {
                    return "RSS";
                } else if('list-of-links' === portlet.widgetType) {
-                   return "LOL";
+				   if (portlet.widgetConfig.links.length != 1) {
+					   return "LOL";
+				   } else if (portlet.widgetConfig.links.length === 1 && portlet.altMaxUrl) {
+					   // If list of links has only one link and if it is the same as the portlet URL, display the
+					   // normal portlet view
+					   if (portlet.widgetConfig.links[0].href === portlet.url) {
+						   return "NORMAL";
+					   }
+				   }
                } else if ('search-with-links' === portlet.widgetType) {
                    return "SWL";
                } else {
                    return "WIDGET";
                }
-
            }else if(portlet.pithyStaticContent != null) {
                return "PITHY";
            } else if (portlet.staticContent != null
@@ -165,7 +172,7 @@ define(['angular', 'jquery'], function(angular, $) {
          } else {
            return portlet.url;
          }
-       }
+       };
 
        childController.maxStaticPortlet = function gotoMaxStaticPortlet(portlet) {
            sharedPortletService.setProperty(portlet);

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -142,12 +142,10 @@ define(['angular', 'jquery'], function(angular, $) {
                } else if('rss' === portlet.widgetType) {
                    return "RSS";
                } else if('list-of-links' === portlet.widgetType) {
-				   if (portlet.widgetConfig.links.length === 1 && portlet.altMaxUrl) {
+				   if (portlet.widgetConfig.links.length === 1 && portlet.altMaxUrl && portlet.widgetConfig.links[0].href === portlet.url) {
 					   // If list of links has only one link and if it is the same as the portlet URL, display the
 					   // normal portlet view
-					   if (portlet.widgetConfig.links[0].href === portlet.url) {
-						   return "NORMAL";
-					   }
+					   return "NORMAL";
 				   } else {
 					   return "LOL";
 				   }

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -142,14 +142,14 @@ define(['angular', 'jquery'], function(angular, $) {
                } else if('rss' === portlet.widgetType) {
                    return "RSS";
                } else if('list-of-links' === portlet.widgetType) {
-				   if (portlet.widgetConfig.links.length != 1) {
-					   return "LOL";
-				   } else if (portlet.widgetConfig.links.length === 1 && portlet.altMaxUrl) {
+				   if (portlet.widgetConfig.links.length === 1 && portlet.altMaxUrl) {
 					   // If list of links has only one link and if it is the same as the portlet URL, display the
 					   // normal portlet view
 					   if (portlet.widgetConfig.links[0].href === portlet.url) {
 						   return "NORMAL";
 					   }
+				   } else {
+					   return "LOL";
 				   }
                } else if ('search-with-links' === portlet.widgetType) {
                    return "SWL";


### PR DESCRIPTION
In this PR:
- List-of-links widgets will display as default widgets if the following criteria are met:
    - `widgetType` is list-of-links
    - there is only one link in `widgetConfig.links`
    - `altMaxUrl` is true
    - the URL of that link is the same as the portlet's `url` attribute

### Screenshot
![screen shot 2016-07-26 at 1 58 33 pm](https://cloud.githubusercontent.com/assets/5818702/17151661/fd93fd60-5339-11e6-9878-4481a5ac90ea.png)

**Note:** I tested this by changing the mock data so that the Manager Time and Approval widget meets all the criteria mentioned above. I did not push those changes.
