### PR TITLE
Hotfix materialized widget display issues

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -1,3 +1,17 @@
+widget-card {
+  .widget-header {
+    .md-title {
+      font-size: 18px;
+      font-weight: 200;
+    }
+  }
+  .widget-content {
+    height: 100%;
+    padding: 0;
+    margin-bottom: 36px;
+  }
+}
+
 weather {
   .forecast .day {
       text-align: center;

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -1,5 +1,6 @@
 widget-card {
   .widget-header {
+    padding: 8px;
     .md-title {
       font-size: 18px;
       font-weight: 200;
@@ -9,6 +10,9 @@ widget-card {
     height: 100%;
     padding: 0;
     margin-bottom: 36px;
+    .bold {
+      font-weight: 500;
+    }
   }
 }
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -1,5 +1,5 @@
 <md-card class="widget-frame" id="portlet-id-{{portlet.nodeId}}">
-  <md-card-header>
+  <md-card-header class="widget-header">
     <!-- Widget Chrome -->
     <div class='widget-info'>
       <i title="Info" class="fa fa-info-circle"
@@ -16,7 +16,7 @@
       <span class='md-title' style='text-align: center;' id="appTitle_portlet.title-{{portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">{{portlet.title }}</span>
     </md-card-header-text>
   </md-card-header>
-  <md-card-content style='padding: 0 !important;'>
+  <md-card-content class="widget-content">
     <sub class="sr-only" id="goToApps-{{portlet.nodeId}}">go to</sub>
     <!-- For widgets, show fancy markup! -->
     <div ng-if="'WIDGET' === widgetCtrl.portletType(portlet)">


### PR DESCRIPTION
Widget body is now 100% height with a 36px bottom margin (the height of the "launch" button). This should ensure that all of the widget's content is displayed, but it's not a perfect fix. I think the underlying structure of widgets should be revisited long-term. I also plan on materializing the `<circle-button>` directive, which should help. 

### Screenshot
![screen shot 2016-07-29 at 11 46 13 am](https://cloud.githubusercontent.com/assets/5818702/17256261/621843aa-5582-11e6-9286-2deb13a1a699.png)
