### PR TITLE
MUMUP-1536 link ratings API from details page, if beta setting.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/override.js
+++ b/angularjs-portal-home/src/main/webapp/js/override.js
@@ -66,6 +66,11 @@ define(['angular'], function(angular) {
               "description" : "Enable/Disable keywords showing up in marketplace details"
             },
             {
+              "id" : "linkRatingsApi",
+              "title" : "Link ratings API",
+              "description" : "Links the ratings JSON API from the ratings count in the details page for each app. Actual access to this JSON API depends upon MANAGE permissions; this setting just includes the hyperlink in the UI for convenience."
+            },
+            {
               "id" : "exampleWidgets",
               "title" : "Example Widgets",
               "description" : "Show the My Courses, Email, and Calendar example widgets"

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -248,7 +248,9 @@ define(['angular', 'jquery'], function(angular, $) {
 
     app.controller('MarketplaceDetailsController', [
         '$controller', '$scope', '$routeParams', 'marketplaceService',
-        function($controller, $scope, $routeParams, marketplaceService) {
+        'SERVICE_LOC',
+        function($controller, $scope, $routeParams, marketplaceService,
+                 SERVICE_LOC) {
 
           $controller('marketplaceCommonFunctions', { $scope : $scope });
 
@@ -256,6 +258,8 @@ define(['angular', 'jquery'], function(angular, $) {
               currentCategory=category;
               currentPage='details';
           };
+          
+          $scope.ratingPrefix = SERVICE_LOC.base + SERVICE_LOC.marketplace.base;
 
           var figureOutBackStuff = function() {
             var fromInfo = marketplaceService.getFromInfo();

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -55,7 +55,7 @@
                         <span ng-if="$storage.linkRatingsApi">
                             <rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
                             
-                            ( <a ng-href="/portal/api/marketplace/{{portlet.fname}}/ratings">{{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span></a> )
+                            ( <a ng-href="{{ratingPrefix}}{{portlet.fname}}/ratings">{{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span></a> )
                             
                         </span>
                         <span ng-if="!$storage.linkRatingsApi">

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -52,7 +52,13 @@
                     </div>
                     <div class="desc-item">
                         <h3 tabindex="0" class="md-title">Ratings</h3>
-                        <span>
+                        <span ng-if="$storage.linkRatingsApi">
+                            <rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
+                            
+                            ( <a ng-href="/portal/api/marketplace/{{portlet.fname}}/ratings">{{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span></a> )
+                            
+                        </span>
+                        <span ng-if="!$storage.linkRatingsApi">
                             <rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
                             ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
                         </span>


### PR DESCRIPTION
Annette asked me to grab the ratings details for a particular app.

In the interest of enabling fishing:

Adds a beta setting:

![link ratings api](https://cloud.githubusercontent.com/assets/952283/17370708/b229a4d6-5962-11e6-894a-abd28ab54008.png)

If (default) not set, details page presents ratings as before.

![wiscard balance details](https://cloud.githubusercontent.com/assets/952283/17370746/d3fc83ee-5962-11e6-8d3d-99757f23206c.png)

If the beta setting is set, the details page presentation of ratings is enhanced with a hyperlink

![got hyperlink-](https://cloud.githubusercontent.com/assets/952283/17370801/1559ba5a-5963-11e6-92df-7f01fe9d3d8d.png)

to the raw JSON API.

```JSON
{"ratings":
  [
    {"rating":5,
     "review":"Exactly what you need to know about your Wiscard and the most important direct links for managing it - which aren't easy to find otherwise."}
  ]
}
```

Note that authorization is applied on the JSON API itself, so while anyone could flip the beta setting to get the hyperlink, this has no security implications.

The raw JSON API is probably a "good enough" administrative user experience for accessing this data for now, though of course it will be tempting for a talented front end developer ( @thevoiceofzeke ?) to give this a more beautiful experience. :)
