### PR TITLE
Adjust size/positioning of elements for some widget types

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -1,6 +1,5 @@
 widget-card {
   .widget-header {
-    padding: 8px;
     .md-title {
       font-size: 18px;
       font-weight: 200;
@@ -12,6 +11,12 @@ widget-card {
     margin-bottom: 36px;
     .bold {
       font-weight: 500;
+    }
+    .widget-type-container {
+      height: 196px;
+      .widget-icon-container {
+        height: 100%;
+      }
     }
   }
 }
@@ -148,8 +153,13 @@ weather {
   }
 }
 
-.widget-frame .widget-icon-container .option-link-icon i {
-  padding:30px 15px 10px;
+.widget-frame .widget-icon-container {
+  i {
+    padding: 0 0 30px;
+  }
+  .option-link-icon i {
+    padding:30px 15px 10px;
+  }
 }
 
 .scroll-widget {

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -1,11 +1,11 @@
 <script type="text/ng-template" id="toggle-modes.html">
   <div ng-controller="ToggleController">
-    <div ng-if='modeIs(MODES.EXPANDED)'>
-      <a href="javascript:;" ng-click="switchMode(MODES.COMPACT)">Show compact mode</a>
-    </div>
-    <div ng-if='modeIs(MODES.COMPACT)'>
-      <a href="javascript:;" ng-click="switchMode(MODES.EXPANDED)">Show expanded mode</a>
-    </div>
+    <md-menu-item ng-if='modeIs(MODES.EXPANDED)'>
+      <md-button class="md-accent" href="javascript:;" ng-click="switchMode(MODES.COMPACT)">Show Compact Mode</md-button>
+    </md-menu-item>
+    <md-menu-item ng-if='modeIs(MODES.COMPACT)'>
+      <md-button class="md-accent" href="javascript:;" ng-click="switchMode(MODES.EXPANDED)">Show Expanded Mode</md-button>
+    </md-menu-item>
   </div>
 </script>
 <app-header-two-way-bind app-title="'Home'"

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
@@ -1,20 +1,22 @@
-<div class="widget-icon-container">
-  <div class="option-link-icon">
-    <a href="{{portlet.selectedUrl}}" target="_blank"><portlet-icon></portlet-icon></a>
+<div class="widget-option-link" layout="column" layout-align="center center">
+  <div class="widget-icon-container">
+    <div class="option-link-icon">
+      <a href="{{portlet.selectedUrl}}" target="_blank"><portlet-icon></portlet-icon></a>
+    </div>
   </div>
-</div>
-<div>
-    <div ng-if="portlet.widgetData.length == 0" class='center'>
-        <loading-gif data-object='portlet.widgetData'></loading-gif>
-    </div>
-    <div ng-if="config.singleElement && (!portlet.widgetData[config.arrayName] || portlet.widgetData[config.arrayName].length == 0)" class='center'>
-        <span title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</span>
-    </div>
-    <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1" style='margin-top: -10px;'>
-       <select ng-model="portlet.selectedUrl" class='form-control'>
-           <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}" title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</option>
-           <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}" title='{{obj[config.display].length > 26 ? obj[config.display] : ""}}'>{{obj[config.display] | trimMiddle:26}}</option>
-       </select>
-    </div>
+  <div>
+      <div ng-if="portlet.widgetData.length == 0" class='center'>
+          <loading-gif data-object='portlet.widgetData'></loading-gif>
+      </div>
+      <div ng-if="config.singleElement && (!portlet.widgetData[config.arrayName] || portlet.widgetData[config.arrayName].length == 0)" class='center'>
+          <span title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</span>
+      </div>
+      <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1" style='margin-top: -10px;'>
+         <select ng-model="portlet.selectedUrl" class='form-control'>
+             <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}" title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</option>
+             <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}" title='{{obj[config.display].length > 26 ? obj[config.display] : ""}}'>{{obj[config.display] | trimMiddle:26}}</option>
+         </select>
+      </div>
+  </div>
 </div>
 <a class="btn btn-default launch-app-button" href="{{portlet.selectedUrl}}" target="_blank">Launch {{portlet.title}}</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -31,7 +31,7 @@
       <a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
     </div>
 
-    <div ng-switch='widgetCtrl.portletType(portlet)'>
+    <div ng-switch="widgetCtrl.portletType(portlet)" class="widget-type-container">
 
       <div ng-switch-when="OPTION_LINK">
         <option-link app="portlet" config="portlet.widgetConfig"></option-link>
@@ -81,7 +81,7 @@
 
       <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
       <a tabindex="-1" ng-switch-when="NORMAL" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}">
-        <div class="widget-icon-container">
+        <div class="widget-icon-container" layout="column" layout-align="center center">
           <portlet-icon></portlet-icon>
         </div>
         <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>
@@ -89,7 +89,7 @@
 
       <!-- For simple content portlets, show only an icon -->
       <a tabindex="-1" ng-switch-when="SIMPLE" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="simple-content-container">
-        <div class="widget-icon-container">
+        <div class="widget-icon-container" layout="column" layout-align="center center">
           <portlet-icon></portlet-icon>
         </div>
         <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="btn btn-default launch-app-button">Launch full app</button>


### PR DESCRIPTION
In this PR:
- Portlet title padding increased (so that content is not smashed up against title text)
- Structure/style of some widget types adjusted so that content is center-aligned vertically and horizontally
- mode toggle menu rewritten in material so that it fits in new, material frame

### Screenshot (compare to [predev](https://predev.my.wisc.edu/web/expanded))
![screen shot 2016-08-03 at 1 20 32 pm](https://cloud.githubusercontent.com/assets/5818702/17376877/1996bab8-597d-11e6-9b58-e77a78e2079b.png)

**Note**: You'll also notice that the circle buttons don't look quite right. There are some changes included in my uw-frame material PR to improve their appearance.