### PR TITLE
Fix display of add-favorites widget

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/home.less
+++ b/angularjs-portal-home/src/main/webapp/css/home.less
@@ -226,6 +226,9 @@ div.table-cell {
 .add-favorites {
   background:transparent;
   border:1px dashed #ccc;
+  display: flex;
+  justify-content: center;
+  align-items: center;
   &:hover {
     border:1px solid #f8f8f8;
   }


### PR DESCRIPTION
Changes to widget styles caused the "add to home" widget to display incorrectly. This is a fix for that specific widget.

![screen shot 2016-08-03 at 3 35 05 pm](https://cloud.githubusercontent.com/assets/5818702/17381155/2dca9dd4-5990-11e6-9dd1-5debf42bc294.png)
