### PR TITLE
Set default theme to first one and tab to 'Welcome' in master-overrides.js 

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/master-override.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-override.js
@@ -12,7 +12,7 @@ define(['angular'], function(angular) {
             'compact' : true,
             'expanded' : true,
             'isWeb' : true,
-            'defaultTheme' : 'group',
+            'defaultTheme' : 0,
             'debug' : true,
             'showUserSettingsPage' : true
           },
@@ -26,8 +26,8 @@ define(['angular'], function(angular) {
             'newstuffInfo': '/web/staticFeeds/new-stuff.json',
             'context'     : '/uPortal/',
             'base'        : '/uPortal/api/',
-            'layout'      : 'layoutDoc?tab=UW Bucky Home',
-            'layoutTab' : 'UW Bucky Home',
+            'layout'      : 'layoutDoc?tab=Welcome',
+            'layoutTab' : 'Welcome',
             'marketplace' : {
                 'base' : 'marketplace/',
                 'entry' : 'entry/',


### PR DESCRIPTION
Change defaultTheme to use first theme instead of group API service, which does not exist in base uPortal. Also changed to default uPortal tab.