### PR TITLE
Remove removed-widget toast and widget hover color

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/home.less
+++ b/angularjs-portal-home/src/main/webapp/css/home.less
@@ -8,9 +8,9 @@ default-card portlet-icon img {
 }
 
 .widget-remove {
-  top: 0px;
+  top: 0;
   position: absolute;
-  right:0px;
+  right:0;
 }
 
 .add-more {
@@ -39,7 +39,7 @@ default-card portlet-icon img {
 }
 .portlet-div:hover {
   background-color:#f3f3f3;
-  padding-left:0px;
+  padding-left:0;
   border-left:5px solid @color1;
   z-index:100;
 }
@@ -58,11 +58,11 @@ default-card portlet-icon img {
   color:#333;
 }
 .widget-content {
-  padding:0px 12px 0px 12px;
+  padding:0 12px 0 12px;
   height:80px;
 }
 .portlet-title {
-  margin: 0px;
+  margin: 0;
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   padding:6px 30px 5px 12px;
@@ -82,12 +82,12 @@ default-card portlet-icon img {
 .portlet-title > div {
   float: right;
   display: inline;
-  padding:0px;
+  padding:0;
 }
 .home-section-header {
   padding:10px 12px;
-  margin:0px;
-  margin-bottom:0px;
+  margin:0;
+  margin-bottom:0;
   color:#333;
   border-bottom:1px solid @color3;
   display:table;
@@ -100,7 +100,7 @@ default-card portlet-icon img {
 }
 .portlet-title div {
   position: relative;
-  top: 0px;
+  top: 0;
 }
 div.table {
   display : table;
@@ -112,7 +112,7 @@ div.table-cell {
   vertical-align : middle;
 }
 .ui-sortable-helper {
-  box-shadow:0px 0px 25px #ccc;
+  box-shadow:0 0 25px #ccc;
   -ms-transform: rotate(3deg); /* IE 9 */
   -webkit-transform: rotate(3deg); /* Chrome, Safari, Opera */
   transform: rotate(3deg);
@@ -135,13 +135,13 @@ div.table-cell {
 .tile-list {
   list-style-type: none;
   margin: 15px auto;
-  padding: 0px;
+  padding: 0;
   max-width:1200px;
 }
 
 // View Toggle
 .home-title {
-  padding:0px 0px 0px 15px;
+  padding:0 0 0 15px;
 
 }
 .inner-nav-container .inner-nav li.home-title {
@@ -149,7 +149,7 @@ div.table-cell {
   a {
     color:#555;
     font-weight:400;
-    border-right:0px solid transparent;
+    border-right:0 solid transparent;
     &:hover {
       cursor:default;
     }
@@ -175,28 +175,24 @@ div.table-cell {
   height:150px;
   color:#333;
   text-align:center;
+  &:hover {
+    cursor: pointer;
+  }
   a {
     display:block;
     height:100%;
-    box-shadow:0px 2px 0px #ddd;
+    box-shadow:0 2px 0 #ddd;
     border-radius:4px;
     &:hover {
       background-color:#f8f8f8;
-      color:@color1;
-      box-shadow:0px 3px 0px #ddd;
-      h4 {
-        color:@color1;
-      }
-      i {
-        color:@color1;
-      }
+      box-shadow:0 3px 0 #ddd;
     }
   }
   h4 {
     font-size:1.2em;
-    margin:0px;
+    margin:0;
     color:#333;
-    padding:0px 5px;
+    padding:0 5px;
   }
   div {
     display:inline-block;
@@ -233,7 +229,8 @@ div.table-cell {
     border:1px solid #f8f8f8;
   }
   a {
-    box-shadow:0px 0px 0px transparent;
+    transition: @button-transition;
+    box-shadow:0 0 0 transparent;
   }
 }
 .new-stuff p {
@@ -274,7 +271,7 @@ div.table-cell {
   font: bold 15px Sans-Serif;
   color: white;
   text-align: center;
-  text-shadow: rgba(255,255,255,0.5) 0px 1px 0px;
+  text-shadow: rgba(255,255,255,0.5) 0 1px 0;
   -webkit-transform: rotate(45deg);
   -moz-transform:    rotate(45deg);
   -ms-transform:     rotate(45deg);
@@ -290,9 +287,9 @@ div.table-cell {
   background-image:    -moz-linear-gradient(top, @demo-color, @demo-color-darker);
   background-image:     -ms-linear-gradient(top, @demo-color, @demo-color-darker);
   background-image:      -o-linear-gradient(top, @demo-color, @demo-color-darker);
-  -webkit-box-shadow: 0px 0px 3px rgba(0,0,0,0.3);
-  -moz-box-shadow:    0px 0px 3px rgba(0,0,0,0.3);
-  box-shadow:         0px 0px 3px rgba(0,0,0,0.3);
+  -webkit-box-shadow: 0 0 3px rgba(0,0,0,0.3);
+  -moz-box-shadow:    0 0 3px rgba(0,0,0,0.3);
+  box-shadow:         0 0 3px rgba(0,0,0,0.3);
   z-index:999;
 }
 
@@ -307,7 +304,7 @@ div.table-cell {
   z-index:9000;
   span {
     font-size:50px;
-    margin:30px 0px 10px;
+    margin:30px 0 10px;
   }
   a {
     color:@color1;

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -64,7 +64,6 @@ define(['angular', 'jquery'], function(angular, $) {
                         var index = $.inArray(result[0], $scope.layout);
                         //remove
                         $scope.layout.splice(index,1);
-                        $mdToast.show($mdToast.simple().textContent(title + " removed.").hideDelay(3000));
                         if($sessionStorage.marketplace != null) {
                             var marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) { return e.fname === result[0].fname});
                             if(marketplaceEntries.length > 0) {


### PR DESCRIPTION
In this PR:
- Toast message no longer appears upon removing a widget from home
- Hovering a compact widget no longer changes the widget's text/icon colors
- Fixed a bug where hovering some widgets did not change the cursor to a pointer (now all widgets behave the same on hover)
- Added a CSS transition to the add-favorites widget so it's background color changes smoothly instead of instantly