### PR TITLE
Improve cross-browser consistency of widget appearance

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -1,14 +1,15 @@
 widget-card {
   .widget-header {
-    height: 30%;
+    height: 20%;
     line-height: 1.1;
+    align-items: center;
     .md-title {
       font-size: 18px;
       font-weight: 200;
     }
   }
   .widget-content {
-    height: 70%;
+    height: 80%;
     padding: 0;
     margin-bottom: 36px;
     .bold {


### PR DESCRIPTION
Noticed that IE still had the clipping issue, where some of the widget content was not visible. Made a small change that should fix it for now. I still think the overall structure of widgets should be overhauled in the future.

### Screenshots (IE, then Chrome)
![screen shot 2016-08-24 at 2 11 47 pm](https://cloud.githubusercontent.com/assets/5818702/17944344/fe565d92-6a04-11e6-997c-53ad4bf15f3c.png)
![screen shot 2016-08-24 at 2 11 55 pm](https://cloud.githubusercontent.com/assets/5818702/17944348/035745ae-6a05-11e6-8aeb-9d1a87aace4f.png)

