### PR TITLE
Improve consistency of widget appearance

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -96,12 +96,26 @@ rss {
 
 /* SEARCH WITH LINKS */
 swl {
+  md-input-container {
+    margin-top: 0;
+    padding-right: 16px;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    align-content: flex-start;
+    .md-button {
+      margin: 0;
+      padding: 0;
+    }
+  }
   div[class^="search-with-links__"] {
     display: flex;
     flex-direction: row;
     justify-content: center;
     align-items: baseline;
     align-content: center;
+    width: 100%;
     circle-button {
       width: 120px;
       height: 88px;

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -1,24 +1,44 @@
-widget-card {
-  .widget-header {
-    height: 20%;
-    line-height: 1.1;
-    align-items: center;
-    .md-title {
-      font-size: 18px;
-      font-weight: 200;
-    }
-  }
-  .widget-content {
-    height: 80%;
+/* LIST OF LINKS */
+lol {
+  .list-of-links {
+    height: 194px;
     padding: 0;
-    margin-bottom: 36px;
-    .bold {
-      font-weight: 500;
-    }
-    .widget-type-container {
-      height: 196px;
-      .widget-icon-container {
-        height: 100%;
+    div[class^="list-of-links__"] {
+      height: 194px;
+      overflow: hidden;
+      display: flex;
+      flex-flow: row wrap;
+      &.list-of-links__1 {
+        justify-content: center;
+        align-items: center;
+        align-content: center;
+      }
+      &.list-of-links__2 {
+        justify-content: space-around;
+        align-items: baseline;
+        align-content: center;
+        padding: 40px 0;
+      }
+      &.list-of-links__3 {
+        justify-content: space-around;
+        align-items: baseline;
+        align-content: space-around;
+      }
+      &.list-of-links__4 {
+        justify-content: space-around;
+        align-items: baseline;
+        align-content: flex-start;
+      }
+      &.list-of-links__long {
+        justify-content: space-around;
+        .widget-list a:hover {
+          cursor: pointer;
+        }
+      }
+      circle-button {
+        width: 120px;
+        height: 88px;
+        text-align: center;
       }
     }
   }
@@ -168,27 +188,6 @@ weather {
 .scroll-widget {
   max-height: 210px;
   overflow-y: scroll;
-}
-.lol {
-  .v-center {
-    position:relative;
-    top:40px;
-  }
-  .link-icon {
-    font-weight:600;
-  }
-  .link-icon i {
-    color:@color1;
-    padding-right:10px;
-  }
-  .col-xs-6 {
-    height:95px;
-    padding:0 !important;
-  }
-  .additional-text {
-    position:relative;
-    top:70px;
-  }
 }
 
 .rss {

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -66,6 +66,34 @@ option-link {
   }
 }
 
+/* RSS FEED WIDGET */
+rss {
+  .rss {
+    overflow-y: hidden;
+    height: 194px;
+    .widget-list {
+      max-height: 194px;
+      li a {
+        div {
+          display: inline-block;
+        }
+        div.headline {
+          width: 80%;
+          font-size: 12px;
+        }
+        div.headline.nodate {
+          width: 100%;
+        }
+        div.date {
+          width: 18%;
+          font-size: 10px;
+          vertical-align: top;
+        }
+      }
+    }
+  }
+}
+
 weather {
   .forecast .day {
       text-align: center;
@@ -202,27 +230,6 @@ weather {
 .scroll-widget {
   max-height: 210px;
   overflow-y: scroll;
-}
-
-.rss {
-  overflow-y: hidden; max-height: 210px;
-  .widget-list li a {
-    div {
-      display: inline-block;
-    }
-    div.headline {
-      width: 80%;
-      font-size: 12px;
-    }
-    div.headline.nodate {
-      width: 100%;
-    }
-    div.date {
-      width: 18%;
-      font-size: 10px;
-      vertical-align: top;
-    }
-  }
 }
 
 .fixed-width-widget {

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -44,6 +44,25 @@ lol {
   }
 }
 
+/* OPTION LINK */
+option-link {
+  .widget-option-link {
+    height: 196px;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    align-content: center;
+    align-items: center;
+    .option-link-icon {
+      margin-bottom: 16px;
+      i {
+        color: @grayscale10;
+        font-size: 70px;
+      }
+    }
+  }
+}
+
 weather {
   .forecast .day {
       text-align: center;
@@ -114,11 +133,6 @@ weather {
     }
   }
 }
-.widget-content option-link {
-  .widget-icon-container i {
-    padding:40px 10px 5px 10px;
-  }
-}
 
 .widget-frame {
   .widget-body {
@@ -179,9 +193,6 @@ weather {
 .widget-frame .widget-icon-container {
   i {
     padding: 0 0 30px;
-  }
-  .option-link-icon i {
-    padding:30px 15px 10px;
   }
 }
 

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -110,6 +110,27 @@ swl {
   }
 }
 
+/* NORMAL WIDGETS */
+.normal-widget {
+  height: 194px;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  align-content: center;
+  .widget-icon-container {
+    padding-top: 40px;
+  }
+  &:hover {
+    text-decoration: none !important;
+  }
+}
+
+/* GENERIC WIDGETS */
+.generic-widget {
+  height: 194px;
+}
+
+/* WEATHER WIDGET */
 weather {
   .forecast .day {
       text-align: center;
@@ -181,12 +202,6 @@ weather {
   }
 }
 
-.widget-frame {
-  .widget-body {
-    padding:0px 8px;
-  }
-}
-
 .list-content .widget-info,
 .widget-frame .widget-info, {
   position: absolute;
@@ -234,12 +249,6 @@ weather {
         color:#666;
       }
     }
-  }
-}
-
-.widget-frame .widget-icon-container {
-  i {
-    padding: 0 0 30px;
   }
 }
 

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -94,6 +94,22 @@ rss {
   }
 }
 
+/* SEARCH WITH LINKS */
+swl {
+  div[class^="search-with-links__"] {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: baseline;
+    align-content: center;
+    circle-button {
+      width: 120px;
+      height: 88px;
+      text-align: center;
+    }
+  }
+}
+
 weather {
   .forecast .day {
       text-align: center;

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -142,6 +142,16 @@ swl {
 /* GENERIC WIDGETS */
 .generic-widget {
   height: 194px;
+  md-input-container {
+    margin-top: 0;
+    margin-bottom: 0;
+    padding-right: 16px;
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    align-items: center;
+    align-content: flex-start;
+  }
 }
 
 /* WEATHER WIDGET */

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -60,6 +60,9 @@ option-link {
         font-size: 70px;
       }
     }
+    md-input-container {
+      margin: 0 0 18px 0;
+    }
   }
 }
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/lol.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/lol.html
@@ -1,33 +1,35 @@
-<div class='widget-body lol'>
-	 <div ng-show="config.links.length == 1">
-		 <div class='col-xs-6 col-xs-offset-3 v-center center' ng-repeat='item in config.links'>
-				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}' data-trunclen='24'></circle-button>
-     </div>
-	 </div>
-	 <div ng-show="config.links.length == 2">
-		 <div class='col-xs-6 v-center center' ng-repeat='item in config.links'>
-				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}' data-trunclen='24'></circle-button>
-     </div>
-		 <p class="bold center additional-text">{{config.additionalText}}</p>
-	 </div>
-	 <div ng-show="config.links.length == 3">
-		 <div ng-repeat="item in config.links">
-			 <div class='col-xs-6 center' ng-class="{'col-xs-offset-3':($index==2)}">
- 				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}' data-trunclen='24'></circle-button>
-       </div>
-		 </div>
-	 </div>
-	 <div ng-show="config.links.length == 4">
-		 <div class='col-xs-6 center' ng-repeat='item in config.links'>
-				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}' data-trunclen='24'></circle-button>
-     </div>
-	 </div>
-	 <div ng-show="config.links.length > 4">
-		 <ul class="widget-list">
-			 <li ng-repeat='item in config.links | limitTo: 7' class="link-icon">
-				 <i class="fa {{item.icon}}"></i><a href="{{item.href}}" target="{{item.target}}">{{item.title | truncate:24}}</a>
-			 </li>
-		 </ul>
-	 </div>
+<div class="widget-body list-of-links">
+
+  <!-- FOUR LINKS OR LESS -->
+  <div ng-show="config.links.length <= 4" class="list-of-links__{{config.links.length}}">
+    <circle-button ng-repeat="item in config.links"
+                   data-href="{{item.href}}"
+                   data-target="{{item.target}}"
+                   data-fa-icon="{{item.icon}}"
+                   data-disabled="false"
+                   data-title="{{item.title}}"
+                   data-trunclen="24">
+    </circle-button>
+  </div>
+
+  <!-- MORE THAN FOUR LINKS -->
+  <div ng-show="config.links.length > 4" class="list-of-links__long">
+    <ul class="widget-list">
+      <li ng-repeat='item in config.links | limitTo: 7' class="link-icon">
+        <i class="fa {{item.icon}}"></i>
+        <a ng-href="item.href" target="{{item.target}}">
+          {{item.title | truncate:24}}
+        </a>
+      </li>
+    </ul>
+  </div>
+
 </div>
-<a ng-if='config.launchText && portlet.url' class="btn btn-default launch-app-button" href="{{portlet.url}}" target="_blank">{{config.launchText}}</a>
+
+<!-- LAUNCH BUTTON -->
+<a ng-if='config.launchText && portlet.url'
+   class="launch-app-button"
+   ng-href="portlet.url"
+   target="_blank">
+  {{config.launchText}}
+</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
@@ -1,25 +1,37 @@
 <div class="widget-option-link" layout="column" layout-align="center center">
-  <div class="widget-icon-container">
-    <div class="option-link-icon">
-      <a href="{{portlet.selectedUrl}}" target="_blank"><portlet-icon></portlet-icon></a>
+
+  <!-- OPTION-LINK ICON -->
+  <div class="option-link-icon">
+    <a href="{{portlet.selectedUrl}}" target="_blank">
+      <portlet-icon></portlet-icon>
+    </a>
+  </div>
+
+  <!-- OPTION-LINK TEXT/CONTROLS -->
+  <div class="option-link-controls">
+    <!-- LOADING GIF IF EMPTY -->
+    <div ng-if="portlet.widgetData.length == 0" class="center">
+      <loading-gif data-object='portlet.widgetData'></loading-gif>
+    </div>
+    <!-- IF ONE ELEMENT -->
+    <div ng-if="config.singleElement && (!portlet.widgetData[config.arrayName] || portlet.widgetData[config.arrayName].length == 0)"
+         class="center">
+      <span title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>
+        {{portlet.widgetData[config.display] | trimMiddle:26}}
+      </span>
+    </div>
+    <!-- IF MORE THAN ONE ELEMENT -->
+    <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1" style='margin-top: -10px;'>
+      <select ng-model="portlet.selectedUrl" class='form-control'>
+        <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}" title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</option>
+        <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}" title='{{obj[config.display].length > 26 ? obj[config.display] : ""}}'>{{obj[config.display] | trimMiddle:26}}</option>
+      </select>
     </div>
   </div>
-  <div>
-      <div ng-if="portlet.widgetData.length == 0" class='center'>
-          <loading-gif data-object='portlet.widgetData'></loading-gif>
-      </div>
-      <div ng-if="config.singleElement && (!portlet.widgetData[config.arrayName] || portlet.widgetData[config.arrayName].length == 0)" class='center'>
-          <span title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</span>
-      </div>
-      <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1" style='margin-top: -10px;'>
-         <select ng-model="portlet.selectedUrl" class='form-control'>
-             <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}" title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</option>
-             <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}" title='{{obj[config.display].length > 26 ? obj[config.display] : ""}}'>{{obj[config.display] | trimMiddle:26}}</option>
-         </select>
-      </div>
-  </div>
 </div>
-<a class="btn btn-default launch-app-button"
+
+<!-- LAUNCH BUTTON -->
+<a class="launch-app-button"
    href="{{portlet.selectedUrl}}"
    target="_blank">
    <span ng-if='config.launchText'>{{config.launchText}}</span>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/option-link.html
@@ -21,11 +21,23 @@
       </span>
     </div>
     <!-- IF MORE THAN ONE ELEMENT -->
-    <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1" style='margin-top: -10px;'>
-      <select ng-model="portlet.selectedUrl" class='form-control'>
-        <option ng-if='config.singleElement' selected="selected" value="{{portlet.widgetData[config.value]}}" title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>{{portlet.widgetData[config.display] | trimMiddle:26}}</option>
-        <option ng-repeat='obj in portlet.widgetData[config.arrayName]' value="{{obj[config.value]}}" title='{{obj[config.display].length > 26 ? obj[config.display] : ""}}'>{{obj[config.display] | trimMiddle:26}}</option>
-      </select>
+    <div ng-if="portlet.widgetData && portlet.widgetData[config.arrayName] && portlet.widgetData[config.arrayName].length >= 1">
+      <md-input-container>
+        <md-select ng-model="portlet.selectedUrl" class="md-accent">
+          <md-option ng-if="config.singleElement" selected="selected"
+                     class="md-default"
+                     value="{{portlet.widgetData[config.value]}}"
+                     title='{{portlet.widgetData[config.display].length > 26 ? portlet.widgetData[config.display] : ""}}'>
+            {{portlet.widgetData[config.display] | trimMiddle:26}}
+          </md-option>
+          <md-option ng-repeat="obj in portlet.widgetData[config.arrayName]"
+                     class="md-default"
+                     value="{{obj[config.value]}}"
+                     title="{{obj[config.display].length > 26 ? obj[config.display] : ''}}">
+            {{obj[config.display] | trimMiddle:26}}
+          </md-option>
+        </md-select>
+      </md-input-container>
     </div>
   </div>
 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/rssfeed.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/rssfeed.html
@@ -3,7 +3,7 @@
    <ul class='widget-list'>
       <li ng-repeat='item in data.items | filter:filterText | limitTo:config.lim'>
         <a class='full-width' ng-href='{{item.link}}' target='_blank'>
-          <div class='headline bold' ng-class="{ 'nodate' :  !config.showdate }">
+          <div class='headline' ng-class="{ 'nodate' :  !config.showdate }">
             {{item.title | truncate:config.titleLim}}
           </div>
           <div class='date bold' ng-if='config.showdate'>
@@ -12,14 +12,14 @@
         </a>
       </li>
       <li ng-if='config.showShowing && config.lim && data.items.length > config.lim' class='no-highlight'>
-        <span class='center'><p class='bold'>Showing {{config.lim}} of {{data.items.length}}</p></span>
+        <p class='center'>Showing {{config.lim}} of {{data.items.length}}</p>
       </li>
       <li ng-if='error' class='no-highlight'>There was an issue loading the information, click see all for more details</li>
       <li ng-if='isEmpty' class='no-highlight'>No information at this time.</li>
    </ul>
 </div>
 <a target='{{config.target}}'
-   class='btn btn-default launch-app-button ng-scope'
+   class='launch-app-button ng-scope'
    ng-href='{{portlet.url}}'>
    <span ng-if='config.launchText'>{{config.launchText}}</span>
    <span ng-if='!config.launchText'>See all</span>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
@@ -1,18 +1,23 @@
-<div class='widget-body'>
+<div class="widget-body">
   <form action='{{secureURL}}' target='{{config.actionTarget}}'>
-     <div class='input-group'><input type='text' name='{{config.actionParameter}}' class='form-control' placeholder='{{config.searchPlaceholder}}'><span class='input-group-btn'><button class='btn btn-primary' type='submit'><i class='fa fa-search'></i></button></span></div>
+    <md-input-container class="md-block" md-no-float>
+      <input type="text" name="{{config.actionParameter}}" placeholder="{{config.searchPlaceholder}}">
+      <md-button type="submit" class="md-primary md-icon-button">
+        <i class="fa fa-search"></i>
+      </md-button>
+    </md-input-container>
   </form>
    <!-- Links -->
-   <div class='row'>
-     <div ng-show="config.links.length == 1">
-  		 <div class='col-xs-6 col-xs-offset-3 center' ng-repeat='item in config.links'>
-  				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}' data-trunclen='24'></circle-button>
-       </div>
-  	 </div>
-  	 <div ng-show="config.links.length == 2">
-  		 <div class='col-xs-6 center' ng-repeat='item in config.links'>
-  				<circle-button data-href='{{item.href}}' data-target='{{item.target}}' data-fa-icon='{{item.icon}}' data-disabled='false' data-title='{{item.title}}' data-trunclen='24'></circle-button>
-       </div>
+   <div layout="row">
+     <div class="search-with-links__{{config.links.length}}">
+       <circle-button ng-repeat="item in config.links"
+                      data-href="{{item.href}}"
+                      data-target="{{item.target}}"
+                      data-fa-icon="{{item.icon}}"
+                      data-disabled="false"
+                      data-title="{{item.title}}"
+                      data-trunclen="24">
+       </circle-button>
   	 </div>
    </div>
 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/search-with-links.html
@@ -16,7 +16,7 @@
   	 </div>
    </div>
 </div>
-<a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="_blank">
+<a class="launch-app-button" href="{{portlet.url}}" target="_blank">
   <span ng-if='config.launchText'>{{config.launchText}}</span>
   <span ng-if='!config.launchText'>Launch app</span>
 </a>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -62,10 +62,10 @@
         <div class="portlet-content">
            <div ng-bind-html="portlet.pithyStaticContent"></div>
         </div>
-        <a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
+        <a class="launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
       </div>
 
-      <div ng-switch-when="GENERIC">
+      <div ng-switch-when="GENERIC" class="generic-widget">
         <div ng-controller="GenericWidgetController as genericWidgetCtrl">
             <div ng-if="loading" id="loading">
                 <loading-gif data-object='content' data-empty='isEmpty'></loading-gif>
@@ -84,22 +84,22 @@
       </div>
 
       <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
-      <a tabindex="-1" ng-switch-when="NORMAL" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}">
+      <a tabindex="-1" ng-switch-when="NORMAL" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}" class="normal-widget">
         <div class="widget-icon-container" layout="column" layout-align="center center">
           <portlet-icon></portlet-icon>
         </div>
-        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="btn btn-default launch-app-button">
+        <button aria-label="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>
       </a>
 
       <!-- For simple content portlets, show only an icon -->
-      <a tabindex="-1" ng-switch-when="SIMPLE" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="simple-content-container">
+      <a tabindex="-1" ng-switch-when="SIMPLE" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="normal-widget">
         <div class="widget-icon-container" layout="column" layout-align="center center">
           <portlet-icon></portlet-icon>
         </div>
-        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="btn btn-default launch-app-button">
+        <button aria-label="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -107,5 +107,5 @@
 
     </div>
   </md-card-content>
-  
+
 </md-card>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -88,7 +88,7 @@
         <div class="widget-icon-container" layout="column" layout-align="center center">
           <portlet-icon></portlet-icon>
         </div>
-        <button aria-label="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
+        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>
@@ -99,7 +99,7 @@
         <div class="widget-icon-container" layout="column" layout-align="center center">
           <portlet-icon></portlet-icon>
         </div>
-        <button aria-label="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
+        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -1,4 +1,6 @@
 <md-card class="widget-frame" id="portlet-id-{{portlet.nodeId}}">
+
+  <!-- HEADER -->
   <md-card-header class="widget-header">
     <!-- Widget Chrome -->
     <div class='widget-info'>
@@ -16,6 +18,8 @@
       <span class='md-title' style='text-align: center;' id="appTitle_portlet.title-{{portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">{{portlet.title }}</span>
     </md-card-header-text>
   </md-card-header>
+
+  <!-- BODY -->
   <md-card-content class="widget-content">
     <sub class="sr-only" id="goToApps-{{portlet.nodeId}}">go to</sub>
     <!-- For widgets, show fancy markup! -->
@@ -103,4 +107,5 @@
 
     </div>
   </md-card-content>
+  
 </md-card>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -32,7 +32,7 @@
          </div>
          <div ng-bind-html="portlet.widgetContent"></div>
       </div>
-      <a class="btn btn-default launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
+      <a class="launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
     </div>
 
     <div ng-switch="widgetCtrl.portletType(portlet)" class="widget-type-container">


### PR DESCRIPTION
Widget consistency (or lack thereof) has been on my mind for a long time now. I want to get this up for the sake of gathering info/feedback before I spend too much time on this. It can always be tabled for later.

**In this PR**:
- Removed percentage-based sizes from most widget-related container classes (and replaced those with hard-coded pixels, since we know widgets will always be 290px high)
- Replaced/removed some bootstrap classes:
    - `option-link` widget input is now material
    - `list-of-links` widget now spaces its circle-button links with flex grid instead
    - launch buttons are no longer bootstrap buttons
    - `simple` and `normal` widget icon position is now flex-based

**Notes:** 
- This PR is part of a package that includes [myuw-overlays/entities #270](https://git.doit.wisc.edu/myuw-overlay/entities/merge_requests/270) and [uw-frame #285](https://github.com/UW-Madison-DoIT/uw-frame/pull/285)
- I backlogged stories for this work [here](https://jira.doit.wisc.edu/jira/browse/MUMUP-2700).

### Screenshots

#### list-of-links
![screen shot 2016-08-25 at 12 44 03 pm](https://cloud.githubusercontent.com/assets/5818702/17982360/1e33672c-6acd-11e6-8f6f-b3c8a229d5aa.png)
![screen shot 2016-08-25 at 12 46 09 pm](https://cloud.githubusercontent.com/assets/5818702/17982363/2213a320-6acd-11e6-9b40-aec01b9b9e6b.png)
![screen shot 2016-08-25 at 12 44 09 pm](https://cloud.githubusercontent.com/assets/5818702/17982370/26d06484-6acd-11e6-8f20-217a48999371.png)
![screen shot 2016-08-25 at 12 46 48 pm](https://cloud.githubusercontent.com/assets/5818702/17982376/2c2e7664-6acd-11e6-837c-5ccd00642a0e.png)
![screen shot 2016-08-25 at 12 49 37 pm](https://cloud.githubusercontent.com/assets/5818702/17982378/303bec78-6acd-11e6-9572-a3ef7c66ed1c.png)

#### normal/simple (identical markup)
![screen shot 2016-08-25 at 1 47 47 pm](https://cloud.githubusercontent.com/assets/5818702/17982388/36654b3a-6acd-11e6-88de-74ea4dfbe1c7.png)

#### rss
![screen shot 2016-08-25 at 1 27 06 pm](https://cloud.githubusercontent.com/assets/5818702/17982354/1a3f55ae-6acd-11e6-9417-795055b1783e.png)

#### option-link
![screen shot 2016-08-25 at 1 16 24 pm](https://cloud.githubusercontent.com/assets/5818702/17982394/3d6e3a18-6acd-11e6-929a-7c627a9c417f.png)

#### search-with-links
![screen shot 2016-08-25 at 2 30 57 pm](https://cloud.githubusercontent.com/assets/5818702/17983124/aa8025aa-6ad0-11e6-803b-09f5aaae0fb9.png)


#### generic 
![screen shot 2016-08-25 at 1 58 29 pm](https://cloud.githubusercontent.com/assets/5818702/17982421/63fe410a-6acd-11e6-863e-dd5ab9c223a1.png)

*Note the lack of box-shadow under the launch button*