### PR TITLE
Fix toggle using alternate hue of accent color

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -1,6 +1,6 @@
 <script type="text/ng-template" id="toggle-modes.html">
   <div ng-controller="ToggleController">
-    <md-switch class="md-accent md-hue-2 app-header-toggle" ng-model="expandedMode"
+    <md-switch class="md-accent app-header-toggle" ng-model="expandedMode"
                aria-label="Toggle expanded widget layout" ng-change="toggleMode(expandedMode)"
                style="margin-top:0;margin-bottom:0;">
       <span>Expand widgets</span>


### PR DESCRIPTION
Noticed during sprint review that "expand widgets" toggle was using a darker hue of the accent color, which is hard to see for some themes. This PR changes it back to using the default hue of the accent color.