### PR TITLE
Remove uppercase text-transform from marketplace details widgets

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -208,7 +208,6 @@
           cursor: pointer;
           white-space: nowrap;
           position: relative;
-          text-transform: uppercase;
           float: left;
           font-weight: 500;
           box-sizing: border-box;
@@ -486,7 +485,6 @@
         .widget-frame {
           margin: 0;
           .launch-app-button {
-            text-transform: uppercase;
             transition: @button-transition;
             &:hover {
               background: @grayscale8;


### PR DESCRIPTION
Launch button is no longer in all caps: 
![screen shot 2016-09-06 at 12 38 24 pm](https://cloud.githubusercontent.com/assets/5818702/18284266/f778dec6-742e-11e6-9acc-9df8c8880a15.png)
