### PR TITLE
Materialize search results page

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -43,7 +43,4 @@
       margin-left: 20px;
     }
   }
-  .md-tab {
-    text-transform: none;
-  }
 }

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -3,26 +3,43 @@
   margin: 15px;
   padding: 3px 0 0;
   .no-result {
-    padding: 10px 0 5px;
+    padding: 10px 16px;
   }
   hr {
     margin: 0;
   }
-
-  h4.header, .seeMoreResults {
-    margin: 10px 0 5px;
+  h4.md-subhead {
+    padding: 24px 16px 16px;
+    font-weight: 600;
+    margin: 0 0 6px 0;
+    position: relative;
+    color: #333;
+    font-size: 20px;
+    border-top: 1px solid rgba(0,0,0,0.12);
+    &:before {
+      content: "";
+      position: absolute;
+      left: 16px;
+      bottom: 0;
+      height: 6px;
+      width: 100px;
+      background: @color1;
+    }
+  }
+  .seeMoreResults {
+    padding: 10px 16px 20px;
   }
   .search-results-container {
-    padding: 0 10px 20px 20px;
+    padding: 0;
     .moreDetails{
       padding-top:5px;
     }
   }
   .result {
-    padding: 5px 0 5px;
+    padding: 2px 16px;
     h4 {
       font-weight: 400;
-      margin-bottom: 0;
+      margin-bottom: 4px;
     }
     p {
       margin: 0;

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -13,7 +13,7 @@
     margin: 10px 0 5px;
   }
   .search-results-container {
-    padding:20px 10px 20px 20px;
+    padding: 0 10px 20px 20px;
     .moreDetails{
       padding-top:5px;
     }

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -1,7 +1,6 @@
 .search-results {
   background-color: @white;
-  background-color: #fff;
-  margin:15px;
+  margin: 15px;
   padding: 3px 0 0;
   .no-result {
     padding: 10px 0 5px;
@@ -9,11 +8,7 @@
   hr {
     margin: 0;
   }
-  .inner-nav-container .inner-nav li {
-    &:focus {
-      outline:0;
-    }
-  }
+
   h4.header, .seeMoreResults {
     margin: 10px 0 5px;
   }
@@ -26,26 +21,29 @@
   .result {
     padding: 5px 0 5px;
     h4 {
-      font-weight:400;
-      margin-bottom:0px;
+      font-weight: 400;
+      margin-bottom: 0;
     }
     p {
-      margin:0px;
+      margin: 0;
       b {
         font-weight: 600;
       }
     }
-    a.add {
-      margin-right:15px;
+    .md-button.add {
+      margin-left: 0;
       &:hover {
-        cursor:pointer;
+        cursor: pointer;
       }
     }
     .added {
-      margin-right:15px;
+      margin-right: 15px;
     }
     .rating {
-      margin-left:20px;
+      margin-left: 20px;
     }
+  }
+  .md-tab {
+    text-transform: none;
   }
 }

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -16,14 +16,13 @@
     color: #333;
     font-size: 20px;
     border-top: 1px solid rgba(0,0,0,0.12);
-    &:before {
+    .subhead-border {
       content: "";
       position: absolute;
       left: 16px;
       bottom: 0;
       height: 6px;
       width: 100px;
-      background: @color1;
     }
   }
   .seeMoreResults {

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -1,144 +1,250 @@
-<div class="row search-results">
-  <div ng-show="googleSearchEnabled || directoryEnabled" class="inner-nav-container">
-    <ul class="inner-nav">
-      <li class="active" ng-click="filterTo('all')" id="all-selector">
-        <a>All ({{ totalCount }})</a>
-      </li>
-      <li ng-click="filterTo('myuw')" id="myuw-selector">
-        <a>MyUW ({{myuwFilteredResults.length}})</a>
-      </li>
-      <li ng-show="directoryEnabled" ng-click="filterTo('directory')" id="directory-selector">
-        <a>Directory ({{wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount}})</a>
-      </li>
-      <li ng-show="googleSearchEnabled" ng-click="filterTo('google')" id="google-selector">
-        <a>{{domainResultsLabel}} ({{googleResultsEstimatedCount}})</a>
-      </li>
-    </ul>
-  </div>
+<md-content class="search-results">
+  <md-tabs md-dynamic-height md-border-bottom ng-show="googleSearchEnabled || directoryEnabled">
 
-  <div id="myuw-results" class='search-results-container'>
-    <div id="myuw-results-header">
-      <h4 class="header">MyUW</h4>
-      <hr>
-    </div>
-    <loading-gif data-object='myuwResults'></loading-gif>
-    <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
-      No MyUW results. <a href="apps">Try browsing instead?</a>
-    </div>
-    <div ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)" class="result">
-      <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
-      <p>{{ portlet.description }}</p>
-      <p>
-        <a ng-click="addToHome(portlet)"
-           ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
-           class="add">
-          <i class="fa fa-plus"></i> Add to home
-        </a>
-        <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode"
-              class="added">
-          <i class="fa fa-check"></i> Added to home
-        </span>
-        <button class='btn btn-link' style='padding:0;' title='See more about {{portlet.title}}' ng-click='navToDetails(portlet, "Search")'>Details</button>
-        <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
-      </p>
-    </div>
-    <div class="marketplace-load-more" hide-while-loading ng-show="myuwFilteredResults.length > searchResultLimit">
-      <button class="btn btn-primary btn-lg"
-              ng-click="searchResultLimit = searchResultLimit + 20;"
-              hide-while-loading
-              ng-show="myuwFilteredResults.length > searchResultLimit"
-             >Load more MyUW results</button>
-    </div>
-  </div>
+    <!-- ALL RESULTS -->
+    <md-tab ng-click="filterTo('all')">
+      <md-tab-label>
+        All&nbsp;&nbsp;<span class="badge">{{ totalCount }}</span>
+      </md-tab-label>
+      <md-tab-body>
+        <md-content layout-padding>
+          <!-- MyUW results -->
+          <div class='search-results-container'>
+            <h4 class="header">MyUW</h4>
+            <hr>
+            <loading-gif data-object='myuwResults'></loading-gif>
+            <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
+              No MyUW results. <a href="apps">Try browsing instead?</a>
+            </div>
+            <div ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)"
+                 class="result">
+              <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
+              <p>{{ portlet.description }}</p>
+              <p>
+                <md-button ng-click="addToHome(portlet)"
+                   ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
+                   class="md-primary add">
+                  <i class="fa fa-plus"></i> Add to home
+                </md-button>
+                <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
+                <md-button class="md-default" title='See more about {{portlet.title}}' ng-click='navToDetails(portlet, "Search")'>Details</md-button>
+                <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
+              </p>
+            </div>
+            <marketplace-load-more ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
+          </div>
 
-  <!--wisc directory results-->
-  <div ng-show="directoryEnabled" id="wisc-directory-results" class='search-results-container'>
-    <div id="wisc-directory-results-header">
-      <h4 class='header'>Directory</h4>
-      <hr>
-    </div>
-    <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
-    <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
-      No directory results.
-    </div>
-    <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
-      <h4>{{item.fullName}}</h4>
-      <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
-      <p>
-        <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
-        <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
-      </p>
-      <div ng-if="showingDetails" class="result">
-        <div ng-if="item.address" class="moreDetails">
-          <p>{{item.address.room}}</p>
-          <p>{{item.address.streetAddress}}</p>
-          <p>{{item.address.cityStateZip}}</p>
-        </div>
-        <div ng-repeat="title in item.titles" class="moreDetails">
-          <p>Title: {{title.title}}</p>
-          <p>Division: {{title.division}}</p>
-          <p>Department: {{title.department}}</p>
-          <p>Unit: {{title.subdepartment}}</p>
-        </div>
-      </div>
-      <div ng-click="showingDetails=!showingDetails">
-        <p>
-          <a href="javascript:;" ng-if="item.titles[0] || item.address">
-            <span ng-if="!showingDetails">See more</span>
-            <span ng-if="showingDetails">See less</span>
-          </a>
-        </p>
-      </div>
-    </div>
-    <div class="seeMoreResults">
-      <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit" id="wiscDirectorySeeMoreResults">
-        <a href="javascript:;" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
-      </p>
-      <p ng-if="wiscDirectoryErrorMessage">
-          {{wiscDirectoryErrorMessage}}
-        </p>
-    </div>
+          <!-- Wisc directory results-->
+          <div ng-show="directoryEnabled" class="search-results-container">
+            <h4 class='header'>Directory</h4>
+            <hr>
+            <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
+            <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
+              No directory results.
+            </div>
+            <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
+              <h4>{{item.fullName}}</h4>
+              <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
+              <p>
+                <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
+                <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
+              </p>
+              <div ng-if="showingDetails" class="result">
+                <div ng-if="item.address" class="moreDetails">
+                  <p>{{item.address.room}}</p>
+                  <p>{{item.address.streetAddress}}</p>
+                  <p>{{item.address.cityStateZip}}</p>
+                </div>
+                <div ng-repeat="title in item.titles" class="moreDetails">
+                  <p>Title: {{title.title}}</p>
+                  <p>Division: {{title.division}}</p>
+                  <p>Department: {{title.department}}</p>
+                  <p>Unit: {{title.subdepartment}}</p>
+                </div>
+              </div>
+              <div ng-click="showingDetails=!showingDetails">
+                <p>
+                  <a href="" ng-if="item.titles[0] || item.address">
+                    <span ng-if="!showingDetails">See more</span>
+                    <span ng-if="showingDetails">See less</span>
+                  </a>
+                </p>
+              </div>
+            </div>
+            <div class="seeMoreResults">
+              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit" id="wiscDirectorySeeMoreResults">
+                <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
+              </p>
+              <p ng-if="wiscDirectoryErrorMessage">
+                {{wiscDirectoryErrorMessage}}
+              </p>
+            </div>
+          </div>
 
-  </div>
+          <!--Campus domain results-->
+          <div ng-show="googleSearchEnabled" class="search-results-container">
+            <h4 class='header'>{{domainResultsLabel}}</h4>
+            <hr>
+            <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
+            <div ng-show="googleResults.length === 0" class='no-result'>
+              No {{domainResultsLabel}} results.
+            </div>
+            <div ng-repeat="item in googleResults" class="result">
+              <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
+              <p ng-bind-html="item.content"></p>
+              <p>
+                <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
+              </p>
 
-  <!--Campus Domain results-->
-  <div ng-show="googleSearchEnabled" id="wisc-edu-results" class='search-results-container'>
-    <div id="wisc-edu-results-header">
-      <h4 class='header'>{{domainResultsLabel}}</h4>
-      <hr>
-    </div>
-    <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
-    <div ng-show="googleResults.length === 0" class='no-result'>
-      No {{domainResultsLabel}} results.
-    </div>
-    <div ng-repeat="item in googleResults" class="result">
-      <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
-      <p ng-bind-html="item.content"></p>
-      <p>
-        <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
-      </p>
+            </div>
+            <div>
+              <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}" target="_blank">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
+            </div>
+          </div>
 
-    </div>
-    <div>
-      <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}" target="_blank">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
-    </div>
-  </div>
+          <!-- No search results found -->
+          <div id="no-results" class="search-results-container" ng-show="totalCount === 0">
+            <p><strong>No matches.</strong></p>
+            <p>Suggestions:</p>
+            <p ng-if="kbSearchUrl">
+              Search the <a ng-href="{{kbSearchUrl}}{{searchText}}" target="_blank">KnowledgeBase</a>
+            </p>
+            <p ng-if="eventsSearchUrl">
+              Look for <a ng-href="{{eventsSearchUrl}}{{searchText}}" target="_blank">events</a>
+            </p>
+            <p ng-if="helpdeskUrl">
+              Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank">Help Desk</a>
+            </p>
+            <p ng-if="feedbackUrl">
+              <a ng-href="{{feedbackUrl}}" target="_blank">Give feedback </a>on MyUW search
+            </p>
+          </div>
+        </md-content>
+      </md-tab-body>
+    </md-tab>
 
-  <!-- No search results found -->
-  <div id="no-results" class="search-results-container" ng-show="totalCount === 0">
-    <p><strong>No matches.</strong></p>
-    <p>Suggestions:</p>
-    <p ng-if="kbSearchUrl">
-      Search the <a ng-href="{{kbSearchUrl}}{{searchText}}" target="_blank">KnowledgeBase</a>
-    </p>
-    <p ng-if="eventsSearchUrl">
-      Look for <a ng-href="{{eventsSearchUrl}}{{searchText}}" target="_blank">events</a>
-    </p>
-    <p ng-if="helpdeskUrl">
-      Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank">Help Desk</a>
-    </p>
-    <p ng-if="feedbackUrl">
-      <a ng-href="{{feedbackUrl}}" target="_blank">Give feedback </a>on MyUW search
-    </p>
-  </div>
-</div>
+    <!-- MyUW RESULTS ONLY -->
+    <md-tab ng-click="filterTo('myuw')">
+      <md-tab-label>
+        MyUW&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
+      </md-tab-label>
+      <md-tab-body>
+        <md-content layout-padding>
+          <!-- MyUW results -->
+          <div class='search-results-container'>
+            <h4 class="header">MyUW</h4>
+            <hr>
+            <loading-gif data-object='myuwResults'></loading-gif>
+            <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
+              No MyUW results. <a href="apps">Try browsing instead?</a>
+            </div>
+            <div ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)"
+                 class="result">
+              <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
+              <p>{{ portlet.description }}</p>
+              <p>
+                <md-button ng-click="addToHome(portlet)"
+                           ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
+                           class="md-primary add">
+                  <i class="fa fa-plus"></i> Add to home
+                </md-button>
+                <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
+                <md-button class="md-default" title='See more about {{portlet.title}}' ng-click='navToDetails(portlet, "Search")'>Details</md-button>
+                <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
+              </p>
+            </div>
+            <marketplace-load-more ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
+          </div>
+        </md-content>
+      </md-tab-body>
+    </md-tab>
+
+    <!-- DIRECTORY RESULTS ONLY -->
+    <md-tab ng-show="directoryEnabled" ng-click="filterTo('directory')">
+      <md-tab-label>
+        Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
+      </md-tab-label>
+      <md-tab-body>
+        <md-content layout-padding>
+          <!-- Wisc directory results-->
+          <div ng-show="directoryEnabled" class="search-results-container">
+            <h4 class='header'>Directory</h4>
+            <hr>
+            <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
+            <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
+              No directory results.
+            </div>
+            <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
+              <h4>{{item.fullName}}</h4>
+              <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
+              <p>
+                <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
+                <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
+              </p>
+              <div ng-if="showingDetails" class="result">
+                <div ng-if="item.address" class="moreDetails">
+                  <p>{{item.address.room}}</p>
+                  <p>{{item.address.streetAddress}}</p>
+                  <p>{{item.address.cityStateZip}}</p>
+                </div>
+                <div ng-repeat="title in item.titles" class="moreDetails">
+                  <p>Title: {{title.title}}</p>
+                  <p>Division: {{title.division}}</p>
+                  <p>Department: {{title.department}}</p>
+                  <p>Unit: {{title.subdepartment}}</p>
+                </div>
+              </div>
+              <div ng-click="showingDetails=!showingDetails">
+                <p>
+                  <a href="" ng-if="item.titles[0] || item.address">
+                    <span ng-if="!showingDetails">See more</span>
+                    <span ng-if="showingDetails">See less</span>
+                  </a>
+                </p>
+              </div>
+            </div>
+            <div class="seeMoreResults">
+              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit" id="wiscDirectorySeeMoreResults">
+                <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
+              </p>
+              <p ng-if="wiscDirectoryErrorMessage">
+                {{wiscDirectoryErrorMessage}}
+              </p>
+            </div>
+          </div>
+        </md-content>
+      </md-tab-body>
+    </md-tab>
+
+    <!-- GOOGLE CUSTOM SEARCH RESULTS ONLY -->
+    <md-tab ng-show="googleSearchEnabled" ng-click="filterTo('google')">
+      <md-tab-label>
+        {{domainResultsLabel}}&nbsp;&nbsp;<span class="badge">{{ googleResultsEstimatedCount }}</span>
+      </md-tab-label>
+      <md-tab-body>
+        <md-content layout-padding>
+          <!--Campus domain results-->
+          <div ng-show="googleSearchEnabled" class="search-results-container">
+            <h4 class='header'>{{domainResultsLabel}}</h4>
+            <hr>
+            <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
+            <div ng-show="googleResults.length === 0" class='no-result'>
+              No {{domainResultsLabel}} results.
+            </div>
+            <div ng-repeat="item in googleResults" class="result">
+              <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
+              <p ng-bind-html="item.content"></p>
+              <p>
+                <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
+              </p>
+
+            </div>
+            <div>
+              <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}" target="_blank">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
+            </div>
+          </div>
+        </md-content>
+      </md-tab-body>
+    </md-tab>
+  </md-tabs>
+</md-content>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -125,7 +125,7 @@
               Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank">Help Desk</a>
             </p>
             <p ng-if="feedbackUrl">
-              <a ng-href="{{feedbackUrl}}" target="_blank">Give feedback </a>on MyUW search
+              <a ng-href="{{feedbackUrl}}" target="_blank">Give feedback</a> on MyUW search
             </p>
           </div>
         </md-content>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -7,11 +7,11 @@
         All&nbsp;&nbsp;<span class="badge">{{ totalCount }}</span>
       </md-tab-label>
       <md-tab-body>
-        <md-content layout-padding>
+        <md-content>
           <!-- MyUW results -->
           <div class='search-results-container'>
-            <h4 class="header">MyUW</h4>
-            <hr>
+            <h4 class="md-subhead">MyUW</h4>
+            
             <loading-gif data-object='myuwResults'></loading-gif>
             <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
               No MyUW results. <a href="apps">Try browsing instead?</a>
@@ -31,13 +31,13 @@
                 <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
               </p>
             </div>
-            <marketplace-load-more ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
+            <marketplace-load-more layout="row" layout-align="center center" ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
           </div>
 
           <!-- Wisc directory results-->
           <div ng-show="directoryEnabled" class="search-results-container">
-            <h4 class='header'>Directory</h4>
-            <hr>
+            <h4 class="md-subhead">Directory</h4>
+            
             <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
             <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
               No directory results.
@@ -72,7 +72,7 @@
               </div>
             </div>
             <div class="seeMoreResults">
-              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit" id="wiscDirectorySeeMoreResults">
+              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit">
                 <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
               </p>
               <p ng-if="wiscDirectoryErrorMessage">
@@ -83,8 +83,8 @@
 
           <!--Campus domain results-->
           <div ng-show="googleSearchEnabled" class="search-results-container">
-            <h4 class='header'>{{domainResultsLabel}}</h4>
-            <hr>
+            <h4 class="md-subhead">{{domainResultsLabel}}</h4>
+
             <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
             <div ng-show="googleResults.length === 0" class='no-result'>
               No {{domainResultsLabel}} results.
@@ -95,10 +95,11 @@
               <p>
                 <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
               </p>
-
             </div>
-            <div>
-              <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}" target="_blank">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
+            <div layout="row" layout-align="center center" layout-padding>
+              <md-button ng-if="webSearchUrl && !googleEmptyResults" class="md-primary md-raised" ng-href="{{webSearchUrl + searchText}}" aria-label="view more results for {{searchText}} on {{domainResultsLabel}}">
+                <i class="fa fa-external-link"></i> View more results
+              </md-button>
             </div>
           </div>
 
@@ -129,11 +130,11 @@
         MyUW&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
       </md-tab-label>
       <md-tab-body>
-        <md-content layout-padding>
+        <md-content>
           <!-- MyUW results -->
           <div class='search-results-container'>
-            <h4 class="header">MyUW</h4>
-            <hr>
+            <h4 class="md-subhead">MyUW</h4>
+            
             <loading-gif data-object='myuwResults'></loading-gif>
             <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
               No MyUW results. <a href="apps">Try browsing instead?</a>
@@ -153,7 +154,7 @@
                 <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
               </p>
             </div>
-            <marketplace-load-more ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
+            <marketplace-load-more layout="row" layout-align="center center" ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
           </div>
         </md-content>
       </md-tab-body>
@@ -165,11 +166,11 @@
         Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
       </md-tab-label>
       <md-tab-body>
-        <md-content layout-padding>
+        <md-content>
           <!-- Wisc directory results-->
           <div ng-show="directoryEnabled" class="search-results-container">
-            <h4 class='header'>Directory</h4>
-            <hr>
+            <h4 class="md-subhead">Directory</h4>
+            
             <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
             <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
               No directory results.
@@ -204,7 +205,7 @@
               </div>
             </div>
             <div class="seeMoreResults">
-              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit" id="wiscDirectorySeeMoreResults">
+              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit">
                 <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
               </p>
               <p ng-if="wiscDirectoryErrorMessage">
@@ -222,11 +223,11 @@
         {{domainResultsLabel}}&nbsp;&nbsp;<span class="badge">{{ googleResultsEstimatedCount }}</span>
       </md-tab-label>
       <md-tab-body>
-        <md-content layout-padding>
+        <md-content>
           <!--Campus domain results-->
           <div ng-show="googleSearchEnabled" class="search-results-container">
-            <h4 class='header'>{{domainResultsLabel}}</h4>
-            <hr>
+            <h4 class="md-subhead">{{domainResultsLabel}}</h4>
+            
             <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
             <div ng-show="googleResults.length === 0" class='no-result'>
               No {{domainResultsLabel}} results.
@@ -237,10 +238,11 @@
               <p>
                 <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
               </p>
-
             </div>
-            <div>
-              <h4 ng-if="webSearchUrl && !googleEmptyResults"><a ng-href="{{webSearchUrl + searchText}}" target="_blank">View more results for {{searchText}} on {{domainResultsLabel}}</a></h4>
+            <div layout="row" layout-align="center center" layout-padding>
+              <md-button ng-if="webSearchUrl && !googleEmptyResults" class="md-primary md-raised" ng-href="{{webSearchUrl + searchText}}" aria-label="view more results for {{searchText}} on {{domainResultsLabel}}">
+                <i class="fa fa-external-link"></i> View more results
+              </md-button>
             </div>
           </div>
         </md-content>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -10,8 +10,10 @@
         <md-content>
           <!-- MyUW results -->
           <div class='search-results-container'>
-            <h4 class="md-subhead">MyUW</h4>
-            
+            <h4 class="md-subhead">
+              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+              MyUW
+            </h4>
             <loading-gif data-object='myuwResults'></loading-gif>
             <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
               No MyUW results. <a href="apps">Try browsing instead?</a>
@@ -36,7 +38,10 @@
 
           <!-- Wisc directory results-->
           <div ng-show="directoryEnabled" class="search-results-container">
-            <h4 class="md-subhead">Directory</h4>
+            <h4 class="md-subhead">
+              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+              Directory
+            </h4>
             
             <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
             <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
@@ -83,7 +88,10 @@
 
           <!--Campus domain results-->
           <div ng-show="googleSearchEnabled" class="search-results-container">
-            <h4 class="md-subhead">{{domainResultsLabel}}</h4>
+            <h4 class="md-subhead">
+              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+              {{domainResultsLabel}}
+            </h4>
 
             <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
             <div ng-show="googleResults.length === 0" class='no-result'>
@@ -133,7 +141,10 @@
         <md-content>
           <!-- MyUW results -->
           <div class='search-results-container'>
-            <h4 class="md-subhead">MyUW</h4>
+            <h4 class="md-subhead">
+              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+              MyUW
+            </h4>
             
             <loading-gif data-object='myuwResults'></loading-gif>
             <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
@@ -169,7 +180,10 @@
         <md-content>
           <!-- Wisc directory results-->
           <div ng-show="directoryEnabled" class="search-results-container">
-            <h4 class="md-subhead">Directory</h4>
+            <h4 class="md-subhead">
+              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+              Directory
+            </h4>
             
             <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
             <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
@@ -226,7 +240,10 @@
         <md-content>
           <!--Campus domain results-->
           <div ng-show="googleSearchEnabled" class="search-results-container">
-            <h4 class="md-subhead">{{domainResultsLabel}}</h4>
+            <h4 class="md-subhead">
+              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+              {{domainResultsLabel}}
+            </h4>
             
             <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
             <div ng-show="googleResults.length === 0" class='no-result'>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -23,11 +23,11 @@
               <p>
                 <md-button ng-click="addToHome(portlet)"
                    ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
-                   class="md-primary add">
+                   class="md-primary add" aria-label="add {{ portlet.title }} to home">
                   <i class="fa fa-plus"></i> Add to home
                 </md-button>
                 <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
-                <md-button class="md-default" title='See more about {{portlet.title}}' ng-click='navToDetails(portlet, "Search")'>Details</md-button>
+                <md-button class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
                 <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
               </p>
             </div>
@@ -146,11 +146,11 @@
               <p>
                 <md-button ng-click="addToHome(portlet)"
                            ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
-                           class="md-primary add">
+                           class="md-primary add" aria-label="add {{ portlet.title }} to home">
                   <i class="fa fa-plus"></i> Add to home
                 </md-button>
                 <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
-                <md-button class="md-default" title='See more about {{portlet.title}}' ng-click='navToDetails(portlet, "Search")'>Details</md-button>
+                <md-` class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
                 <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
               </p>
             </div>


### PR DESCRIPTION
This PR satisfies the requirements of [MUMMNG-2694](https://jira.doit.wisc.edu/jira/browse/MUMMNG-2694)

**In this PR:**
- Replaced old tab navigation with angular material tabs and custom badges
- Added some material buttons to MyUW search results

### Screenshots
<img width="940" alt="screen shot 2016-09-26 at 1 08 06 pm" src="https://cloud.githubusercontent.com/assets/5818702/18846284/d11bedba-83ea-11e6-839d-2355fc61639d.png">

<img width="426" alt="screen shot 2016-09-26 at 1 08 20 pm" src="https://cloud.githubusercontent.com/assets/5818702/18846293/d86301f8-83ea-11e6-8ca7-d026eaf59747.png">

### Animations demo
![search-demo](https://cloud.githubusercontent.com/assets/5818702/18846638/88714446-83ec-11e6-9f2c-cfb1d4347138.gif)


**Notes:**
- This PR depends on [uw-frame PR#318](https://github.com/UW-Madison-DoIT/uw-frame/pull/318) in order for the tabs to appear as pictured
- I plan on backlogging a new story to explore more design options for search results
- It might be worthwhile to create a generic `search-results` directive that we can reuse for each category of results. The current version functions fine as is, but a directive would help cut down on copy+pasted code. 