### PR TITLE
Create directives for types of search results

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -30,8 +30,16 @@
   }
   .search-results-container {
     padding: 0;
+    &:first-child {
+      h4.md-subhead {
+        border-top: none;
+      }
+    }
     .moreDetails{
       padding-top:5px;
+    }
+    .marketplace-load-more {
+      margin-bottom: 12px;
     }
   }
   .result {

--- a/angularjs-portal-home/src/main/webapp/my-app/main.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/main.js
@@ -30,6 +30,7 @@ define([
     './rating/components',
     './rating/controllers',
     './search/controllers',
+    './search/directives',
     './search/services'
 ], function(angular, require, marketplaceRoutes, listRoute, notificationsRoute, portalSettingsRoutes,
 			featuresRoute, aboutRoute, layoutRoute, staticRoutes, widgetRoutes, searchRoutes) {
@@ -50,6 +51,7 @@ define([
         'my-app.rating.components',
         'my-app.rating.controllers',
         'my-app.search.controllers',
+        'my-app.search.directives',
         'my-app.search.services',
         'ngRoute',
         'ngSanitize',

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-load-more.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-load-more.html
@@ -1,5 +1,5 @@
 <div class="marketplace-load-more">
 	<md-button class="md-primary md-raised" ng-click="searchResultLimit = searchResultLimit + 20;" hide-while-loading>
-		Load More
+		Load more
 	</md-button>
 </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -19,7 +19,6 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
                 $scope.filterMatches = [];
                 return;
             }
-
             $scope.filterMatches = marketplaceService.filterPortletsBySearchTerm($scope.portlets, newVal);
         });
 
@@ -87,46 +86,9 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         );
       };
 
-      $scope.filterTo = function(filterName) {
-        $('.search-results .inner-nav li').removeClass('active');
-        if (filterName == 'all') {
-          $('#all-selector').addClass('active');
-          $('#myuw-results').show();
-          $('#myuw-results-header').show();
-          $('#wisc-directory-results').show();
-          $('#wisc-directory-results-header').show();
-          $('#wisc-edu-results').show();
-          $('#wisc-edu-results-header').show();
-          $('#wiscDirectorySeeMoreResults').show();
-          initwiscDirectoryResultLimit();
-        } else if (filterName == 'myuw') {
-          $('#myuw-selector').addClass('active');
-          $('#myuw-results').show();
-          $('#myuw-results-header').hide();
-          $('#wisc-directory-results').hide();
-          $('#wisc-edu-results').hide();
-          $('#wiscDirectorySeeMoreResults').hide();
-        } else if (filterName == 'directory') {
-          $('#directory-selector').addClass('active');
-          $('#wisc-directory-results').show();
-          $('#wisc-directory-results-header').hide();
-          $('#myuw-results').hide();
-          $('#wisc-edu-results').hide();
-          $('#wiscDirectorySeeMoreResults').hide();
-          $scope.wiscDirectoryResultLimit = 25;
-        } else if (filterName == 'google') {
-          $('#google-selector').addClass('active');
-          $('#wisc-edu-results').show();
-          $('#wisc-edu-results-header').hide();
-          $('#myuw-results').hide();
-          $('#wisc-directory-results').hide();
-          $('#wiscDirectorySeeMoreResults').hide();
-        }
-      };
-
       var initwiscDirectoryResultLimit = function(){
           $scope.wiscDirectoryResultLimit = 3;
-      }
+      };
 
       var init = function(){
         $scope.sortParameter = ['-rating','-userRated'];

--- a/angularjs-portal-home/src/main/webapp/my-app/search/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/directives.js
@@ -1,0 +1,30 @@
+'use strict';
+
+define(['angular', 'require'], function(angular, require) {
+
+  var app = angular.module('my-app.search.directives', []);
+
+  app.directive('marketplaceResults', function() {
+    return {
+      restrict : 'E',
+      templateUrl : require.toUrl('./partials/marketplace-results.html')
+    }
+  });
+
+  app.directive('directoryResults', function() {
+    return {
+      restrict : 'E',
+      templateUrl : require.toUrl('./partials/directory-results.html')
+    }
+  });
+
+  app.directive('campusDomainResults', function() {
+    return {
+      restrict : 'E',
+      templateUrl : require.toUrl('./partials/campus-domain-results.html')
+    }
+  });
+
+  return app;
+
+});

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/campus-domain-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/campus-domain-results.html
@@ -1,0 +1,21 @@
+<h4 class="md-subhead">
+  <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+  {{domainResultsLabel}}
+</h4>
+
+<loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
+<div ng-show="googleResults.length === 0" class='no-result'>
+  No {{domainResultsLabel}} results.
+</div>
+<div ng-repeat="item in googleResults" class="result">
+  <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
+  <p ng-bind-html="item.content"></p>
+  <p>
+    <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
+  </p>
+</div>
+<div layout="row" layout-align="center center" layout-padding>
+  <md-button ng-if="webSearchUrl && !googleEmptyResults" class="md-primary md-raised" ng-href="{{webSearchUrl + searchText}}" aria-label="view more results for {{searchText}} on {{domainResultsLabel}}">
+    <i class="fa fa-external-link"></i> View more results
+  </md-button>
+</div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/directory-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/directory-results.html
@@ -1,0 +1,46 @@
+<h4 class="md-subhead">
+  <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+  Directory
+</h4>
+
+<loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
+<div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
+  No directory results.
+</div>
+<div class="result" ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit">
+  <h4>{{item.fullName}}</h4>
+  <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
+  <p>
+    <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
+    <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
+  </p>
+  <div ng-if="showingDetails" class="result">
+    <div ng-if="item.address" class="moreDetails">
+      <p>{{item.address.room}}</p>
+      <p>{{item.address.streetAddress}}</p>
+      <p>{{item.address.cityStateZip}}</p>
+    </div>
+    <div ng-repeat="title in item.titles" class="moreDetails">
+      <p>Title: {{title.title}}</p>
+      <p>Division: {{title.division}}</p>
+      <p>Department: {{title.department}}</p>
+      <p>Unit: {{title.subdepartment}}</p>
+    </div>
+  </div>
+  <div ng-click="showingDetails=!showingDetails">
+    <p>
+      <a href="" ng-if="item.titles[0] || item.address">
+        <span ng-if="!showingDetails">See more</span>
+        <span ng-if="showingDetails">See less</span>
+      </a>
+    </p>
+  </div>
+</div>
+<div class="seeMoreResults">
+  <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit">
+    <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
+  </p>
+  <p ng-if="wiscDirectoryErrorMessage">
+    {{wiscDirectoryErrorMessage}}
+  </p>
+</div>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -1,0 +1,23 @@
+<h4 class="md-subhead">
+  <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
+  MyUW
+</h4>
+<loading-gif data-object='myuwResults'></loading-gif>
+<div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
+  No MyUW results. <a href="apps">Try browsing instead?</a>
+</div>
+<div class="result" ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)">
+  <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
+  <p>{{ portlet.description }}</p>
+  <p>
+    <md-button ng-click="addToHome(portlet)"
+               ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
+               class="md-primary add" aria-label="add {{ portlet.title }} to home">
+      <i class="fa fa-plus"></i> Add to home
+    </md-button>
+    <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
+    <md-button class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
+    <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
+  </p>
+</div>
+<marketplace-load-more layout="row" layout-align="center center" ng-show="myuwResults.length > searchResultLimit"></marketplace-load-more>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -2,113 +2,25 @@
   <md-tabs md-dynamic-height md-border-bottom ng-show="googleSearchEnabled || directoryEnabled">
 
     <!-- ALL RESULTS -->
-    <md-tab ng-click="filterTo('all')">
+    <md-tab>
       <md-tab-label>
         All&nbsp;&nbsp;<span class="badge">{{ totalCount }}</span>
       </md-tab-label>
       <md-tab-body>
         <md-content>
           <!-- MyUW results -->
-          <div class='search-results-container'>
-            <h4 class="md-subhead">
-              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-              MyUW
-            </h4>
-            <loading-gif data-object='myuwResults'></loading-gif>
-            <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
-              No MyUW results. <a href="apps">Try browsing instead?</a>
-            </div>
-            <div ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)"
-                 class="result">
-              <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
-              <p>{{ portlet.description }}</p>
-              <p>
-                <md-button ng-click="addToHome(portlet)"
-                   ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
-                   class="md-primary add" aria-label="add {{ portlet.title }} to home">
-                  <i class="fa fa-plus"></i> Add to home
-                </md-button>
-                <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
-                <md-button class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
-                <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
-              </p>
-            </div>
-            <marketplace-load-more layout="row" layout-align="center center" ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
+          <div class="search-results-container">
+            <marketplace-results></marketplace-results>
           </div>
 
           <!-- Wisc directory results-->
           <div ng-show="directoryEnabled" class="search-results-container">
-            <h4 class="md-subhead">
-              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-              Directory
-            </h4>
-            
-            <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
-            <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
-              No directory results.
-            </div>
-            <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
-              <h4>{{item.fullName}}</h4>
-              <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
-              <p>
-                <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
-                <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
-              </p>
-              <div ng-if="showingDetails" class="result">
-                <div ng-if="item.address" class="moreDetails">
-                  <p>{{item.address.room}}</p>
-                  <p>{{item.address.streetAddress}}</p>
-                  <p>{{item.address.cityStateZip}}</p>
-                </div>
-                <div ng-repeat="title in item.titles" class="moreDetails">
-                  <p>Title: {{title.title}}</p>
-                  <p>Division: {{title.division}}</p>
-                  <p>Department: {{title.department}}</p>
-                  <p>Unit: {{title.subdepartment}}</p>
-                </div>
-              </div>
-              <div ng-click="showingDetails=!showingDetails">
-                <p>
-                  <a href="" ng-if="item.titles[0] || item.address">
-                    <span ng-if="!showingDetails">See more</span>
-                    <span ng-if="showingDetails">See less</span>
-                  </a>
-                </p>
-              </div>
-            </div>
-            <div class="seeMoreResults">
-              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit">
-                <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
-              </p>
-              <p ng-if="wiscDirectoryErrorMessage">
-                {{wiscDirectoryErrorMessage}}
-              </p>
-            </div>
+            <directory-results></directory-results>
           </div>
 
           <!--Campus domain results-->
           <div ng-show="googleSearchEnabled" class="search-results-container">
-            <h4 class="md-subhead">
-              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-              {{domainResultsLabel}}
-            </h4>
-
-            <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
-            <div ng-show="googleResults.length === 0" class='no-result'>
-              No {{domainResultsLabel}} results.
-            </div>
-            <div ng-repeat="item in googleResults" class="result">
-              <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
-              <p ng-bind-html="item.content"></p>
-              <p>
-                <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
-              </p>
-            </div>
-            <div layout="row" layout-align="center center" layout-padding>
-              <md-button ng-if="webSearchUrl && !googleEmptyResults" class="md-primary md-raised" ng-href="{{webSearchUrl + searchText}}" aria-label="view more results for {{searchText}} on {{domainResultsLabel}}">
-                <i class="fa fa-external-link"></i> View more results
-              </md-button>
-            </div>
+            <campus-domain-results></campus-domain-results>
           </div>
 
           <!-- No search results found -->
@@ -133,46 +45,22 @@
     </md-tab>
 
     <!-- MyUW RESULTS ONLY -->
-    <md-tab ng-click="filterTo('myuw')">
+    <md-tab>
       <md-tab-label>
         MyUW&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
       </md-tab-label>
       <md-tab-body>
         <md-content>
           <!-- MyUW results -->
-          <div class='search-results-container'>
-            <h4 class="md-subhead">
-              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-              MyUW
-            </h4>
-            
-            <loading-gif data-object='myuwResults'></loading-gif>
-            <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
-              No MyUW results. <a href="apps">Try browsing instead?</a>
-            </div>
-            <div ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)"
-                 class="result">
-              <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>
-              <p>{{ portlet.description }}</p>
-              <p>
-                <md-button ng-click="addToHome(portlet)"
-                           ng-if="portlet.canAdd && !portlet.hasInLayout && !GuestMode"
-                           class="md-primary add" aria-label="add {{ portlet.title }} to home">
-                  <i class="fa fa-plus"></i> Add to home
-                </md-button>
-                <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
-                <md-` class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
-                <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
-              </p>
-            </div>
-            <marketplace-load-more layout="row" layout-align="center center" ng-show="myuwFilteredResults.length > searchResultLimit"></marketplace-load-more>
+          <div class="search-results-container">
+            <marketplace-results></marketplace-results>
           </div>
         </md-content>
       </md-tab-body>
     </md-tab>
 
     <!-- DIRECTORY RESULTS ONLY -->
-    <md-tab ng-show="directoryEnabled" ng-click="filterTo('directory')">
+    <md-tab ng-show="directoryEnabled">
       <md-tab-label>
         Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
       </md-tab-label>
@@ -180,59 +68,14 @@
         <md-content>
           <!-- Wisc directory results-->
           <div ng-show="directoryEnabled" class="search-results-container">
-            <h4 class="md-subhead">
-              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-              Directory
-            </h4>
-            
-            <loading-gif data-object='wiscDirectoryResults' data-empty="wiscDirectoryResultsEmpty"></loading-gif>
-            <div ng-show="wiscDirectoryResultsEmpty && !wiscDirectoryTooManyResults" class='no-result'>
-              No directory results.
-            </div>
-            <div ng-repeat="item in wiscDirectoryResults | limitTo:wiscDirectoryResultLimit" class="result">
-              <h4>{{item.fullName}}</h4>
-              <p ng-if="item.formalName">Also known as {{item.formalName}}</p>
-              <p>
-                <a ng-repeat="email in item.emails" ng-href="mailto:{{email}}" target="_blank">{{email}}</a>
-                <a ng-repeat="phone in item.phones" ng-href="tel:{{phone}}" target="_blank">{{phone}}</a>
-              </p>
-              <div ng-if="showingDetails" class="result">
-                <div ng-if="item.address" class="moreDetails">
-                  <p>{{item.address.room}}</p>
-                  <p>{{item.address.streetAddress}}</p>
-                  <p>{{item.address.cityStateZip}}</p>
-                </div>
-                <div ng-repeat="title in item.titles" class="moreDetails">
-                  <p>Title: {{title.title}}</p>
-                  <p>Division: {{title.division}}</p>
-                  <p>Department: {{title.department}}</p>
-                  <p>Unit: {{title.subdepartment}}</p>
-                </div>
-              </div>
-              <div ng-click="showingDetails=!showingDetails">
-                <p>
-                  <a href="" ng-if="item.titles[0] || item.address">
-                    <span ng-if="!showingDetails">See more</span>
-                    <span ng-if="showingDetails">See less</span>
-                  </a>
-                </p>
-              </div>
-            </div>
-            <div class="seeMoreResults">
-              <p ng-if="wiscDirectoryResultCount>wiscDirectoryResultLimit">
-                <a href="" ng-click="filterTo('directory')">See all {{wiscDirectoryResultCount}} directory results</a>
-              </p>
-              <p ng-if="wiscDirectoryErrorMessage">
-                {{wiscDirectoryErrorMessage}}
-              </p>
-            </div>
+            <directory-results></directory-results>
           </div>
         </md-content>
       </md-tab-body>
     </md-tab>
 
     <!-- GOOGLE CUSTOM SEARCH RESULTS ONLY -->
-    <md-tab ng-show="googleSearchEnabled" ng-click="filterTo('google')">
+    <md-tab ng-show="googleSearchEnabled">
       <md-tab-label>
         {{domainResultsLabel}}&nbsp;&nbsp;<span class="badge">{{ googleResultsEstimatedCount }}</span>
       </md-tab-label>
@@ -240,27 +83,7 @@
         <md-content>
           <!--Campus domain results-->
           <div ng-show="googleSearchEnabled" class="search-results-container">
-            <h4 class="md-subhead">
-              <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-              {{domainResultsLabel}}
-            </h4>
-            
-            <loading-gif data-object='googleResults' data-empty='googleEmptyResults'></loading-gif>
-            <div ng-show="googleResults.length === 0" class='no-result'>
-              No {{domainResultsLabel}} results.
-            </div>
-            <div ng-repeat="item in googleResults" class="result">
-              <h4><a ng-href="{{item.clicktrackUrl}}" target="_blank" ng-bind-html="item.title"></a></h4>
-              <p ng-bind-html="item.content"></p>
-              <p>
-                <a ng-href="{{item.clicktrackUrl}}" ng-bind-html="item.formattedUrl"></a>
-              </p>
-            </div>
-            <div layout="row" layout-align="center center" layout-padding>
-              <md-button ng-if="webSearchUrl && !googleEmptyResults" class="md-primary md-raised" ng-href="{{webSearchUrl + searchText}}" aria-label="view more results for {{searchText}} on {{domainResultsLabel}}">
-                <i class="fa fa-external-link"></i> View more results
-              </md-button>
-            </div>
+            <campus-domain-results></campus-domain-results>
           </div>
         </md-content>
       </md-tab-body>


### PR DESCRIPTION
**In this PR:**
- New directive for each type of search results (only serves to reduce copy+pasted code)
- Fixed a bug that made the "load more" button for MyUW results never appear 
    - Currently in prod, if you search a term that would return more than 20 results (like the letter "r"), you will only get 20 results and the "load more" button will not appear
- Made the marketplace "load more" button sentence case
- Minor style tweaks
- Got rid of some unused jQuery in the search controller

![screen shot 2016-09-27 at 11 30 05 am](https://cloud.githubusercontent.com/assets/5818702/18882743/179cef08-84a6-11e6-9f2f-9dd92ac03ef0.png)
