### PR TITLE
Make launch-button guidance more readable

### DIFF
--- a/docs/markdown/widget-launch-button.md
+++ b/docs/markdown/widget-launch-button.md
@@ -1,30 +1,49 @@
-MyUW widgets are designed to be flexible - users can accomplish or access a single task or piece of information, or they can access a collection of related things that will help them accomplish their task. Widgets can:
-
-* Provide users with real-time, continuous info about their account (e.g. list of pay statements in the Payroll Information widget, Wiscard balance in the Wiscard widget)
-* Provide users with a snapshot of information that may impact their decision to take an action (e.g. adding money to my Wiscard)
-* Support periodic user action (e.g. viewing pay statements)
-* Allow users to quickly access pieces of the app to complete key or regular tasks (e.g. Course Services, My Professional Development, Course Guide)
-* Provide users with at-a-glance information that represents the main use for the widget (e.g. Weather)
-
-The main button label used on your MyUW widget should succinctly and consistently (across widgets) reflect the action a user should expect to take place upon clicking. For example, clicking on the main button of a widget could allow the user to take the following actions:
+### Launch button purpose
+The launch button label used on your MyUW widget should concisely reflect the action a user should expect to take place upon clicking. 
+For example, clicking on the main button of a widget could allow the user to take the following actions:
 
 * View a full list of “To-Dos” or a full checklist
 * Launch an application within MyUW
 * Launch an application outside of MyUW
 * Launch a website outside of MyUW
 
-To maintain consistency of labeling, which is key for a good user experience, we strongly suggest you use the following labels for your widget buttons:
+### The launch-button directive
+All uw-frame apps have access to the `<launch-button>` directive, which you can use by copying the following code into your widget's template:
 
-* Launch app - For task-based applications
-* See all - Best used if your widget features a list of items (a checklist, a list of headlines) and if clicking on the widget button takes users to a complete list, not to a website or app
-* Open website - For content-based websites
+```html
+<launch-button 
+	data-href="" 
+	data-target="" 
+	data-button-text=""
+	data-aria-label="">
+</launch-button>
+```
 
-If one of these labels does not work, widget button labels are customizable. Because the action a user can take upon clicking on the main button on a MyUW widget can vary, it’s important to consider the following guidelines:
+This directive includes the classes, styles, and configurable attributes necessary to create a launch button and looks and feels like it's part 
+of the widget. You can read more about the configurable attributes of this directive in [uw-frame's directive documentation](http://uw-madison-doit.github.io/uw-frame/latest/#/md/directives)
 
-* Be clear about what will happen when a user clicks the main button - will it launch an application? Display a full list?
-* Keep button labels to around 20 characters; this character limit will ensure the label fits the button even when a user is using MyUW on a mobile device
-* Use direct and actionable verbs: “open,” “launch,” “view,” etc.
-* Make sure you’re using language the user also uses
-* Remember that the button exists in the context of the widget and the task the user is focused on, so redundancy may not be necessary. For example, you don’t need to repeat the application’s name in the button label.
+### Suggested button text
+To maintain consistency of labeling, which is key for a good user experience, **we strongly suggest you choose from following labels** for 
+your launch button's `data-button-text` attribute:
 
-To make sure your buttons are accessible, we encourage you to use the [aria-describedby](https://www.w3.org/TR/WCAG20-TECHS/ARIA1.html) property to provide non-sighted users more explicit information about what action the user is taking. For example, your visual button label, which can be seen by sighted users, may be “Launch app,” but your aria-describedby property could note: “This button will launch the Time and Absence app in MyUW.”
+* **See all**: Best used if your widget features a list of items (a checklist, a list of headlines, an RSS feed) and if clicking on the widget button takes users to a complete list
+* **Open website**: For content-based websites and any widgets that link to a static site with an external URL
+* **Launch app**: Best for task-based applications -- can also be used for any applications that open within MyUW and do not meet the criteria of other labels
+
+### Launch buttons and accessibility
+To ensure your launch buttons are accessible to vision-impaired users and other screen reader users, use the `data-aria-label` 
+to provide additional context that is not communicated by the button's text alone. Aria-labels should be kept short and should include 
+only the bare minimum text to communicate what the button does. For example:
+
+If your app's title is "Time and Absence" and your launch-button text is "Launch app," the best aria-label in this case would be "Launch Time and Absence app."
+
+[Read more about how to use aria-labels effectively](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_aria-label_attribute)
+
+### Custom button text
+If one of the suggested labels does not suit your needs, consider the following guidelines when coming up with custom button text:
+
+* Choose a clear action verb to describe what will happen when a user clicks the button -- "launch," "open," "go to," "view," and "explore" are all viable examples
+* Choose a noun to following the action verb that accurately describes the thing the user is about to experience (e.g. "website," "app," "list," "feed," "wiki," etc.)   
+* Limit the length of your button text to 25 characters (including spaces). This will ensure that all the text is visible on all screen sizes. Text that is too long will be truncated.
+* Use the language your intended audience expects to see
+* Remember that the button exists in the context of the widget it belongs to. It is not necessary to include the application's title in the button text (save it for the aria-label).

--- a/docs/markdown/widgets.md
+++ b/docs/markdown/widgets.md
@@ -1,6 +1,15 @@
  
 ## Widget types
 
+MyUW widgets are designed to be flexible - users can accomplish or access a single task or piece of information, or they can access 
+a collection of related things that will help them accomplish their task. Widgets can:
+
+* Provide users with real-time, continuous info about their account (e.g. list of pay statements in the Payroll Information widget, Wiscard balance in the Wiscard widget)
+* Provide users with a snapshot of information that may impact their decision to take an action (e.g. adding money to my Wiscard)
+* Support periodic user action (e.g. viewing pay statements)
+* Allow users to quickly access pieces of the app to complete key or regular tasks (e.g. Course Services, My Professional Development, Course Guide)
+* Provide users with at-a-glance information that represents the main use for the widget (e.g. Weather)
+
 The following widget types are available and one of the should (hopefully) meet your needs. They are all intended to 
 save developers the time and effort required to make a custom widget.
 
@@ -15,7 +24,7 @@ Follow these steps for each of the widget types described in this doc:
 
 ### List of links
 
-![list of links widget](../img/list-of-links.png)
+![list of links widget](./img/list-of-links.png)
 
 ```
 <name>widgetType</name>
@@ -68,7 +77,7 @@ This provides a more usable click surface, a simpler and cleaner user experience
 
 ### Search with links
 
-![search with links widget](../img/search-with-links.png)
+![search with links widget](./img/search-with-links.png)
 
 ```
 <name>widgetType</name>
@@ -116,7 +125,7 @@ This provides a more usable click surface, a simpler and cleaner user experience
 
 ### RSS widget
 
-![rss widget](../img/rss.png)
+![rss widget](./img/rss.png)
 
 ```
 <name>widgetType</name>


### PR DESCRIPTION
**In this PR:**
- Broke up chunks of the doc with headings
- Simplified much of the text
- Added some other formatting to draw attention to the most important parts
- Moved text that applied to widgets into the widget documentation
- Removed suggestion to use `aria-labelledby` in favor of `aria-label`
- Added suggestion to use `<launch-button>` directive

### Preview
![screen shot 2016-09-28 at 10 22 06 am](https://cloud.githubusercontent.com/assets/5818702/18919925/6f57b3b2-8565-11e6-9fe6-7fec7ad5483c.png)
