### PR TITLE
fix issue where simple widgets launch was not centered in ff

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -127,7 +127,7 @@ swl {
 /* NORMAL WIDGETS */
 .normal-widget {
   height: 194px;
-  display: flex;
+  display: block;
   justify-content: center;
   align-items: flex-start;
   align-content: center;


### PR DESCRIPTION
before
![image](https://cloud.githubusercontent.com/assets/3534544/18964778/f7ea697e-863f-11e6-89e6-ad2aa32ccf52.png)

after
![image](https://cloud.githubusercontent.com/assets/3534544/18964764/e72922d8-863f-11e6-8d27-b3a15e421632.png)


