### PR TITLE
Fix widget rendering problems

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -127,14 +127,9 @@ swl {
 /* NORMAL WIDGETS */
 .normal-widget {
   height: 194px;
-  display: -ms-flexbox;
-  display: -webkit-flex;
   display: flex;
   justify-content: center;
-  -ms-flex-align: flex-start;
-  -webkit-align-items: flex-start;
   align-items: flex-start;
-  -webkit-align-content: center;
   align-content: center;
   .widget-icon-container {
     padding-top: 40px;
@@ -151,8 +146,6 @@ swl {
     margin-top: 0;
     margin-bottom: 0;
     padding-right: 16px;
-    display: -ms-flexbox;
-    display: -webkit-flex;
     display: flex;
     flex-direction: row;
     justify-content: flex-start;

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -127,9 +127,14 @@ swl {
 /* NORMAL WIDGETS */
 .normal-widget {
   height: 194px;
-  display: block;
+  display: -ms-flexbox;
+  display: -webkit-flex;
+  display: flex;
   justify-content: center;
+  -ms-flex-align: flex-start;
+  -webkit-align-items: flex-start;
   align-items: flex-start;
+  -webkit-align-content: center;
   align-content: center;
   .widget-icon-container {
     padding-top: 40px;
@@ -146,6 +151,8 @@ swl {
     margin-top: 0;
     margin-bottom: 0;
     padding-right: 16px;
+    display: -ms-flexbox;
+    display: -webkit-flex;
     display: flex;
     flex-direction: row;
     justify-content: flex-start;

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -84,26 +84,30 @@
       </div>
 
       <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
-      <a tabindex="-1" ng-switch-when="NORMAL" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}" class="normal-widget">
-        <div class="widget-icon-container" layout="column" layout-align="center center">
-          <portlet-icon></portlet-icon>
-        </div>
+      <div ng-switch-when="NORMAL">
+        <a tabindex="-1" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}" class="normal-widget">
+          <div class="widget-icon-container" layout="column" layout-align="center center">
+            <portlet-icon></portlet-icon>
+          </div>
+        </a>
         <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>
-      </a>
+      </div>
 
       <!-- For simple content portlets, show only an icon -->
-      <a tabindex="-1" ng-switch-when="SIMPLE" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="normal-widget">
-        <div class="widget-icon-container" layout="column" layout-align="center center">
-          <portlet-icon></portlet-icon>
-        </div>
+      <div ng-switch-when="SIMPLE">
+        <a tabindex="-1" ng-click="widgetCtrl.maxStaticPortlet(portlet)" class="normal-widget">
+          <div class="widget-icon-container" layout="column" layout-align="center center">
+            <portlet-icon></portlet-icon>
+          </div>
+        </a>
         <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>
-      </a>
+      </div>
 
     </div>
   </md-card-content>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -1,4 +1,4 @@
-<md-card class="widget-frame" id="portlet-id-{{portlet.nodeId}}">
+<md-card class="widget-frame" id="portlet-id-{{portlet.nodeId}}" aria-label="{{ portlet.title }} widget">
 
   <!-- HEADER -->
   <md-card-header class="widget-header">
@@ -15,7 +15,7 @@
     </div>
 
     <md-card-header-text>
-      <span class='md-title' style='text-align: center;' id="appTitle_portlet.title-{{portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">{{portlet.title }}</span>
+      <span class='md-title' style='text-align: center;' id="appTitle_portlet.title-{{portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">{{ portlet.title }}</span>
     </md-card-header-text>
   </md-card-header>
 


### PR DESCRIPTION
**In this PR**:
- structural html change to fix display of simple/normal widgets across browsers
- added an aria-label to widgets that allows screen readers to read "[app title] widget" instead of "unknown"

**Notes:**
- I was unable to test in IE because my VM is having issues. IE 10 and later support the Firefox draft of flex, so the `-webkit` prefixes should be sufficient. Older versions may require additional prefixing. This should be tested.
- Adding [postcss/autoprefixer](https://github.com/postcss/autoprefixer) to our build process will provide the following benefits: 
    - Browser inconsistencies will become irrelevant and we should see fewer (if any) issues like this
    - Our .less code will be easier to read and maintain (we won't have to have a ton of extra lines of code for vendor prefixes) <-- [backlogged MUMMNG-2853](https://jira.doit.wisc.edu/jira/browse/MUMMNG-2853)

### Screenshots (chrome, firefox, safari)
![screen shot 2016-10-03 at 11 11 08 am](https://cloud.githubusercontent.com/assets/5818702/19044662/e21836b2-895a-11e6-992e-32da9a942240.png)
![screen shot 2016-10-03 at 11 11 23 am](https://cloud.githubusercontent.com/assets/5818702/19044671/e607184c-895a-11e6-956b-99f8e6cda268.png)
![screen shot 2016-10-03 at 11 11 43 am](https://cloud.githubusercontent.com/assets/5818702/19044673/e94f4cc2-895a-11e6-918e-7c83b4a0a776.png)
