### PR TITLE
Replace categories buttons with material chips

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -52,7 +52,6 @@
         .rating {
           margin-left: 0;
         }
-        /* TODO: Change default my-uw CSS to add underline to links that are :not(.md-button) */
         a.md-button:hover {
           text-decoration: none;
         }
@@ -81,6 +80,11 @@
     }
     .loading-gif {
       text-align: center;
+    }
+    .show-categories {
+      padding:10px;
+      display:inline-block;
+      background-color:@white;
     }
     @media (min-width:600px) {
       margin: 15px;
@@ -267,53 +271,6 @@
       }
     }
   }
-  /* MARKETPLACE CATEGORIES */
-  .category-links {
-    background-color:@white;
-    color:@categoryBlue;
-    border-color: @categoryBlue;
-    margin: 3px;
-    transition: @button-transition;
-    &:first-child {
-      margin-left: 0;
-    }
-    &:hover {
-      text-decoration:none;
-      background-color:@categoryBlue;
-      color:@white;
-      opacity:1.0;
-    }
-  }
-  .show-categories {
-    padding:10px;
-    border-bottom:1px solid @grayscale4;
-    display:inline-block;
-    width:100%;
-    background-color:@white;
-    .category-links:first-child {
-      margin-left: 3px;
-    }
-    a {
-      float:left;
-      display:block;
-      margin:3px;
-      transition: @button-transition;
-    }
-    a:hover {
-      cursor:pointer;
-    }
-    p {
-      float:left;
-      display:block;
-      padding:5px 10px 0 10px;
-      margin:0;
-    }
-    .selected-category {
-      background-color:@categoryBlue;
-      color:@white;
-      opacity:1.0;
-    }
-  }
 }
 
 /*--------------*/
@@ -383,10 +340,10 @@
     a.md-accent.md-raised {
       &.category-links {
         background-color: @white;
-        color: @categoryBlue;
+        color: @category-blue;
         margin: 6px 8px;
         &:hover {
-          background-color: @categoryBlue;
+          background-color: @category-blue;
           color: @white;
         }
       }
@@ -529,6 +486,31 @@
       }
       button.md-raised.fixed-width {
         width: 100%;
+      }
+    }
+  }
+}
+
+/*-------------------*/
+/* MARKETPLACE CHIPS */
+/*-------------------*/
+.marketplace, .portlet-details-page {
+  .md-chips {
+    box-shadow: none;
+    .md-chip {
+      transition: @button-transition;
+      a:not(.md-button):not(.btn):not(.launch-app-button) {
+        color: rgb(66,66,66);
+        display: block;
+        &.selected-category {
+          color: @category-blue;
+        }
+        &:hover {
+          text-decoration: none;
+        }
+      }
+      &:hover {
+        background: rgb(193,193,193);
       }
     }
   }

--- a/angularjs-portal-home/src/main/webapp/css/variables.less
+++ b/angularjs-portal-home/src/main/webapp/css/variables.less
@@ -22,7 +22,7 @@
    ========================================================================== */
 @white: #FFFFFF;
 @black: #000000;
-@categoryBlue: #066999;
+@category-blue: #066999;
 
 /*
  * Grayscale colors. 1 is lightest, 10 is darkest.

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -72,13 +72,15 @@
                         </ul>
                     </div>
                     <div class="desc-item">
-                        <h3 tabindex="0" class="md-title">Categories</h3>
-                        <div layout="row">
-                            <md-button ng-repeat="category in portlet.categories"
-                                       ng-href="apps" ng-click="specifyCategory(category)"
-                                       class="md-raised md-accent category-links">{{::category}}
-                            </md-button>
-                        </div>
+                      <h3 tabindex="0" class="md-title">Categories</h3>
+                      <md-chips ng-if="portlet.categories.length > 0"
+                                ng-model="portlet.categories"
+                                readonly="true"
+                                md-removable="false">
+                        <md-chip-template>
+                          <a ng-href="apps" ng-click="specifyCategory($chip)">{{ $chip }}</a>
+                        </md-chip-template>
+                      </md-chips>
                     </div>
                     <div class="desc-item" ng-if="portlet.marketplaceScreenshots.length != 0">
                         <h3 tabindex="0" class="md-title">Screenshots</h3>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -78,7 +78,7 @@
                                 readonly="true"
                                 md-removable="false">
                         <md-chip-template>
-                          <a ng-href="apps" ng-click="specifyCategory($chip)">{{ $chip }}</a>
+                          <a ng-href="apps" ng-click="specifyCategory($chip)" aria-label="see more apps in the {{ $chip }} category">{{ $chip }}</a>
                         </md-chip-template>
                       </md-chips>
                     </div>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -75,12 +75,14 @@
 
 	<!-- CATEGORIES ROW -->
 	<div layout="row" class="category-list" ng-if="portlet.categories.length > 0">
-		<a ng-repeat="category in portlet.categories"
-		   ng-if="portlet.categories.length > 0"
-		   ng-click="selectFilter('category',category)"
-		   class="btn btn-outline btn-sm category-links">
-			{{::category}}
-		</a>
+    <md-chips ng-if="portlet.categories.length > 0"
+              ng-model="portlet.categories"
+              readonly="true"
+              md-removable="false">
+      <md-chip-template>
+        <a ng-click="selectFilter('category', $chip)">{{ $chip }}</a>
+      </md-chip-template>
+    </md-chips>
 	</div>
 
   <!-- Action buttons for mobile -->

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -80,7 +80,7 @@
               readonly="true"
               md-removable="false">
       <md-chip-template>
-        <a ng-click="selectFilter('category', $chip)">{{ $chip }}</a>
+        <a ng-click="selectFilter('category', $chip)" aria-label="see more apps in the {{ $chip }} category">{{ $chip }}</a>
       </md-chip-template>
     </md-chips>
 	</div>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -50,9 +50,16 @@
       </div>
     </div>
 
-    <div ng-show="showCategories" class="show-categories">
-      <a ng-repeat="category in categories" href="" class="btn btn-outline btn-sm category-links" ng-click="selectFilter('category',category)" ng-class="{true: 'selected-category'}[categoryToShow === category]">{{category}}</a>
-    </div>
+    <md-chips ng-show="showCategories" class="show-categories"
+              ng-model="categories"
+              readonly="true"
+              md-removable="false">
+      <md-chip-template>
+        <a ng-click="selectFilter('category', $chip)" ng-class="{true: 'selected-category'}[categoryToShow === $chip]">{{ $chip }}</a>
+      </md-chip-template>
+    </md-chips>
+
+    <!--<a href="" class="" ng-click="selectFilter('category',category)" ng-repeat="category in categories"  ng-class="{true: 'selected-category'}[categoryToShow === category]">{{ category }}</a>-->
 
     <loading-gif data-object='portlets'></loading-gif>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -55,11 +55,9 @@
               readonly="true"
               md-removable="false">
       <md-chip-template>
-        <a ng-click="selectFilter('category', $chip)" ng-class="{true: 'selected-category'}[categoryToShow === $chip]">{{ $chip }}</a>
+        <a ng-click="selectFilter('category', $chip)" ng-class="{true: 'selected-category'}[categoryToShow === $chip]" aria-label="see apps in the {{ $chip }} category">{{ $chip }}</a>
       </md-chip-template>
     </md-chips>
-
-    <!--<a href="" class="" ng-click="selectFilter('category',category)" ng-repeat="category in categories"  ng-class="{true: 'selected-category'}[categoryToShow === category]">{{ category }}</a>-->
 
     <loading-gif data-object='portlets'></loading-gif>
 


### PR DESCRIPTION
**In this PR:**
- Removed bootstrap buttons for MyUW app categories and replaced them with material chips
- Removed some unnecessary CSS
- Added aria-labels to category chips

### Screenshots (marketplace browse, details page)
![screen shot 2016-10-05 at 10 03 24 am](https://cloud.githubusercontent.com/assets/5818702/19118855/65a35bd6-8ae3-11e6-8d4b-cbc440e6bb08.png)
![screen shot 2016-10-05 at 10 03 35 am](https://cloud.githubusercontent.com/assets/5818702/19118856/65aa8b04-8ae3-11e6-8c6f-52f988f66ccb.png)
