### PR TITLE
Build on uw-frame 2.8.1-snapshot rather than 2.7.1-snapshot.

### DIFF
--- a/angularjs-portal-home/pom.xml
+++ b/angularjs-portal-home/pom.xml
@@ -22,7 +22,7 @@
       <groupId>edu.wisc.my.apps</groupId>
       <artifactId>uw-frame</artifactId>
       <type>war</type>
-      <version>2.7.1-SNAPSHOT</version>
+      <version>2.8.1-SNAPSHOT</version>
     </dependency>
 
     <!-- Test -->


### PR DESCRIPTION
Because uw-frame 2.8.0 released, so 2.8.1-snap is the now active snap.