### PR TITLE
Patch always logging in issue

### DIFF
--- a/angularjs-portal-home/src/main/webapp/main.js
+++ b/angularjs-portal-home/src/main/webapp/main.js
@@ -52,6 +52,11 @@ require(['./config', './js/login-config'], function(config, loginConfig) {
               if (response.data.username === 'guest') {
                 $rootScope.GuestMode = true;
               }
+              if(sessionStorage) {
+                //for some really weird reason the $sessionStorage here isn't being
+                //persisted to real session storage, so we have to do it manually.
+                sessionStorage.setItem('ngStorage-portal', JSON.stringify($sessionStorage.portal));
+              }
             }
           });
         } else {

--- a/angularjs-portal-home/src/main/webapp/main.js
+++ b/angularjs-portal-home/src/main/webapp/main.js
@@ -52,10 +52,9 @@ require(['./config', './js/login-config'], function(config, loginConfig) {
               if (response.data.username === 'guest') {
                 $rootScope.GuestMode = true;
               }
-              if(sessionStorage) {
-                //for some really weird reason the $sessionStorage here isn't being
-                //persisted to real session storage, so we have to do it manually.
-                sessionStorage.setItem('ngStorage-portal', JSON.stringify($sessionStorage.portal));
+              //for some really weird reason the $sessionStorage here isn't being
+              //persisted to real session storage, so we have to do it manually.
+              $sessionStorage.$apply();
               }
             }
           });


### PR DESCRIPTION
So there is a bug where `$sessionStorage` in `/main.js` doesn't persist to the actual session storage, super weird. This patch fixes that by doing what the underlying library does.

This fixes 2 things:
+ Impersonate now works
+ Everytime someone hits /web they are not reauthenticated by hitting `/portal/Login?silent=true`