### PR TITLE
Fix display of compact widgets

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/default-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/default-card.html
@@ -1,14 +1,17 @@
 <md-card class="list-content" id="portlet-id-{{::portlet.nodeId}}">
-  <div class='widget-info'>
-    <i title="Info" class="fa fa-info-circle"
-    tooltip="{{::portlet.description}}"
-    tooltip-trigger="mouseenter"
-    tooltip-placement="top"
-    tooltip-popup-delay="200"></i>
-  </div>
-  <div class='widget-remove' ng-hide='GuestMode'>
-    <i title="Remove" class="fa fa-times portlet-options" ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"><a aria-label="Remove this app symbol" href="#"></a></i>
-  </div>
+  <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of this app">
+    <md-tooltip md-direction="top" class="widget-action-tooltip">
+      {{portlet.description}}
+    </md-tooltip>
+    <md-icon>info</md-icon>
+  </md-button>
+  <md-button class="widget-action widget-remove md-icon-button"
+             aria-label="remove {{ portlet.title }} widget from your home screen"
+             ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"
+             ng-hide="GuestMode || cantRemove">
+    <md-icon>close</md-icon>
+  </md-button>
+
   <a aria-labelledby="appTitle_portlet.title-{{::portlet.nodeId}}" tabindex="0" ng-if="'EXCLUSIVE' === layoutCtrl.portletType(portlet)" href="exclusive/{{::portlet.fname}}" target="{{::portlet.target}}">
     <div class="icon-container">
       <portlet-icon></portlet-icon>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -10,7 +10,7 @@
       <md-icon>info</md-icon>
     </md-button>
     <md-button class="widget-action widget-remove md-icon-button"
-               aria-label="remove this widget from your home screen"
+               aria-label="remove {{ portlet.title }} widget from your home screen"
                ng-click="widgetCtrl.removePortlet(portlet.nodeId, portlet.title)"
                ng-hide="GuestMode || cantRemove">
       <md-icon>close</md-icon>


### PR DESCRIPTION
Recent changes to the "widget info" tooltip didn't include compact widgets, and they broke. This PR fixes them.

#### Before
![screen shot 2016-10-10 at 10 59 21 am](https://cloud.githubusercontent.com/assets/5818702/19242441/c8ed3466-8ed8-11e6-95c9-f56e72b340b1.png)

#### After
![screen shot 2016-10-10 at 10 59 29 am](https://cloud.githubusercontent.com/assets/5818702/19242449/d05a95e0-8ed8-11e6-8414-5128adaa64c3.png)
