### PR TITLE
Fix broken launch buttons

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -87,12 +87,12 @@
 
       <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
       <div ng-switch-when="NORMAL">
-        <a tabindex="-1" ng-href="{{widgetCtrl.renderURL(portlet)}}" target="{{portlet.target}}" class="normal-widget">
+        <a tabindex="-1" ng-href="widgetCtrl.renderURL(portlet)" target="{{portlet.target}}" class="normal-widget">
           <div class="widget-icon-container" layout="column" layout-align="center center">
             <portlet-icon></portlet-icon>
           </div>
         </a>
-        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
+        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button" ng-href="widgetCtrl.renderURL(portlet)">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>
@@ -105,7 +105,7 @@
             <portlet-icon></portlet-icon>
           </div>
         </a>
-        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button">
+        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button"  ng-click="widgetCtrl.maxStaticPortlet(portlet)">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -95,7 +95,7 @@
         <launch-button data-href="{{ widgetCtrl.renderURL(portlet) }}"
                        data-target="_blank"
                        data-button-text="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}"
-                       data-aria-label="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}">
+                       data-aria-label="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}">
         </launch-button>
       </div>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -87,15 +87,16 @@
 
       <!-- For basic apps (not a widget, not simple content, no pithy content), show only an icon -->
       <div ng-switch-when="NORMAL">
-        <a tabindex="-1" ng-href="widgetCtrl.renderURL(portlet)" target="{{portlet.target}}" class="normal-widget">
+        <a tabindex="-1" ng-href="{{ widgetCtrl.renderURL(portlet) }}" target="{{portlet.target}}" class="normal-widget">
           <div class="widget-icon-container" layout="column" layout-align="center center">
             <portlet-icon></portlet-icon>
           </div>
         </a>
-        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button" ng-href="widgetCtrl.renderURL(portlet)">
-          <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
-          <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
-        </button>
+        <launch-button data-href="{{ widgetCtrl.renderURL(portlet) }}"
+                       data-target="_blank"
+                       data-button-text="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}"
+                       data-aria-label="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}">
+        </launch-button>
       </div>
 
       <!-- For simple content portlets, show only an icon -->


### PR DESCRIPTION
**In this PR**:
- "NORMAL" widgets now use the `<launch-button>` directive and have an `href` attribute
- "SIMPLE" widgets still use plain `<button>`, but they now have an `ng-click` attribute