### PR TITLE
MUMUP-2766 Allows MyUW search results if no extra search specified

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -1,5 +1,5 @@
 <md-content class="search-results">
-  <md-tabs md-dynamic-height md-border-bottom ng-show="googleSearchEnabled || directoryEnabled">
+  <md-tabs md-dynamic-height md-border-bottom >
 
     <!-- ALL RESULTS -->
     <md-tab>
@@ -24,7 +24,7 @@
           </div>
 
           <!-- No search results found -->
-          <div id="no-results" class="search-results-container" ng-show="totalCount === 0">
+          <div id="no-results" class="search-results-container search-results" ng-show="totalCount === 0">
             <p><strong>No matches.</strong></p>
             <p>Suggestions:</p>
             <p ng-if="kbSearchUrl">
@@ -45,7 +45,7 @@
     </md-tab>
 
     <!-- MyUW RESULTS ONLY -->
-    <md-tab>
+    <md-tab ng-if="googleSearchEnabled || directoryEnabled">
       <md-tab-label>
         MyUW&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
       </md-tab-label>
@@ -60,7 +60,7 @@
     </md-tab>
 
     <!-- DIRECTORY RESULTS ONLY -->
-    <md-tab ng-show="directoryEnabled">
+    <md-tab ng-if="directoryEnabled">
       <md-tab-label>
         Directory&nbsp;&nbsp;<span class="badge">{{ wiscDirectoryTooManyResults ? '25+' : wiscDirectoryResultCount }}</span>
       </md-tab-label>
@@ -75,7 +75,7 @@
     </md-tab>
 
     <!-- GOOGLE CUSTOM SEARCH RESULTS ONLY -->
-    <md-tab ng-show="googleSearchEnabled">
+    <md-tab ng-if="googleSearchEnabled">
       <md-tab-label>
         {{domainResultsLabel}}&nbsp;&nbsp;<span class="badge">{{ googleResultsEstimatedCount }}</span>
       </md-tab-label>


### PR DESCRIPTION
Bug - without web search or directory search enabled, the whole md-tabs would be hidden.
Cosmetic fix - no search results section was not consistent with other search result padding

Shows the MyUW only tab when there is another tab to show (web or directory).
Needs ng-if vs ng-show, because the tab markup still exists with ng-show resulting basically empty tabs.

Before without a web search or directory search enabled:
![image](https://cloud.githubusercontent.com/assets/5521429/19493254/85892a64-953f-11e6-950e-1cb55b73fd62.png)

Before with the no-results styling and results enabled:
![image](https://cloud.githubusercontent.com/assets/5521429/19493455/47f89468-9540-11e6-8440-4da0658e8d61.png)


After without a web search or directory search enabled:

![image](https://cloud.githubusercontent.com/assets/5521429/19493327/cd8773ca-953f-11e6-9748-56c38813f7c1.png)


After with only 1 enabled:

![image](https://cloud.githubusercontent.com/assets/5521429/19493438/35dcf724-9540-11e6-8af3-10a79db59c17.png)

