### PR TITLE
Improve portal home accessibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ angularjs-portal-home/src/main/webapp/my-app/my-app.css
 angularjs-portal-home/.codenvy
 angularjs-portal-mock-portal/.codenvy
 doc_target
+npm-debug.log

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -36,7 +36,7 @@
          </div>
          <div ng-bind-html="portlet.widgetContent"></div>
       </div>
-      <a class="launch-app-button" href="{{portlet.url}}" target="{{portlet.target}}">Launch full app</a>
+      <a class="launch-app-button" ng-href="{{ portlet.url }}" target="{{ portlet.target }}">Launch full app</a>
     </div>
 
     <div ng-switch="widgetCtrl.portletType(portlet)" class="widget-type-container">

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -3,9 +3,9 @@
   <!-- HEADER -->
   <md-card-header class="widget-header">
     <!-- Widget Chrome -->
-    <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of this app">
+    <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of {{ portlet.title }}">
       <md-tooltip md-direction="top" class="widget-action-tooltip">
-        {{portlet.description}}
+        {{ portlet.description }}
       </md-tooltip>
       <md-icon>info</md-icon>
     </md-button>
@@ -17,7 +17,9 @@
     </md-button>
 
     <md-card-header-text>
-      <span class='md-title' style='text-align: center;' id="appTitle_portlet.title-{{portlet.nodeId}}" aria-labelledby="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">{{ portlet.title }}</span>
+      <span class="md-title" style="text-align: center;" id="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">
+	      {{ portlet.title }}
+      </span>
     </md-card-header-text>
   </md-card-header>
 
@@ -107,7 +109,7 @@
             <portlet-icon></portlet-icon>
           </div>
         </a>
-        <button aria-labelledby="goToApps-{{portlet.nodeId}} appTitle_portlet.title-{{portlet.nodeId}}" class="launch-app-button"  ng-click="widgetCtrl.maxStaticPortlet(portlet)">
+        <button aria-label="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}" class="launch-app-button"  ng-click="widgetCtrl.maxStaticPortlet(portlet)">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -3,7 +3,7 @@
   <!-- HEADER -->
   <md-card-header class="widget-header">
     <!-- Widget Chrome -->
-    <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of {{ portlet.title }}">
+    <md-button class="widget-action widget-info md-icon-button" aria-label="Description: {{ portlet.description }}" role="tooltip">
       <md-tooltip md-direction="top" class="widget-action-tooltip">
         {{ portlet.description }}
       </md-tooltip>
@@ -17,7 +17,7 @@
     </md-button>
 
     <md-card-header-text>
-      <span class="md-title" style="text-align: center;" id="appTitle_portlet.title-{{portlet.nodeId}}" tabindex="0">
+      <span class="md-title" style="text-align: center;" aria-label="{{ portlet.title }}" tabindex="0">
 	      {{ portlet.title }}
       </span>
     </md-card-header-text>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -98,7 +98,7 @@
                        data-target="_blank"
                        data-rel="noopener noreferrer"
                        data-button-text="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}"
-                       data-aria-label="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}">
+                       data-aria-label="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch ' + portlet.title }}">
         </launch-button>
       </div>
 
@@ -109,7 +109,7 @@
             <portlet-icon></portlet-icon>
           </div>
         </a>
-        <button aria-label="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch full app' }}" class="launch-app-button"  ng-click="widgetCtrl.maxStaticPortlet(portlet)">
+        <button aria-label="{{ portlet.widgetConfig.launchText ? portlet.widgetConfig.launchText : 'Launch ' + portlet.title }}" class="launch-app-button"  ng-click="widgetCtrl.maxStaticPortlet(portlet)">
           <span ng-if='portlet.widgetConfig.launchText'>{{portlet.widgetConfig.launchText}}</span>
           <span ng-if='!portlet.widgetConfig.launchText'>Launch full app</span>
         </button>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -36,7 +36,7 @@
          </div>
          <div ng-bind-html="portlet.widgetContent"></div>
       </div>
-      <a class="launch-app-button" ng-href="{{ portlet.url }}" target="{{ portlet.target }}">Launch full app</a>
+      <a class="launch-app-button" href="{{ portlet.url }}" target="{{ portlet.target }}">Launch full app</a>
     </div>
 
     <div ng-switch="widgetCtrl.portletType(portlet)" class="widget-type-container">


### PR DESCRIPTION
[MUMUP-2807](https://jira.doit.wisc.edu/jira/browse/MUMUP-2807)

**In this PR:**
- Added aria-labels to elements that were being skipped by screen reader
- Changed the "info" button's role to a tooltip and provide the tooltip text as the button's aria-label

Overall this results in a smoother experience when using a screen reader, with clearer context when navigating by keyboard.