### PR TITLE
Hack: RSS widget config now is JSON URL rather than RSS URL.

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -198,7 +198,16 @@ define(['angular', 'jquery'], function(angular, $) {
         }
 
           var getRSSJsonified = function(feedURL) {
-          return $http.get('api/proxy/rss2json?rss_url=' + feedURL);
+            // This is a hack. 
+            // It would be maybe healthier to enhance RSS widget to
+            // support
+            // 1. configure explicitly with URL that generates the JSON
+            // 2. configure with pithy key to feed ( campus_news )
+            // 3. configure explicitly with RSS URL and automatically
+            //    run that through an RSS to JSON converter.
+            // Whereas this hack repurposes existing configuration for (3)
+            // to do (1).
+          return $http.get(feedURL);
         }
 
         return {

--- a/docs/markdown/widgets.md
+++ b/docs/markdown/widgets.md
@@ -149,12 +149,12 @@ This provides a more usable click surface, a simpler and cleaner user experience
 <portlet-preference>
     <name>widgetConfig</name>
     <value>
-    	<![CDATA[{
-    		"lim": 4,
-    		"showdate": true,
-    		"dateFormat": "MM-dd-yyyy",
-    		"showShowing": true
-    	}]]>
+      <![CDATA[{
+        "lim": 4,
+        "showdate": true,
+        "dateFormat": "MM-dd-yyyy",
+        "showShowing": true
+      }]]>
     </value>
 </portlet-preference>
 ```

--- a/docs/markdown/widgets.md
+++ b/docs/markdown/widgets.md
@@ -144,7 +144,7 @@ This provides a more usable click surface, a simpler and cleaner user experience
 </portlet-preference>
 <portlet-preference>
     <name>widgetURL</name>
-    <value>http://www.ncaa.com/news/ncaa/d1/rss.xml</value>
+    <value>/rss-to-json/rssTransform/prop/campus-news</value>
 </portlet-preference>
 <portlet-preference>
     <name>widgetConfig</name>
@@ -162,7 +162,9 @@ This provides a more usable click surface, a simpler and cleaner user experience
 #### Additional information
 
 Note the addition required value in the entity file:
-* `widgetUrl`: The URL of the rss feed you want to display
+* `widgetUrl`: The URL of the *JSON representation of the* RSS feed you want to display
+
+The [rssToJson][] microservice is a fine way to convert desired RSS feeds into the required JSON representation.
 
 ### Custom widgets
 Using a JSON service is a great way to have user-focused content in your widgets. Here are the steps you have to take to create your custom JSON-backed widget:
@@ -255,3 +257,4 @@ Example:
 Read more about the [launch button text guidance](#/md/widget-launch-button).
 
 
+[rssToJson]: https://github.com/UW-Madison-DoIT/rssToJson


### PR DESCRIPTION
Okay, here's the deal.

We're pivoting from 

Status quo:

the RSS widgets declaring an RSS URL and that RSS URL needing to be fed to an out-in-the-cloud converter, 

to 

RSS widgets declaring a URL that produces the needed JSON directly (that happens to be an RSS to JSON conversion service, taking as a parameter a key indicating what RSS feed ought to be converted).

(For an example of this pivoting, see [this test tier entity change](https://git.doit.wisc.edu/myuw-overlay/entities/merge_requests/464/diffs).)

It might be better to support configuring the RSS widget in any of the three ways, that is

1. With the URL of the actual desired RSS feed. This is in some sense simplest. The RSS widget Type would then have the responsibility of applying however it is that one retrieves and converts RSS as implemented in this particular AngularJS-portal deployment. Nice abstractions: the metadata defining a widget might be expert about just what RSS feed it ought to be rendering, but it isn't expert about how RSS retrieval and transformation is implemented.

2. With the URL of the transformed JSON. This is in some sense the closest parallel to other widget types -- some widgets are dynamic, pull a JSON feed, know the URL of that JSON feed.

3. With the identifier (key) of the RSS feed.  This in some sense abstracts away the most, since the widget metadata would know conceptually what news feed it wants (campus_news, say) but nothing about how that particular feed happened to be implemented, in this tier even.


But to get news feeds working again, what we're doing is cannibalizing prior configuration support for (1) to instead be (2).

