### PR TITLE
MUMUP-2825 angularjs-portal docs: now less ugly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ angularjs-portal-home/.codenvy
 angularjs-portal-mock-portal/.codenvy
 doc_target
 npm-debug.log
+docs/_site

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gem 'github-pages', group: :jekyll_plugins
+gem 'jekyll-default-layout'
+gem 'jekyll-optional-front-matter'
+gem 'jekyll-readme-index'
+gem 'jekyll-titles-from-headings'

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,0 +1,6 @@
+gems:
+  - github-pages
+  - jekyll-default-layout
+  - jekyll-optional-front-matter
+  - jekyll-readme-index
+  - jekyll-titles-from-headings

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -4,3 +4,5 @@ gems:
   - jekyll-optional-front-matter
   - jekyll-readme-index
   - jekyll-titles-from-headings
+
+theme: jekyll-theme-dinky


### PR DESCRIPTION
Makes the new GitHub Pages Jekyll-driven angularjs-portal docs less ugly

simply by adopting the `dinky` theme.

In doing so adds enough configuration to allow running Jekyll locally

```
bundle exec jekyll serve
```

to enable local testing. Here's what it looks like locally for me:

![jekyll on localhost](https://cloud.githubusercontent.com/assets/952283/22267070/f824f3f0-e247-11e6-8506-5ccaf9fdaca6.png)


UPDATE: and here it is [previewed for reals on GitHub Pages](http://apetro.github.io/angularjs-portal/).