### PR TITLE
Add maintenance mode styles and markup for widgets

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+continuation_indent_size = 2
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+

--- a/angularjs-portal-home/src/main/webapp/css/widget.less
+++ b/angularjs-portal-home/src/main/webapp/css/widget.less
@@ -282,3 +282,32 @@ weather {
   width : 315px;
   margin : auto;
 }
+
+/* MAINTENANCE MODE */
+.widget-frame {
+  .overlay__maintenance-mode {
+	position: absolute;
+	width: 100%;
+	height: 100%;
+	background: rgba(0,0,0,0.5);
+	z-index: 99;
+	border-radius: 3px;
+	.maintenance-content {
+	  text-align: center;
+	  font-weight: bold;
+	  padding: 10px;
+	  background: #fff;
+	  margin: 66px 10px 0 10px;
+	  display: block;
+	  border-radius: 3px;
+	  p {
+		margin-bottom: 0;
+		.material-icons {
+		  height: 40px;
+		  width: 40px;
+		  font-size: 40px;
+		}
+	  }
+	}
+  }
+}

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -1,36 +1,36 @@
 'use strict';
 
-define(['angular'], function(angular){
+define(['angular'], function (angular) {
 
   var app = angular.module('my-app.layout.widget.controllers', []);
 
-  app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService){
+  app.controller('OptionLinkController', ['$scope', 'layoutService', function ($scope, layoutService) {
 
-    var configInit = function(){
-      if(!$scope.config) {
+    var configInit = function () {
+      if (!$scope.config) {
         //setting up defaults since config doesn't exist
         $scope.config = {
-            singleElement : false,
-            arrayName : 'array',
-            value : 'value',
-            display : 'display'
+          singleElement: false,
+          arrayName: 'array',
+          value: 'value',
+          display: 'display'
         };
       }
     };
 
-    var populateWidgetContent = function() {
-      if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+    var populateWidgetContent = function () {
+      if ($scope.portlet.widgetURL && $scope.portlet.widgetType) {
         //fetch portlet widget json
         $scope.portlet.widgetData = [];
 
-        layoutService.getWidgetJson($scope.portlet).then(function(data) {
-          if(data) {
+        layoutService.getWidgetJson($scope.portlet).then(function (data) {
+          if (data) {
             console.log(data);
             //set init
-            if($scope.config.singleElement) {
+            if ($scope.config.singleElement) {
               //set the default selected url
               $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.value];
-            } else if($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
+            } else if ($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
               $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
             }
           } else {
@@ -42,50 +42,50 @@ define(['angular'], function(angular){
     configInit();
     populateWidgetContent();
   }]);
-  
-  app.controller('LTILaunchController', ['$scope', 'layoutService', 'keyValueService', '$q', '$sce', function($scope, layoutService, keyValueService, $q, $sce){
+
+  app.controller('LTILaunchController', ['$scope', 'layoutService', 'keyValueService', '$q', '$sce', function ($scope, layoutService, keyValueService, $q, $sce) {
     $scope.loading = false;
-    var init = function(){
+    var init = function () {
       $scope.loading = true;
-      layoutService.getWidgetJson($scope.portlet).then(function(data) {
-          $scope.loading = false;
-          if(data) {
-            $scope.formInputs = data.formInputs;
-            $scope.formAction = $sce.trustAsResourceUrl(data.action);
-          }
-      }, function(){
-          $scope.loading = false;
+      layoutService.getWidgetJson($scope.portlet).then(function (data) {
+        $scope.loading = false;
+        if (data) {
+          $scope.formInputs = data.formInputs;
+          $scope.formAction = $sce.trustAsResourceUrl(data.action);
+        }
+      }, function () {
+        $scope.loading = false;
       });
     }
     init();
   }]);
 
-  app.controller('WeatherController', ['$scope', 'layoutService', 'keyValueService', '$q', function($scope, layoutService, keyValueService, $q){
+  app.controller('WeatherController', ['$scope', 'layoutService', 'keyValueService', '$q', function ($scope, layoutService, keyValueService, $q) {
     $scope.weatherData = [];
     $scope.loading = false;
     $scope.showMetric = false;
     $scope.currentlyImperial = true;
-    $scope.fetchKey="userWeatherPreference";
-    $scope.initialPreference=true;
+    $scope.fetchKey = "userWeatherPreference";
+    $scope.initialPreference = true;
 
 
-    var populateWidgetContent = function() {
-      if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+    var populateWidgetContent = function () {
+      if ($scope.portlet.widgetURL && $scope.portlet.widgetType) {
         $scope.loading = true;
         //fetch portlet widget json
         $scope.portlet.widgetData = [];
         var widgetPromise = layoutService.getWidgetJson($scope.portlet);
         var preferencePromise = keyValueService.getValue($scope.fetchKey);
 
-        $q.all([widgetPromise, preferencePromise]).then(function(data) {
+        $q.all([widgetPromise, preferencePromise]).then(function (data) {
           $scope.loading = false;
-          if(data) {
+          if (data) {
             console.log(data);
             var allTheWeathers = data[0];
-            var myPref= data[1];
-            var myPreference='F';
-            if(myPref.userWeatherPreference=='C'){
-            	myPreference='C';
+            var myPref = data[1];
+            var myPreference = 'F';
+            if (myPref.userWeatherPreference == 'C') {
+              myPreference = 'C';
             }
 
             $scope.portlet.widgetData = allTheWeathers.weathers;
@@ -96,51 +96,51 @@ define(['angular'], function(angular){
             $scope.error = true;
             console.warn("Got nothing back from widget fetch");
           }
-        }, function(){
+        }, function () {
           $scope.loading = false;
           $scope.error = true;
         });
       }
     };
 
-    $scope.changePref=function(userPreference){
+    $scope.changePref = function (userPreference) {
 
-    	if(userPreference==='C'){
-    		$scope.changeToC();
-    		$scope.showMetric=true;
-    	}else{
-    		$scope.changeToF();
-    	}
-    	if($scope.initialPreference){
-    		$scope.initialPreference=false;
-    	}else{
-    		var value = {};
-    		value.userWeatherPreference = userPreference;
-       		keyValueService.setValue($scope.fetchKey, value);
-    	}
+      if (userPreference === 'C') {
+        $scope.changeToC();
+        $scope.showMetric = true;
+      } else {
+        $scope.changeToF();
+      }
+      if ($scope.initialPreference) {
+        $scope.initialPreference = false;
+      } else {
+        var value = {};
+        value.userWeatherPreference = userPreference;
+        keyValueService.setValue($scope.fetchKey, value);
+      }
     }
 
-    $scope.changeToC = function(){
-      if ($scope.currentlyImperial){
-        for (var i = 0; i < $scope.weatherData.length; i++){
-          $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature-32)*(5/9);
+    $scope.changeToC = function () {
+      if ($scope.currentlyImperial) {
+        for (var i = 0; i < $scope.weatherData.length; i++) {
+          $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature - 32) * (5 / 9);
 
-          for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
-            $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature-32)*(5/9)
-            $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature-32)*(5/9)
+          for (var j = 0; j < $scope.weatherData[i].forecast.length; j++) {
+            $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature - 32) * (5 / 9)
+            $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature - 32) * (5 / 9)
           }
         }
         $scope.currentlyImperial = false;
       }
     };
-    $scope.changeToF = function(){
-      if (!$scope.currentlyImperial){
-        for (var i = 0; i < $scope.weatherData.length; i++){
-          $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature)*(9/5) +32;
+    $scope.changeToF = function () {
+      if (!$scope.currentlyImperial) {
+        for (var i = 0; i < $scope.weatherData.length; i++) {
+          $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature) * (9 / 5) + 32;
 
-          for (var j=0; j <$scope.weatherData[i].forecast.length; j++){
-            $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature)*(9/5) + 32;
-            $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature)*(9/5) + 32;
+          for (var j = 0; j < $scope.weatherData[i].forecast.length; j++) {
+            $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature) * (9 / 5) + 32;
+            $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature) * (9 / 5) + 32;
           }
         }
         $scope.currentlyImperial = true;
@@ -148,44 +148,44 @@ define(['angular'], function(angular){
     }
     console.log("Config: " + $scope.portlet.widgetConfig);
     populateWidgetContent();
-    $scope.details=false;
+    $scope.details = false;
   }]);
 
-  app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService){
-      $scope.loading = false;
-      var populateWidgetContent = function() {
-        if($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-          $scope.loading = true;
-          //fetch portlet widget json
-          $scope.portlet.widgetData = [];
-          layoutService.getWidgetJson($scope.portlet).then(function(data) {
-            $scope.loading = false;
-            if(data) {
-              $scope.portlet.widgetData = data;
-              $scope.content = $scope.portlet.widgetData;
-              if(Array.isArray($scope.content) &&  $scope.content.length == 0) {
-                $scope.isEmpty = true;
-              } else if($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
-                  && eval($scope.portlet.widgetConfig.evalString)) {
-                //ideally this would do a check on an embedded object for emptiness
-                //example : '$scope.content.report.length === 0'
-                $scope.isEmpty = true;
-              }
-            } else {
-              console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
+  app.controller('GenericWidgetController', ['$scope', 'layoutService', function ($scope, layoutService) {
+    $scope.loading = false;
+    var populateWidgetContent = function () {
+      if ($scope.portlet.widgetURL && $scope.portlet.widgetType) {
+        $scope.loading = true;
+        //fetch portlet widget json
+        $scope.portlet.widgetData = [];
+        layoutService.getWidgetJson($scope.portlet).then(function (data) {
+          $scope.loading = false;
+          if (data) {
+            $scope.portlet.widgetData = data;
+            $scope.content = $scope.portlet.widgetData;
+            if (Array.isArray($scope.content) && $scope.content.length == 0) {
+              $scope.isEmpty = true;
+            } else if ($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
+              && eval($scope.portlet.widgetConfig.evalString)) {
+              //ideally this would do a check on an embedded object for emptiness
+              //example : '$scope.content.report.length === 0'
               $scope.isEmpty = true;
             }
-        }, function(){
-            $scope.loading = false;
-          });
-        }
-      };
+          } else {
+            console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
+            $scope.isEmpty = true;
+          }
+        }, function () {
+          $scope.loading = false;
+        });
+      }
+    };
 
     $scope.filteredArray = function (array, objectVar, strings) {
-      if(array && objectVar && strings) {
+      if (array && objectVar && strings) {
         return array.filter(function (letter) {
-          for(var i = 0; i < strings.length ; i++) {
-            if(letter[objectVar].indexOf(strings[i]) != -1) {
+          for (var i = 0; i < strings.length; i++) {
+            if (letter[objectVar].indexOf(strings[i]) != -1) {
               return true;
             }
           }
@@ -195,12 +195,12 @@ define(['angular'], function(angular){
       }
     };
 
-    if($scope.portlet.widgetTemplate) {
+    if ($scope.portlet.widgetTemplate) {
       $scope.content = [];
-      $scope.template =  $scope.portlet.widgetTemplate;
+      $scope.template = $scope.portlet.widgetTemplate;
       $scope.isEmpty = false;
       $scope.portlet.widgetData = [];
-      console.log("Config for "+ $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
+      console.log("Config for " + $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
       populateWidgetContent();
     } else {
       console.error($scope.portlet.fname + " said its a widget, but no template defined.");
@@ -208,243 +208,251 @@ define(['angular'], function(angular){
     }
   }]);
 
-  app.controller("RSSWidgetController", ['$scope', 'layoutService', function($scope, layoutService){
+  app.controller("RSSWidgetController", ['$scope', 'layoutService', function ($scope, layoutService) {
 
-      $scope.getPrettyDate = function(dateString) {
-        var dte;
-        if(dateString) {
-            dte = new Date(dateString);
-        } else {
-            dte = null;
+    $scope.getPrettyDate = function (dateString) {
+      var dte;
+      if (dateString) {
+        dte = new Date(dateString);
+      } else {
+        dte = null;
+      }
+      return dte;
+    };
+
+    var init = function () {
+      $scope.loading = true;
+      if ($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
+        if (!$scope.config) {
+          $scope.config = {};
         }
-        return dte;
-      };
 
-      var init = function(){
-        $scope.loading = true;
-        if($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
-          if(!$scope.config) {
-            $scope.config = {};
-          }
+        if (!$scope.config.lim) {
+          $scope.config.lim = 5;
+        }
 
-          if(!$scope.config.lim) {
-            $scope.config.lim = 5;
-          }
+        if (!$scope.config.titleLim) {
+          $scope.config.titleLim = 40;
+        }
 
-          if(!$scope.config.titleLim) {
-            $scope.config.titleLim = 40;
-          }
+        if (!$scope.config.showShowing) {
+          //default must be false as falsy is weird
+          $scope.config.showShowing = false;
+        }
 
-          if(!$scope.config.showShowing) {
-            //default must be false as falsy is weird
-            $scope.config.showShowing = false;
-          }
+        var successFn = function (result) {
+          $scope.loading = false;
+          $scope.data = result.data;
 
-          var successFn = function(result){
-              $scope.loading = false;
-              $scope.data = result.data;
-
-              if($scope.data.status !== 'ok') {
-                 $scope.error = true;
-                 $scope.loading = false;
-              } else {
-                      if(!$scope.data.items
-                          || $scope.data.items.length == 0) {
-                             $scope.isEmpty = true;
-                             $scope.loading = false;
-                             $scope.error = true;
-                      }else{
-                       if(!$scope.config.showShowing && $scope.data.items.length > $scope.config.lim){
-                          $scope.config.showShowing = true;
-                      }
-               }
-              }
-          };
-
-         var errorFn = function(data){
+          if ($scope.data.status !== 'ok') {
             $scope.error = true;
-            $scope.isEmpty = true;
             $scope.loading = false;
-          };
-          layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn,errorFn);
-        }
+          } else {
+            if (!$scope.data.items
+              || $scope.data.items.length == 0) {
+              $scope.isEmpty = true;
+              $scope.loading = false;
+              $scope.error = true;
+            } else {
+              if (!$scope.config.showShowing && $scope.data.items.length > $scope.config.lim) {
+                $scope.config.showShowing = true;
+              }
+            }
+          }
+        };
+
+        var errorFn = function (data) {
+          $scope.error = true;
+          $scope.isEmpty = true;
+          $scope.loading = false;
+        };
+        layoutService.getRSSJsonified($scope.portlet.widgetURL).then(successFn, errorFn);
+      }
+    };
+
+    init();
+
+  }]);
+
+  //SearchWithLinksController
+  app.controller("SearchWithLinksController", ['$scope', '$sce', function ($scope, $sce) {
+    $scope.secureURL = $sce.trustAsResourceUrl($scope.config.actionURL);
+  }]);
+
+  //widget creator
+  app.controller("WidgetCreatorController", ['$scope', '$route', '$localStorage', function ($scope, $route, $localStorage) {
+    //general functions
+    var validJSON = function isValidJson(json) {
+      try {
+        JSON.parse(json);
+        return true;
+      } catch (e) {
+        return false;
+      }
+    };
+
+    var init = function () {
+      $scope.storage.isEmpty = false;
+      $scope.storage.portlet = $scope.storage.starterTemplates[0];
+      $scope.storage.inited = true;
+      $scope.portlet = $scope.storage.portlet;
+    };
+
+    var retInit = function () {
+      $scope.portlet = $scope.storage.portlet;
+      $scope.isEmpty = $scope.storage.isEmpty;
+      if ($scope.storage.content && validJSON($scope.storage.content)) {
+        $scope.content = JSON.parse($scope.storage.content);
+        $scope.isEmpty = $scope.storage.evalString ? eval($scope.storage.evalString) : false;
+      } else {
+        $scope.content = {};
+        $scope.isEmpty = true;
+        $scope.errorJSON = $scope.storage.content ? "JSON NOT VALID" : "";
+      }
+      if ($scope.storage.widgetConfig && validJSON($scope.storage.widgetConfig)) {
+        $scope.portlet.widgetConfig = JSON.parse($scope.storage.widgetConfig);
+      } else {
+        $scope.errorConfigJSON = $scope.storage.widgetConfig ? "JSON NOT VALID" : "";
       }
 
-      init();
+      $scope.template = $scope.portlet.widgetTemplate;
 
-    }]);
+    };
 
-    //SearchWithLinksController
-    app.controller("SearchWithLinksController", ['$scope', '$sce', function($scope, $sce){
-      $scope.secureURL = $sce.trustAsResourceUrl($scope.config.actionURL);
-    }]);
+    $scope.reload = function () {
+      $route.reload();
+    };
 
-    //widget creator
-    app.controller("WidgetCreatorController",['$scope', '$route', '$localStorage', function($scope, $route, $localStorage){
-      //general functions
-      var validJSON = function isValidJson(json) {
-        try {
-            JSON.parse(json);
-            return true;
-        } catch (e) {
-            return false;
-        }
-      };
-
-      var init = function(){
-        $scope.storage.isEmpty = false;
-        $scope.storage.portlet = $scope.storage.starterTemplates[0];
-        $scope.storage.inited = true;
-        $scope.portlet = $scope.storage.portlet;
-      };
-
-      var retInit = function() {
-        $scope.portlet = $scope.storage.portlet;
-        $scope.isEmpty = $scope.storage.isEmpty;
-        if($scope.storage.content && validJSON($scope.storage.content)) {
-          $scope.content = JSON.parse($scope.storage.content);
-          $scope.isEmpty = $scope.storage.evalString ? eval($scope.storage.evalString) : false;
-        } else {
-          $scope.content = {};
-          $scope.isEmpty = true;
-          $scope.errorJSON = $scope.storage.content ? "JSON NOT VALID" : "";
-        }
-        if($scope.storage.widgetConfig && validJSON($scope.storage.widgetConfig)) {
-          $scope.portlet.widgetConfig = JSON.parse($scope.storage.widgetConfig);
-        } else {
-          $scope.errorConfigJSON = $scope.storage.widgetConfig ? "JSON NOT VALID" : "";
-        }
-
-        $scope.template = $scope.portlet.widgetTemplate;
-
-      };
-
-      $scope.reload = function(){
+    $scope.clear = function () {
+      if (confirm("Are you sure, all your config will be cleared")) {
+        init();
         $route.reload();
-      };
+      }
+    };
 
-      $scope.clear = function() {
-          if(confirm("Are you sure, all your config will be cleared")) {
-              init();
-              $route.reload();
+    $scope.changeTemplate = function () {
+      $scope.storage.content = $scope.storage.starterTemplate.contentIsJSON ? JSON.stringify($scope.storage.starterTemplate.content) : $scope.storage.starterTemplate.content;
+      $scope.storage.portlet = $scope.storage.starterTemplate;
+      $scope.storage.widgetConfig = JSON.stringify($scope.storage.starterTemplate.widgetConfig);
+      $scope.reload();
+    };
+
+    var initialize = function () {
+      $localStorage.widgetCreator = $localStorage.widgetCreator || {};
+      $scope.storage = $localStorage.widgetCreator; //makes the widget creator stuff contained
+
+      //mock the widget controller
+      $scope.widgetCtrl = {
+        portletType: function (portlet) {
+          if (portlet.type) {
+            return portlet.type;
           }
-      };
-
-      $scope.changeTemplate = function() {
-        $scope.storage.content = $scope.storage.starterTemplate.contentIsJSON ? JSON.stringify($scope.storage.starterTemplate.content) : $scope.storage.starterTemplate.content;
-        $scope.storage.portlet = $scope.storage.starterTemplate;
-        $scope.storage.widgetConfig = JSON.stringify($scope.storage.starterTemplate.widgetConfig);
-        $scope.reload();
-      };
-
-      var initialize = function(){
-        $localStorage.widgetCreator = $localStorage.widgetCreator || {};
-        $scope.storage = $localStorage.widgetCreator; //makes the widget creator stuff contained
-
-        //mock the widget controller
-        $scope.widgetCtrl = {
-					portletType : function(portlet){
-						if(portlet.type) {
-							return portlet.type;
-						}
-						return 'WIDGET_CREATOR';
-					}
-				};
-        $scope.storage.starterTemplates = [
-          {
-            id: 4,
-            type : "WIDGET_CREATOR",
-            title : "Custom",
-            hasWidgetURL : false,
-            description : "This super cool portlet can change lives.",
-            widgetConfig : {},
-            jsonSample : {},
-            url: 'www.example.com'
-          },
-          {
-            id: 1,
-            type : 'SWL',
-            widgetType : 'search-with-links',
-            title: 'Search with Links',
-            jsonSample: false,
-            url: 'www.example.com',
-            widgetConfig : {
-              "actionURL": "https://rprg.wisc.edu/search/",
-              "actionTarget": "_blank",
-              "actionParameter": "q",
-              "launchText": "Go to resource guide",
-              "links": [
-                {
-                  "title": "Get started",
-                  "href": "https://rprg.wisc.edu/phases/initiate/",
-                  "icon": "fa-map-o",
-                  "target": "_blank",
-                  "rel":"noopener noreferrer"
-                },
-								{
-									"title": "Resources",
-									"href": "https://rprg.wisc.edu/category/resource/",
-									"icon": "fa-th-list",
-									"target": "_blank",
-									"rel": "noopener noreferrer"
-								}
-              ],
-							"maintenanceMode": false
-            },
-            hasWidgetURL : false
-          },
-          {
-            id: 2,
-            url: 'www.example.com',
-            type : 'RSS',
-            widgetType : 'rss',
-            title: 'RSS Widget',
-            jsonSample: false,
-            widgetConfig : {lim : 6, target : '' ,showdate: true, titleLim: 40 , dateFormat: 'MM-dd-yyyy', showShowing: true, maintenanceMode: false},
-            hasWidgetURL : true,
-            widgetURL : ""
-          },
-          {
-            id: 3,
-            url: 'www.example.com',
-            type : 'LOL',
-            title : 'List of Links',
-            jsonSample : false,
-            hasWidgetURL : false,
-            widgetConfig : {
-							"launchText":"Launch the Full App",
-							"additionalText":"Additional Text",
-							"links":[
-								{
-									"title":"The Google",
-									"href":"http://www.google.com",
-									"icon":"fa-google",
-									"target":"_blank",
-									"rel":"noopener noreferrer"
-								},
-								{
-									"title":"Bing",
-									"href":"http://www.bing.com",
-									"icon":"fa-bed",
-									"target":"_blank",
-									"rel":"noopener noreferrer"
-								}
-							],
-							"maintenanceMode": false
-						},
-            description : 'A simple list of links'
-          }
-        ];
-
-        if(!$scope.storage.inited) {
-          init();
-          retInit();
-        } else {
-          retInit();
+          return 'WIDGET_CREATOR';
         }
       };
-      initialize();
-    }]);
+      $scope.storage.starterTemplates = [
+        {
+          id: 4,
+          type: "WIDGET_CREATOR",
+          title: "Custom",
+          hasWidgetURL: false,
+          description: "This super cool portlet can change lives.",
+          widgetConfig: {},
+          jsonSample: {},
+          url: 'www.example.com'
+        },
+        {
+          id: 1,
+          type: 'SWL',
+          widgetType: 'search-with-links',
+          title: 'Search with Links',
+          jsonSample: false,
+          url: 'www.example.com',
+          widgetConfig: {
+            "actionURL": "https://rprg.wisc.edu/search/",
+            "actionTarget": "_blank",
+            "actionParameter": "q",
+            "launchText": "Go to resource guide",
+            "links": [
+              {
+                "title": "Get started",
+                "href": "https://rprg.wisc.edu/phases/initiate/",
+                "icon": "fa-map-o",
+                "target": "_blank",
+                "rel": "noopener noreferrer"
+              },
+              {
+                "title": "Resources",
+                "href": "https://rprg.wisc.edu/category/resource/",
+                "icon": "fa-th-list",
+                "target": "_blank",
+                "rel": "noopener noreferrer"
+              }
+            ],
+            "maintenanceMode": false
+          },
+          hasWidgetURL: false
+        },
+        {
+          id: 2,
+          url: 'www.example.com',
+          type: 'RSS',
+          widgetType: 'rss',
+          title: 'RSS Widget',
+          jsonSample: false,
+          widgetConfig: {
+            lim: 6,
+            target: '',
+            showdate: true,
+            titleLim: 40,
+            dateFormat: 'MM-dd-yyyy',
+            showShowing: true,
+            maintenanceMode: false
+          },
+          hasWidgetURL: true,
+          widgetURL: ""
+        },
+        {
+          id: 3,
+          url: 'www.example.com',
+          type: 'LOL',
+          title: 'List of Links',
+          jsonSample: false,
+          hasWidgetURL: false,
+          widgetConfig: {
+            "launchText": "Launch the Full App",
+            "additionalText": "Additional Text",
+            "links": [
+              {
+                "title": "The Google",
+                "href": "http://www.google.com",
+                "icon": "fa-google",
+                "target": "_blank",
+                "rel": "noopener noreferrer"
+              },
+              {
+                "title": "Bing",
+                "href": "http://www.bing.com",
+                "icon": "fa-bed",
+                "target": "_blank",
+                "rel": "noopener noreferrer"
+              }
+            ],
+            "maintenanceMode": false
+          },
+          description: 'A simple list of links'
+        }
+      ];
+
+      if (!$scope.storage.inited) {
+        init();
+        retInit();
+      } else {
+        retInit();
+      }
+    };
+    initialize();
+  }]);
 
   return app;
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -289,7 +289,7 @@ define(['angular'], function(angular){
         } catch (e) {
             return false;
         }
-      }
+      };
 
       var init = function(){
         $scope.storage.isEmpty = false;
@@ -305,7 +305,7 @@ define(['angular'], function(angular){
           $scope.content = JSON.parse($scope.storage.content);
           $scope.isEmpty = $scope.storage.evalString ? eval($scope.storage.evalString) : false;
         } else {
-          $scope.content = {}
+          $scope.content = {};
           $scope.isEmpty = true;
           $scope.errorJSON = $scope.storage.content ? "JSON NOT VALID" : "";
         }
@@ -317,7 +317,7 @@ define(['angular'], function(angular){
 
         $scope.template = $scope.portlet.widgetTemplate;
 
-      }
+      };
 
       $scope.reload = function(){
         $route.reload();
@@ -328,14 +328,14 @@ define(['angular'], function(angular){
               init();
               $route.reload();
           }
-      }
+      };
 
       $scope.changeTemplate = function() {
         $scope.storage.content = $scope.storage.starterTemplate.contentIsJSON ? JSON.stringify($scope.storage.starterTemplate.content) : $scope.storage.starterTemplate.content;
         $scope.storage.portlet = $scope.storage.starterTemplate;
         $scope.storage.widgetConfig = JSON.stringify($scope.storage.starterTemplate.widgetConfig);
         $scope.reload();
-      }
+      };
 
       var initialize = function(){
         $localStorage.widgetCreator = $localStorage.widgetCreator || {};
@@ -343,13 +343,13 @@ define(['angular'], function(angular){
 
         //mock the widget controller
         $scope.widgetCtrl = {
-                              portletType : function(portlet){
-                                if(portlet.type) {
-                                  return portlet.type;
-                                }
-                                return 'WIDGET_CREATOR';
-                              }
-                            };
+					portletType : function(portlet){
+						if(portlet.type) {
+							return portlet.type;
+						}
+						return 'WIDGET_CREATOR';
+					}
+				};
         $scope.storage.starterTemplates = [
           {
             id: 4,
@@ -381,14 +381,15 @@ define(['angular'], function(angular){
                   "target": "_blank",
                   "rel":"noopener noreferrer"
                 },
-                {
-                  "title": "Resources",
-                  "href": "https://rprg.wisc.edu/category/resource/",
-                  "icon": "fa-th-list",
-                  "target": "_blank",
-                  "rel":"noopener noreferrer"
-                }
-              ]
+								{
+									"title": "Resources",
+									"href": "https://rprg.wisc.edu/category/resource/",
+									"icon": "fa-th-list",
+									"target": "_blank",
+									"rel": "noopener noreferrer"
+								}
+              ],
+							"maintenanceMode": false
             },
             hasWidgetURL : false
           },
@@ -399,7 +400,7 @@ define(['angular'], function(angular){
             widgetType : 'rss',
             title: 'RSS Widget',
             jsonSample: false,
-            widgetConfig : {lim : 6, target : '' ,showdate: true, titleLim: 40 , dateFormat: 'MM-dd-yyyy', showShowing: true},
+            widgetConfig : {lim : 6, target : '' ,showdate: true, titleLim: 40 , dateFormat: 'MM-dd-yyyy', showShowing: true, maintenanceMode: false},
             hasWidgetURL : true,
             widgetURL : ""
           },
@@ -411,25 +412,26 @@ define(['angular'], function(angular){
             jsonSample : false,
             hasWidgetURL : false,
             widgetConfig : {
-                         "launchText":"Launch the Full App",
-                         "additionalText":"Additional Text",
-                         "links":[
-                            {
-                               "title":"The Google",
-                               "href":"http://www.google.com",
-                               "icon":"fa-google",
-                               "target":"_blank",
-                               "rel":"noopener noreferrer"
-                            },
-                            {
-                               "title":"Bing",
-                               "href":"http://www.bing.com",
-                               "icon":"fa-bed",
-                               "target":"_blank",
-                               "rel":"noopener noreferrer"
-                            }
-                         ]
-                      },
+							"launchText":"Launch the Full App",
+							"additionalText":"Additional Text",
+							"links":[
+								{
+									"title":"The Google",
+									"href":"http://www.google.com",
+									"icon":"fa-google",
+									"target":"_blank",
+									"rel":"noopener noreferrer"
+								},
+								{
+									"title":"Bing",
+									"href":"http://www.bing.com",
+									"icon":"fa-bed",
+									"target":"_blank",
+									"rel":"noopener noreferrer"
+								}
+							],
+							"maintenanceMode": false
+						},
             description : 'A simple list of links'
           }
         ];
@@ -440,7 +442,7 @@ define(['angular'], function(angular){
         } else {
           retInit();
         }
-      }
+      };
       initialize();
     }]);
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -6,7 +6,7 @@
 			<p>
 				<md-icon class="md-warn">warning</md-icon>
 			</p>
-			<p>This app is undergoing scheduled maintenance and is temporarily unavailable.</p>
+			<p>This app is undergoing maintenance and is temporarily unavailable.</p>
 		</div>
 	</div>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-card.html
@@ -1,9 +1,19 @@
 <md-card class="widget-frame" id="portlet-id-{{portlet.nodeId}}" aria-label="{{ portlet.title }} widget">
 
+	<!-- MAINTENANCE MODE OVERLAY -->
+	<div class="overlay__maintenance-mode" ng-if="portlet.widgetConfig.maintenanceMode">
+		<div class="maintenance-content">
+			<p>
+				<md-icon class="md-warn">warning</md-icon>
+			</p>
+			<p>This app is undergoing scheduled maintenance and is temporarily unavailable.</p>
+		</div>
+	</div>
+
   <!-- HEADER -->
   <md-card-header class="widget-header">
     <!-- Widget Chrome -->
-    <md-button class="widget-action widget-info md-icon-button" aria-label="Description: {{ portlet.description }}" role="tooltip">
+    <md-button class="widget-action widget-info md-icon-button" aria-label="Description: {{ portlet.description }}" role="tooltip" ng-hide="portlet.widgetConfig.maintenanceMode">
       <md-tooltip md-direction="top" class="widget-action-tooltip">
         {{ portlet.description }}
       </md-tooltip>
@@ -12,7 +22,7 @@
     <md-button class="widget-action widget-remove md-icon-button"
                aria-label="remove {{ portlet.title }} widget from your home screen"
                ng-click="widgetCtrl.removePortlet(portlet.nodeId, portlet.title)"
-               ng-hide="GuestMode || cantRemove">
+               ng-hide="GuestMode || cantRemove || portlet.widgetConfig.maintenanceMode">
       <md-icon>close</md-icon>
     </md-button>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-creator.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-creator.html
@@ -29,8 +29,8 @@
             <md-card-title-text>
               <h1>Smart Widget Configuration</h1>
               <p>Read <a 
-                href='http://uw-madison-doit.github.io/angularjs-portal/latest/#/md/expanded' 
-                target='_blank' rel='noopener noreferrer'>
+                href="http://uw-madison-doit.github.io/angularjs-portal/"
+                target="_blank" rel="noopener noreferrer">
                   the documentation on widgets</a>.
               </p>
             </md-card-title-text>

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-creator.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/partials/widget-creator.html
@@ -29,7 +29,7 @@
             <md-card-title-text>
               <h1>Smart Widget Configuration</h1>
               <p>Read <a 
-                href="http://uw-madison-doit.github.io/angularjs-portal/"
+                href="http://uw-madison-doit.github.io/angularjs-portal/widgets.html"
                 target="_blank" rel="noopener noreferrer">
                   the documentation on widgets</a>.
               </p>

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -243,9 +243,10 @@ If you provide a `widgetConfig` with any widget type with a value for `launchTex
 launch button with the provided value, even for non-widgets.
 
 #### Maintenance mode
-If your widget/application depends on a service that is currently experiencing and outage or planned maintenance, you can
+If your widget/application depends on a service that is currently experiencing an outage or planned maintenance, you can
 add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display
-a message communicating that the app is unavailable and the widget will be disabled (unclickable).
+a message communicating that the app is unavailable and the widget will be disabled (unclickable). To turn maintenance mode off,
+simply set the attributes value to "false" or remove it from your `widgetConfig` altogether.
 
 Example:
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -238,8 +238,14 @@ By doing just this we were able to generate:
 
 ## Other Configuration
 
+#### Launch button text
 If you provide a `widgetConfig` with any widget type with a value for `launchText`, it will replace the text of the 
 launch button with the provided value, even for non-widgets.
+
+#### Maintenance mode
+If your widget/application depends on a service that is currently experiencing and outage or planned maintenance, you can
+add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display
+a message communicating that the app is unavailable and the widget will be disabled (unclickable).
 
 Example:
 
@@ -248,7 +254,8 @@ Example:
     <name>widgetConfig</name>
     <value>
     	<![CDATA[{
-      		'launchText' : 'See all the Weather'
+      		'launchText' : 'See all the Weather',
+      		'maintenanceMode' : true
     	}]]>
     </value>
 </portlet-preference>

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -238,11 +238,11 @@ By doing just this we were able to generate:
 
 ## Other Configuration
 
-#### Launch button text
+### Launch button text
 If you provide a `widgetConfig` with any widget type with a value for `launchText`, it will replace the text of the 
 launch button with the provided value, even for non-widgets.
 
-#### Maintenance mode
+### Maintenance mode
 If your widget/application depends on a service that is currently experiencing an outage or planned maintenance, you can
 add the `maintenanceMode` attribute to your `widgetConfig` with a value of "true." Widgets in maintenance mode will display
 a message communicating that the app is unavailable and the widget will be disabled (unclickable). To turn maintenance mode off,


### PR DESCRIPTION
**In this PR**:
- Added CSS styles for maintenance mode "overlay" (meaning: A thing that goes on top of widgets)
- Added HTML markup for maintenance mode
- Added maintenanceMode attribute to widget creator templates
- Added info about maintenance mode to the widget documentation 
- Added working widget docs link to widget creator page
- Add `.editorconfig` to ensure consistent code style (same as uw-frame)

*Notes: I'm confident it'll work, having tested it with the widget creator, but it should still be tested with a real widgetConfig for a real widget. Also, please ignore the whitespace gore in widgetController. I was desperate to add some missing semi-colons and this project has no code style configuration :/*

### Screenshots
![screen shot 2017-01-26 at 12 47 06 pm](https://cloud.githubusercontent.com/assets/5818702/22345430/af6cd73e-e3c5-11e6-829f-8b8538984815.png)
![screen shot 2017-01-26 at 12 51 58 pm](https://cloud.githubusercontent.com/assets/5818702/22345612/64f6e0cc-e3c6-11e6-9b86-9e143e2e7f84.png)

