### PR TITLE
Remove hard-coded 'badgerisms' from user-facing content

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/home-header.html
@@ -11,7 +11,7 @@
                          app-icon="'fa-home'"
                          app-action-link-url="'apps'"
                          app-action-link-icon="GuestMode ? 'fa-globe' : 'fa-plus-square'"
-                         app-action-link-text="GuestMode ? 'Browse MyUW' : 'Add more to home'"
+                         app-action-link-text="GuestMode ? 'Browse {{portal.theme.title}}' : 'Add more to home'"
                          app-single-option="true"
                          app-option-template="'toggle-modes.html'">
 </app-header-two-way-bind>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-no-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-no-results.html
@@ -1,7 +1,7 @@
 <div class="mp-no-results">
 	<div class="mp-no-results-container">
 		<img class="mp-sad-bucky" src="img/bucky-sad.png">
-		<p class="md-title">No matching MyUW content.</p>
+		<p class="md-title">No matching {{portal.theme.title}} content.</p>
 		<div class="mp-no-results-list">
 			<p>Please try again or consider one of the following options:</p>
 			<ul>
@@ -9,7 +9,7 @@
 					<a href="#" ng-click="selectFilter('az','')">Show matching content beyond the &quot;{{categoryToShow}}&quot; category</a>.
 				</li>
 				<li ng-show="(portlets | filter:searchTermFilter | showCategory:categoryToShow).length > 0">
-					<a href="#" ng-click="toggleShowAll()">Show matching MyUW content even if it cannot be launched</a>.
+					<a href="#" ng-click="toggleShowAll()">Show matching {{portal.theme.title}} content even if it cannot be launched</a>.
 				</li>
 				<li ng-if="directorySearchUrl">
 					<a ng-href="{{directorySearchUrl}}{{searchText}}" target="_blank" rel="noopener noreferrer">Search the  directory of people and offices</a>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -1,12 +1,12 @@
 <h4 class="md-subhead">
   <div class="subhead-border" ng-style="{background: primaryColorRgb}"></div>
-  MyUW
+  {{portal.theme.title}}
 </h4>
 <div layout="row" layout-align="center center">
   <loading-gif data-object='myuwResults'></loading-gif>
 </div>
 <div ng-show="myuwResults.length != 0 && myuwFilteredResults.length == 0" class='no-result'>
-  No MyUW results. <a href="apps">Try browsing instead?</a>
+  No {{portal.theme.title}} results. <a href="apps">Try browsing instead?</a>
 </div>
 <div class="result" ng-repeat="portlet in myuwFilteredResults = (myuwResults | filter:searchTermFilter | showApplicable:showAll | orderBy:sortParameter | limitTo:searchResultLimit)">
   <h4><a ng-href="{{getLaunchURL(portlet)}}" target="{{::portlet.target}}">{{ portlet.title }}</a> <small ng-if='GuestMode && !portlet.canAdd'>(login to use)</small></h4>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/search-results.html
@@ -37,7 +37,7 @@
               Get help from the <a ng-href="{{helpdeskUrl}}" target="_blank" rel="noopener noreferrer">Help Desk</a>
             </p>
             <p ng-if="feedbackUrl">
-              <a ng-href="{{feedbackUrl}}" target="_blank" rel="noopener noreferrer">Give feedback</a> on MyUW search
+              <a ng-href="{{feedbackUrl}}" target="_blank" rel="noopener noreferrer">Give feedback</a> on {{portal.theme.title}} search
             </p>
           </div>
         </md-content>
@@ -47,7 +47,7 @@
     <!-- MyUW RESULTS ONLY -->
     <md-tab ng-if="googleSearchEnabled || directoryEnabled">
       <md-tab-label>
-        MyUW&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
+        {{portal.theme.title}}&nbsp;&nbsp;<span class="badge">{{ myuwFilteredResults.length }}</span>
       </md-tab-label>
       <md-tab-body>
         <md-content>

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-This documentation describes [`angularjs-portal`](https://github.com/UW-Madison-DoIT/angularjs-portal), the free and open source alternative [uPortal][] front end used in e.g. [MyUW](https://it.wisc.edu/services/myuw/). `angularjs-portal` is based on [`uw-frame`](https://github.com/UW-Madison-DoIT/uw-frame) (which has [its own documentation](http://uw-madison-doit.github.io/uw-frame/)).
+This documentation describes [AngularJS-Portal](https://github.com/UW-Madison-DoIT/angularjs-portal), the free and open source alternative front end for [uPortal][], used in e.g. [MyUW](https://it.wisc.edu/services/myuw/). AngularJS-Portal is based on [uw-frame](https://github.com/UW-Madison-DoIT/uw-frame) (which has [its own documentation](http://uw-madison-doit.github.io/uw-frame/)).
 
 ## Features
 
@@ -7,12 +7,12 @@ This documentation describes [`angularjs-portal`](https://github.com/UW-Madison-
 #### Persistent layout of widgets
 The home page presents widgets in a remembered order. Logged in users can add to, remove from, and re-order this list.
 
-Under the hood, the home page layout is implemented as a personalized layout fragment in [uPortal][]'s `DLM`, so AngularJS-portal delivers (and updates) a
+Under the hood, the home page layout is implemented as a personalized layout fragment in [uPortal][]'s `DLM`, so AngularJS-Portal delivers (and updates) a
 default set and ordering of home page content that is filtered to the viewing user's permissions.
 
 #### Toggleable view modes
 
-Widgets show on the home page in either a minimalist "compact mode" or a rich "expanded mode". AngularJS-portal takes a guess at the best default mode for a given browser and users can toggle the mode, with their preference stored in browser local storage.
+Widgets show on the home page in either a minimalist "compact mode" or a rich "expanded mode". AngularJS-Portal takes a guess at the best default mode for a given browser and users can toggle the mode, with their preference stored in browser local storage.
 
 + [Expanded mode](expanded.md)
 + [Compact mode](compact.md)

--- a/docs/_includes/footer-aside.html
+++ b/docs/_includes/footer-aside.html
@@ -2,12 +2,12 @@
   <h5>Google groups</h5>
   <ul>
     <li><a href="https://groups.google.com/forum/#!forum/myuw-developers">MyUW Developers</a>:
-      <small>All things AngularJS-portal in the MyUW context</small>
+      <small>All things AngularJS-Portal in the MyUW context</small>
     </li>
     <li><a href="https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev">uportal-dev@</a>:
-      <small> AngularJS-portal development in the uPortal context</small></li>
+      <small> AngularJS-Portal development in the uPortal context</small></li>
     <li><a href="https://groups.google.com/a/apereo.org/forum/#!forum/uportal-user">uportal-user@</a>:
-      <small> AngularJS-portal adoption in the uPortal context</small></li>
+      <small> AngularJS-Portal adoption in the uPortal context</small></li>
   </ul>
 
   <h5>Learn more</h5>

--- a/docs/app-directory.md
+++ b/docs/app-directory.md
@@ -2,7 +2,7 @@
 
 ## App directory philosophy
 
-`AngularJS-portal` uses the app directory to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
+`AngularJS-Portal` uses the app directory to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
 
 This reduces noise and opportunity cost of adding content to the portal. Content that is only interesting to a smaller population can hang out in the directory, ready to be referenced, found, and used, but not bothering anyone who does not go looking for it.
 
@@ -148,7 +148,7 @@ Optionally an application directory entry can specify an "alternative" URL. This
 </parameter>
 ```
 
-Where the external URL is specified, AngularJS-portal will prefer "Launch"ing to the external URL rather than launching to the internal portlet.
+Where the external URL is specified, AngularJS-Portal will prefer "Launch"ing to the external URL rather than launching to the internal portlet.
 
 ### Permissions
 
@@ -227,7 +227,7 @@ Users with `MANAGE` permission over an app directory entry can exercise the JSON
 
 ## App directory implementation details
 
-Currently, the AngularJS-portal app directory *is* the uPortal portlet registry.
+Currently, the AngularJS-Portal app directory *is* the uPortal portlet registry.
 
 This means that the app directory can be viewed and edited via the Portlet Manager tooling in uPortal and that app directory entries are uPortal "entities" bulk loaded via entity import.
 

--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -89,9 +89,8 @@ aside {
     padding-bottom: 4px;
   }
   ul {
-    list-style: none;
-    padding-left: 0;
-    -webkit-padding-start: 0;
+    padding-left: 20px;
+    -webkit-padding-start: 20px;
   }
 }
 

--- a/docs/search.md
+++ b/docs/search.md
@@ -2,7 +2,7 @@
 
 ## Search philosophy
 
-`AngularJS-portal` uses search to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
+AngularJS-Portal uses search to scale beyond the limitations of stuffing content into boxes on tabs in an old-school portal. Instead, users are encouraged to search over a directory potentially containing more stuff than would have fit on tabs.
 
 ## What you can Search
 
@@ -75,7 +75,7 @@ Search is configured in `web-config.js`:
 ...
 ```
 
-You declare one or more search configurations.  A search configuration has a `group`. The first search configuration matching a user's groups will apply to that user's `AngularJS-portal` experience.
+You declare one or more search configurations.  A search configuration has a `group`. The first search configuration matching a user's groups will apply to that user's AngularJS-Portal experience.
 
 Within each search configuration, you can set:
 

--- a/docs/widgets.md
+++ b/docs/widgets.md
@@ -16,7 +16,7 @@ Widgets can:
 ### Advantages of widget types over custom widgets
 
 + It is less development effort to compose configuration and data for an existing widget type than to develop a novel widget.
-+ Widget types are maintained as part of the angularjs-portal product, so usages of these types will less often need developer attention to keep them looking up-to-date and working well.
++ Widget types are maintained as part of the AngularJS-Portal product, so usages of these types will less often need developer attention to keep them looking up-to-date and working well.
 + Widget types separate configuration (widgetConfig) and data (backing JSON web service) from the implementation of the markup for the widget (widget type).
 + Widget types are more amenable to automated unit testing than are ad-hoc custom widgets.
 


### PR DESCRIPTION
**In this PR**:
- Replaced hard-coded references to MyUW with `{{portal.theme.title}}`
- Adjusted docs to reflect changes
- Adjusted docs to make sure all references to angularjs-portal are formatted the same
- Adjusted docs styling to match uw-frame (sidebar list)