### PR TITLE
Issue #582: Use 'eslint --fix' to apply linter recommendations

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/login-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/login-config.js
@@ -1,7 +1,7 @@
 'use strict';
 define([], function() {
   return {
-    "loginURL" : null //null for localhost so we don't break things
-    //"loginURL" : "/portal/Login?silent=true&profile=bucky" //overlay will have something like this
-  }
+    'loginURL': null, // null for localhost so we don't break things
+    // "loginURL" : "/portal/Login?silent=true&profile=bucky" //overlay will have something like this
+  };
 });

--- a/angularjs-portal-home/src/main/webapp/js/master-override.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-override.js
@@ -1,83 +1,81 @@
 define(['angular'], function(angular) {
+  /* Keep in sync with docs/markdown/configuration.md*/
 
-  /*Keep in sync with docs/markdown/configuration.md*/
-
-    var config = angular.module('override', []);
+    let config = angular.module('override', []);
     config
-        //see configuration.md for howto
+        // see configuration.md for howto
         .constant('OVERRIDE', {
-          'APP_FLAGS' : {
+          'APP_FLAGS': {
             'enableToggle': true,
-            'defaultView' : 'expanded',
-            'compact' : true,
-            'expanded' : true,
-            'isWeb' : true,
-            'defaultTheme' : 0,
-            'debug' : true,
-            'showUserSettingsPage' : true
+            'defaultView': 'expanded',
+            'compact': true,
+            'expanded': true,
+            'isWeb': true,
+            'defaultTheme': 0,
+            'debug': true,
+            'showUserSettingsPage': true,
           },
-          'FEATURES' : {
-            enabled: true
+          'FEATURES': {
+            enabled: true,
           },
-          'SERVICE_LOC' : {
-            'aboutURL' : '/uPortal/api/session.json',
-            'sessionInfo' : '/uPortal/api/session.json',
-            'sidebarInfo' : '/web/staticFeeds/sidebar.json',
+          'SERVICE_LOC': {
+            'aboutURL': '/uPortal/api/session.json',
+            'sessionInfo': '/uPortal/api/session.json',
+            'sidebarInfo': '/web/staticFeeds/sidebar.json',
             'newstuffInfo': '/web/staticFeeds/new-stuff.json',
-            'context'     : '/uPortal/',
-            'base'        : '/uPortal/api/',
-            'layout'      : 'layoutDoc?tab=Welcome',
-            'layoutTab' : 'Welcome',
-            'marketplace' : {
-                'base' : 'marketplace/',
-                'entry' : 'entry/',
-                'entries' : 'entries.json'
+            'context': '/uPortal/',
+            'base': '/uPortal/api/',
+            'layout': 'layoutDoc?tab=Welcome',
+            'layoutTab': 'Welcome',
+            'marketplace': {
+                'base': 'marketplace/',
+                'entry': 'entry/',
+                'entries': 'entries.json',
             },
-            'notificationsURL' : '/web/staticFeeds/notifications.json',
-            'groupURL' : '/uPortal/api/groups',
-            'kvURL' : null,
-            'loginSilentURL' : '/uPortal/Login?silent=true'
+            'notificationsURL': '/web/staticFeeds/notifications.json',
+            'groupURL': '/uPortal/api/groups',
+            'kvURL': null,
+            'loginSilentURL': '/uPortal/Login?silent=true',
           },
-          'NAMES' : {
-              'title' : 'uPortal',
-              'ariaLabelTitle' : 'U Portal',
-              'crest' : 'img/uPortal_400.png',
-              'crestalt' : 'U Portal Crest',
-              'sublogo' : '',
-              'guestUserName' : 'guest'
+          'NAMES': {
+              'title': 'uPortal',
+              'ariaLabelTitle': 'U Portal',
+              'crest': 'img/uPortal_400.png',
+              'crestalt': 'U Portal Crest',
+              'sublogo': '',
+              'guestUserName': 'guest',
           },
-          'NOTIFICATION' : {
-              'enabled' : true,
-              'groupFiltering' : true
+          'NOTIFICATION': {
+              'enabled': true,
+              'groupFiltering': true,
           },
-          'MISC_URLS' : {
-            'feedbackURL' : '/uPortal/p/feedback',
-            'whatsNewURL' : '/web/features'
+          'MISC_URLS': {
+            'feedbackURL': '/uPortal/p/feedback',
+            'whatsNewURL': '/web/features',
           },
-          'APP_BETA_FEATURES' : [
+          'APP_BETA_FEATURES': [
             {
-              "id" : "webPortletRender",
-              "title" : "/web portlet rendering",
-              "description" : "Renders portlets via /web's exclusive page, but not as launched from expanded widgets."
-            },
-            {
-              "id" : "showKeywordsInMarketplace",
-              "title" : "Show Keywords in app directory",
-              "description" : "Enable/Disable keywords showing up in app directory entry details"
+              'id' : 'webPortletRender',
+              'title' : '/web portlet rendering',
+              'description' : 'Renders portlets via /web\'s exclusive page, but not as launched from expanded widgets.'
             },
             {
-              "id" : "exampleWidgets",
-              "title" : "Example Widgets",
-              "description" : "Show the My Courses, Email, and Calendar example widgets"
+              'id' : 'showKeywordsInMarketplace',
+              'title' : 'Show Keywords in app directory',
+              'description' : 'Enable/Disable keywords showing up in app directory entry details'
             },
             {
-              "id" : "showFilterOption",
-              "title" : "Show Filter Option on Home",
-              "description" : "Enables a filter on home to filter ones content down to what want"
-            }
-          ]
+              'id' : 'exampleWidgets',
+              'title' : 'Example Widgets',
+              'description' : 'Show the My Courses, Email, and Calendar example widgets'
+            },
+            {
+              'id' : 'showFilterOption',
+              'title' : 'Show Filter Option on Home',
+              'description' : 'Enables a filter on home to filter ones content down to what want'
+            },
+          ],
         });
 
     return config;
-
 });

--- a/angularjs-portal-home/src/main/webapp/js/override.js
+++ b/angularjs-portal-home/src/main/webapp/js/override.js
@@ -1,88 +1,86 @@
 define(['angular'], function(angular) {
+  /* Keep in sync with docs/markdown/configuration.md*/
 
-  /*Keep in sync with docs/markdown/configuration.md*/
-
-    var config = angular.module('override', []);
+    let config = angular.module('override', []);
     config
-        //see configuration.md for howto
+        // see configuration.md for howto
         .constant('OVERRIDE', {
-          'APP_FLAGS' : {
+          'APP_FLAGS': {
             'enableToggle': true,
-            'defaultView' : 'expanded',
-            'compact' : true,
-            'expanded' : true,
-            'isWeb' : true,
-            'defaultTheme' : 'group',
-            'debug' : true,
-            'showUserSettingsPage' : true
+            'defaultView': 'expanded',
+            'compact': true,
+            'expanded': true,
+            'isWeb': true,
+            'defaultTheme': 'group',
+            'debug': true,
+            'showUserSettingsPage': true,
           },
-          'FEATURES' : {
-            enabled: true
+          'FEATURES': {
+            enabled: true,
           },
-          'SERVICE_LOC' : {
-            'aboutURL' : '/portal/api/session.json',
-            'sessionInfo' : '/portal/api/session.json',
-            'sidebarInfo' : '/web/staticFeeds/sidebar.json',
+          'SERVICE_LOC': {
+            'aboutURL': '/portal/api/session.json',
+            'sessionInfo': '/portal/api/session.json',
+            'sidebarInfo': '/web/staticFeeds/sidebar.json',
             'newstuffInfo': '/web/staticFeeds/new-stuff.json',
-            'context'     : '/portal/',
-            'base'        : '/portal/api/',
-            'layout'      : 'layoutDoc?tab=UW Bucky Home',
-            'layoutTab' : 'UW Bucky Home',
-            'marketplace' : {
-                'base' : 'marketplace/',
-                'entry' : 'entry/',
-                'entries' : 'entries.json'
+            'context': '/portal/',
+            'base': '/portal/api/',
+            'layout': 'layoutDoc?tab=UW Bucky Home',
+            'layoutTab': 'UW Bucky Home',
+            'marketplace': {
+                'base': 'marketplace/',
+                'entry': 'entry/',
+                'entries': 'entries.json',
             },
-            'notificationsURL' : '/web/staticFeeds/notifications.json',
-            'groupURL' : '/portal/api/groups',
-            'kvURL' : '/storage',
-            'loginSilentURL' : '/portal/Login?silent=true&profile=bucky'
+            'notificationsURL': '/web/staticFeeds/notifications.json',
+            'groupURL': '/portal/api/groups',
+            'kvURL': '/storage',
+            'loginSilentURL': '/portal/Login?silent=true&profile=bucky',
           },
-          'NAMES' : {
-              'title' : 'MyUW',
-              'ariaLabelTitle' : 'My U W',
-              'crest' : 'img/uwcrest_web_sm.png',
-              'crestalt' : 'UW Crest',
-              'sublogo' : '',
-              'guestUserName' : 'guest'
+          'NAMES': {
+              'title': 'MyUW',
+              'ariaLabelTitle': 'My U W',
+              'crest': 'img/uwcrest_web_sm.png',
+              'crestalt': 'UW Crest',
+              'sublogo': '',
+              'guestUserName': 'guest',
           },
-          'NOTIFICATION' : {
-              'enabled' : true,
-              'groupFiltering' : true
+          'NOTIFICATION': {
+              'enabled': true,
+              'groupFiltering': true,
           },
-          'MISC_URLS' : {
-            'feedbackURL' : '/portal/p/feedback',
-            'whatsNewURL' : 'https://kb.wisc.edu/myuw/page.php?id=48181'
+          'MISC_URLS': {
+            'feedbackURL': '/portal/p/feedback',
+            'whatsNewURL': 'https://kb.wisc.edu/myuw/page.php?id=48181',
           },
-          'APP_BETA_FEATURES' : [
+          'APP_BETA_FEATURES': [
             {
-              "id" : "webPortletRender",
-              "title" : "/web portlet rendering",
-              "description" : "Renders portlets via /web's exclusive page, but not as launched from expanded widgets."
+              'id' : 'webPortletRender',
+              'title' : '/web portlet rendering',
+              'description' : 'Renders portlets via /web\'s exclusive page, but not as launched from expanded widgets.'
             },
             {
-              "id" : "showKeywordsInMarketplace",
-              "title" : "Show Keywords in app directory",
-              "description" : "Enable/Disable keywords showing up in app directory details"
+              'id' : 'showKeywordsInMarketplace',
+              'title' : 'Show Keywords in app directory',
+              'description' : 'Enable/Disable keywords showing up in app directory details'
             },
             {
-              "id" : "linkRatingsApi",
-              "title" : "Link ratings API",
-              "description" : "Links the ratings JSON API from the ratings count in the details page for each app. Actual access to this JSON API depends upon MANAGE permissions; this setting just includes the hyperlink in the UI for convenience."
+              'id' : 'linkRatingsApi',
+              'title' : 'Link ratings API',
+              'description' : 'Links the ratings JSON API from the ratings count in the details page for each app. Actual access to this JSON API depends upon MANAGE permissions; this setting just includes the hyperlink in the UI for convenience.'
             },
             {
-              "id" : "exampleWidgets",
-              "title" : "Example Widgets",
-              "description" : "Show the My Courses, Email, and Calendar example widgets"
+              'id' : 'exampleWidgets',
+              'title' : 'Example Widgets',
+              'description' : 'Show the My Courses, Email, and Calendar example widgets'
             },
             {
-              "id" : "showFilterOption",
-              "title" : "Show Filter Option on Home",
-              "description" : "Enables a filter on home to filter ones content down to what want"
-            }
-          ]
+              'id' : 'showFilterOption',
+              'title' : 'Show Filter Option on Home',
+              'description' : 'Enables a filter on home to filter ones content down to what want'
+            },
+          ],
         });
 
     return config;
-
 });

--- a/angularjs-portal-home/src/main/webapp/js/web-config.js
+++ b/angularjs-portal-home/src/main/webapp/js/web-config.js
@@ -1,33 +1,32 @@
 define(['angular'], function(angular) {
-
-    var config = angular.module('web-config', []);
+    let config = angular.module('web-config', []);
     config.value('SEARCH_CONFIG', [
       {
-        "group" : "UW-Madison",
-        "directorySearchURL" : "/web/api/proxy/wiscdirectory",
-        "googleSearchURL" : "/web/api/proxy/wiscedusearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&sig=b16e3ffbc96e4526fdc0cc8394bf713a&cx=001601028090761970182:uu2tbvfp4za&alt=json",
-        "webSearchURL" : "http://www.wisc.edu/search/?q=",
-        "domainResultsLabel" : "Wisc.edu",
-        'kbSearchURL' : 'https://kb.wisc.edu/search.php?q=',
-        'eventsSearchURL' : 'https://today.wisc.edu/events/search?term=',
-        'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/'
+        'group' : 'UW-Madison',
+        'directorySearchURL' : '/web/api/proxy/wiscdirectory',
+        'googleSearchURL' : '/web/api/proxy/wiscedusearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&sig=b16e3ffbc96e4526fdc0cc8394bf713a&cx=001601028090761970182:uu2tbvfp4za&alt=json',
+        'webSearchURL' : 'http://www.wisc.edu/search/?q=',
+        'domainResultsLabel' : 'Wisc.edu',
+        'kbSearchURL': 'https://kb.wisc.edu/search.php?q=',
+        'eventsSearchURL': 'https://today.wisc.edu/events/search?term=',
+        'helpdeskURL': 'https://kb.wisc.edu/helpdesk/',
       },
       {
-        "group" : "UW System-River Falls",
-        "directorySearchURL" : "/web/api/proxy/uwrfdirectory",
-        "googleSearchURL" : "/web/api/proxy/uwrfsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&hl=en&prettyPrint=false&source=gcsc&gss=.com&sig=432dd570d1a386253361f581254f9ca1&cx=004071655910512460416:8kmve-tofw8&googlehost=www.google.com&nocache=1456777578251&",
-        "webSearchURL" : "https://www.uwrf.edu/AboutUs/SearchResults.cfm?q=",
-        "domainResultsLabel" : "UWRF.edu",
-        'eventsSearchURL' : "https://events.uwrf.edu?q=",
-        'helpdeskURL' : "https://technology.uwrf.edu/TDClient/Home/"
+        'group' : 'UW System-River Falls',
+        'directorySearchURL' : '/web/api/proxy/uwrfdirectory',
+        'googleSearchURL' : '/web/api/proxy/uwrfsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&hl=en&prettyPrint=false&source=gcsc&gss=.com&sig=432dd570d1a386253361f581254f9ca1&cx=004071655910512460416:8kmve-tofw8&googlehost=www.google.com&nocache=1456777578251&',
+        'webSearchURL' : 'https://www.uwrf.edu/AboutUs/SearchResults.cfm?q=',
+        'domainResultsLabel' : 'UWRF.edu',
+        'eventsSearchURL': 'https://events.uwrf.edu?q=',
+        'helpdeskURL': 'https://technology.uwrf.edu/TDClient/Home/'
       },
       {
-        "group" : "UW System-Platteville",
-        'kbSearchURL' : 'https://kb.uwplatt.edu/search.php?q=',
-        'helpdeskURL' : 'https://kb.wisc.edu/helpdesk/',
-        "googleSearchURL" : "/web/api/proxy/uwplattsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&sig=b16e3ffbc96e4526fdc0cc8394bf713a&cx=013148818429580281285:suupwg3jgw4&alt=json",
-        "domainResultsLabel" : "uwplatt.edu"
-      }
+        'group' : 'UW System-Platteville',
+        'kbSearchURL': 'https://kb.uwplatt.edu/search.php?q=',
+        'helpdeskURL': 'https://kb.wisc.edu/helpdesk/',
+        'googleSearchURL' : '/web/api/proxy/uwplattsearch?key=AIzaSyCVAXiUzRYsML1Pv6RwSG1gunmMikTzQqY&rsz=10&num=10&sig=b16e3ffbc96e4526fdc0cc8394bf713a&cx=013148818429580281285:suupwg3jgw4&alt=json',
+        'domainResultsLabel' : 'uwplatt.edu'
+      },
     ]);
     return config;
 });

--- a/angularjs-portal-home/src/main/webapp/main.js
+++ b/angularjs-portal-home/src/main/webapp/main.js
@@ -1,50 +1,49 @@
 'use strict';
 require(['./config', './js/login-config'], function(config, loginConfig) {
-
     require.config(config);
 
     require(['angular', 'jquery', 'my-app'], function(angular, $) {
-      //Idea taken from
-      //https://blog.mariusschulz.com/2014/10/22/asynchronously-bootstrapping-angularjs-applications-with-server-side-data
+      // Idea taken from
+      // https://blog.mariusschulz.com/2014/10/22/asynchronously-bootstrapping-angularjs-applications-with-server-side-data
       doLogin().then(bootstrapApplication)
-       .catch(function(){
+       .catch(function() {
          $('#loading-splash').html('<b style="padding: 10px;">An error has occured during loading, please try refreshing the page. If the issue persists please contact the helpdesk.</b>');
-         console.error("Issue logging in.");
+         console.error('Issue logging in.');
        });
 
-      //Bootstrap the application like normal now
-      function bootstrapApplication(){
+      // Bootstrap the application like normal now
+      function bootstrapApplication() {
         angular.bootstrap(document, ['my-app']);
       }
 
-      //Checks if the last login is still valid (4 hour timeout)
+      // Checks if the last login is still valid (4 hour timeout)
       function lastLoginValid($sessionStorage) {
-        var timeLapseBetweenLogins = 14400000;
+        let timeLapseBetweenLogins = 14400000;
         if($sessionStorage.portal && $sessionStorage.portal.lastAccessed) {
-          var now = (new Date()).getTime();
-          if(now - $sessionStorage.portal.lastAccessed <= timeLapseBetweenLogins) {//4 hours
+          let now = (new Date()).getTime();
+          if(now - $sessionStorage.portal.lastAccessed <= timeLapseBetweenLogins) {// 4 hours
             return true;
           }
         }
         return false;
-      };
+      }
 
       //Do the login
       function doLogin() {
-        //init stuff
-        var initInjector = angular.injector(["ng", "ngStorage"]);
-        var $sessionStorage = initInjector.get("$sessionStorage");
-        var $rootScope = initInjector.get('$rootScope');
+        // init stuff
+        let initInjector = angular.injector(['ng', 'ngStorage']);
+        let $sessionStorage = initInjector.get('$sessionStorage');
+        let $rootScope = initInjector.get('$rootScope');
 
-        //login stuff
+        // login stuff
         if(loginConfig.loginURL && !lastLoginValid($sessionStorage)) {
-          //assume not valid, go get a username and bootstrap the user
-          var $http = initInjector.get("$http");
-          return $http.get(loginConfig.loginURL).then(function(response){
-            if("success" === response.data.status
+          // assume not valid, go get a username and bootstrap the user
+          let $http = initInjector.get('$http');
+          return $http.get(loginConfig.loginURL).then(function(response) {
+            if('success' === response.data.status
             || response.data.username === 'guest') {
-              //store some meta data for caching reason
-              if(!$sessionStorage.portal){
+              // store some meta data for caching reason
+              if(!$sessionStorage.portal) {
                 $sessionStorage.portal = {};
               }
               $sessionStorage.portal.lastAccessed = (new Date).getTime();
@@ -52,19 +51,18 @@ require(['./config', './js/login-config'], function(config, loginConfig) {
               if (response.data.username === 'guest') {
                 $rootScope.GuestMode = true;
               }
-              //for some really weird reason the $sessionStorage here isn't being
-              //persisted to real session storage, so we have to do it manually.
+              // for some really weird reason the $sessionStorage here isn't being
+              // persisted to real session storage, so we have to do it manually.
               $sessionStorage.$apply();
             }
           });
         } else {
-          //the cache is still valid with a valid session, carry on
-          var $q = initInjector.get('$q');
+          // the cache is still valid with a valid session, carry on
+          let $q = initInjector.get('$q');
           return $q.resolve(loginConfig.loginURL
-            ? "Login cache still valid from previous login"
-            : "Silent login not configured.");
+            ? 'Login cache still valid from previous login'
+            : 'Silent login not configured.');
         }
       }
     });
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/controllers.js
@@ -1,8 +1,7 @@
 'use strict';
 
 define(['angular', 'jquery'], function(angular, $) {
-
-    var app = angular.module('my-app.layout.controllers', []);
+    let app = angular.module('my-app.layout.controllers', []);
 
     app.controller('DefaultViewController', [
       '$scope',
@@ -11,11 +10,11 @@ define(['angular', 'jquery'], function(angular, $) {
       '$localStorage',
       '$sessionStorage',
       'APP_FLAGS',
-      function($scope, $location, $mdMedia, $localStorage, $sessionStorage, APP_FLAGS){
+      function($scope, $location, $mdMedia, $localStorage, $sessionStorage, APP_FLAGS) {
         $scope.loading = [];
         if(!APP_FLAGS[$localStorage.layoutMode]) {
-          //layout mode set weird, reset to default
-          var defaultView = ($mdMedia('xs') && APP_FLAGS.compact) ? 'compact' : APP_FLAGS.defaultView;
+          // layout mode set weird, reset to default
+          let defaultView = ($mdMedia('xs') && APP_FLAGS.compact) ? 'compact' : APP_FLAGS.defaultView;
           $localStorage.layoutMode = defaultView;
         }
         $location.path('/' + $localStorage.layoutMode);
@@ -41,11 +40,11 @@ define(['angular', 'jquery'], function(angular, $) {
             this.portletType = function portletType(portlet) {
                 if (portlet.staticContent != null
                     && portlet.altMaxUrl == false) {
-                    return "SIMPLE";
-                } else if(portlet.altMaxUrl == false && (portlet.renderOnWeb || $localStorage.webPortletRender)){
-                    return "EXCLUSIVE";
+                    return 'SIMPLE';
+                } else if(portlet.altMaxUrl == false && (portlet.renderOnWeb || $localStorage.webPortletRender)) {
+                    return 'EXCLUSIVE';
                 } else {
-                    return "NORMAL";
+                    return 'NORMAL';
                 }
             };
 
@@ -58,49 +57,48 @@ define(['angular', 'jquery'], function(angular, $) {
                 $location.path(url);
             };
             this.removePortlet = function removePortletFunction(nodeId, title) {
-                layoutService.removeFromHome(nodeId, title).success(function(){
-                    $scope.$apply(function(request, text){
-                        var result = $.grep($scope.layout, function(e) { return e.nodeId === nodeId});
-                        var index = $.inArray(result[0], $scope.layout);
-                        //remove
-                        $scope.layout.splice(index,1);
+                layoutService.removeFromHome(nodeId, title).success(function() {
+                    $scope.$apply(function(request, text) {
+                        let result = $.grep($scope.layout, function(e) {
+ return e.nodeId === nodeId;});
+                        let index = $.inArray(result[0], $scope.layout);
+                        // remove
+                        $scope.layout.splice(index, 1);
                         if($sessionStorage.marketplace != null) {
-                            var marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) { return e.fname === result[0].fname});
+                            let marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) {
+ return e.fname === result[0].fname;});
                             if(marketplaceEntries.length > 0) {
                                 marketplaceEntries[0].hasInLayout = false;
                             }
                         }
                     });
                 }).error(
-                function(request, text, error){
+                function(request, text, error) {
                     alert('Issue deleting ' + title + ' from your list of favorites, try again later.');
                 });
             };
 
             $scope.sortableOptions = {
-                delay:250,
-                cursorAt : {top: 30, left: 30},
+                delay: 250,
+                cursorAt: {top: 30, left: 30},
                 stop: function(e, ui) {
                     if(ui.item.sortable.dropindex != ui.item.sortable.index) {
-
-                        var node = $scope.layout[ui.item.sortable.dropindex];
-                        console.log("Change happened, logging move of " + node.fname + " from " + ui.item.sortable.index + " to " + ui.item.sortable.dropindex);
-                        //index, length, movingNodeId, previousNodeId, nextNodeId
-                        var prevNodeId = ui.item.sortable.dropindex != 0 ? $scope.layout[ui.item.sortable.dropindex - 1].nodeId : "";
-                        var nextNodeId = ui.item.sortable.dropindex != $scope.layout.length - 1 ? $scope.layout[ui.item.sortable.dropindex + 1].nodeId : "";
+                        let node = $scope.layout[ui.item.sortable.dropindex];
+                        console.log('Change happened, logging move of ' + node.fname + ' from ' + ui.item.sortable.index + ' to ' + ui.item.sortable.dropindex);
+                        // index, length, movingNodeId, previousNodeId, nextNodeId
+                        let prevNodeId = ui.item.sortable.dropindex != 0 ? $scope.layout[ui.item.sortable.dropindex - 1].nodeId : '';
+                        let nextNodeId = ui.item.sortable.dropindex != $scope.layout.length - 1 ? $scope.layout[ui.item.sortable.dropindex + 1].nodeId : '';
                         layoutService.moveStuff(ui.item.sortable.dropindex, $scope.layout.length, node.nodeId, prevNodeId, nextNodeId);
-
                     }
-                }
+                },
             };
 
-            this.init = function(){
+            this.init = function() {
               if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
-
                   $rootScope.layout = [];
                   $scope.layoutEmpty = false;
 
-                  layoutService.getLayout().then(function(data){
+                  layoutService.getLayout().then(function(data) {
                       $rootScope.layout = data.layout;
                       if(data.layout && data.layout.length == 0) {
                           $scope.layoutEmpty = true;
@@ -110,7 +108,6 @@ define(['angular', 'jquery'], function(angular, $) {
             };
 
             this.init();
-
         }]);
 
    app.controller('BaseWidgetFunctionsController', [
@@ -131,35 +128,35 @@ define(['angular', 'jquery'], function(angular, $) {
        childController.portletType = function portletType(portlet) {
            if (portlet.widgetType) {
                if('option-link' === portlet.widgetType) {
-                   return "OPTION_LINK";
+                   return 'OPTION_LINK';
                } else if('weather' === portlet.widgetType) {
-                   return "WEATHER";
+                   return 'WEATHER';
                } else if('generic' === portlet.widgetType) {
-                   return "GENERIC";
+                   return 'GENERIC';
                } else if('rss' === portlet.widgetType) {
-                   return "RSS";
+                   return 'RSS';
                } else if('list-of-links' === portlet.widgetType) {
 				   if (portlet.widgetConfig.links.length === 1 && portlet.altMaxUrl && portlet.widgetConfig.links[0].href === portlet.url) {
 					   // If list of links has only one link and if it is the same as the portlet URL, display the
 					   // normal portlet view
-					   return "NORMAL";
+					   return 'NORMAL';
 				   } else {
-					   return "LOL";
+					   return 'LOL';
 				   }
                } else if ('search-with-links' === portlet.widgetType) {
-                   return "SWL";
-               } else if ('lti-launch' === portlet.widgetType){
-                 return "LTI_LAUNCH";
+                   return 'SWL';
+               } else if ('lti-launch' === portlet.widgetType) {
+                 return 'LTI_LAUNCH';
                } else {
-                   return "WIDGET";
+                   return 'WIDGET';
                }
            }else if(portlet.pithyStaticContent != null) {
-               return "PITHY";
+               return 'PITHY';
            } else if (portlet.staticContent != null
                && portlet.altMaxUrl == false) {
-               return "SIMPLE";
+               return 'SIMPLE';
            } else {
-               return "NORMAL";
+               return 'NORMAL';
            }
        };
 
@@ -180,25 +177,28 @@ define(['angular', 'jquery'], function(angular, $) {
            $location.path(url);
        };
        childController.removePortlet = function removePortletFunction(nodeId, title) {
-           layoutService.removeFromHome(nodeId, title).success(function(){
-               $scope.$apply(function(request, text){
-                   var result = $.grep($scope.layout, function(e) { return e.nodeId === nodeId});
-                   var index = $.inArray(result[0], $scope.layout);
-                   //remove
-                   $scope.layout.splice(index,1);
+           layoutService.removeFromHome(nodeId, title).success(function() {
+               $scope.$apply(function(request, text) {
+                   let result = $.grep($scope.layout, function(e) {
+ return e.nodeId === nodeId;});
+                   let index = $.inArray(result[0], $scope.layout);
+                   // remove
+                   $scope.layout.splice(index, 1);
                    if($sessionStorage.marketplace != null) {
-                       var marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) { return e.fname === result[0].fname});
+                       let marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) {
+ return e.fname === result[0].fname
+});
                        if(marketplaceEntries.length > 0) {
                            marketplaceEntries[0].hasInLayout = false;
                        }
                    }
                });
            }).error(
-           function(request, text, error){
+           function(request, text, error) {
                alert('Issue deleting ' + title + ' from your list of favorites, try again later.');
            });
        };
-     }
+     },
    ]);
 
 
@@ -221,13 +221,13 @@ define(['angular', 'jquery'], function(angular, $) {
                  layoutService,
                  miscService,
                  sharedPortletService) {
-        var base = $controller('BaseWidgetFunctionsController', { $scope : $scope, childController : this });
+        let base = $controller('BaseWidgetFunctionsController', {$scope: $scope, childController: this});
 
         function init() {
           if(typeof $rootScope.layout === 'undefined' || $rootScope.layout == null) {
             $rootScope.layout = [];
             $scope.layoutEmpty = false;
-            layoutService.getLayout().then(function(data){
+            layoutService.getLayout().then(function(data) {
               $rootScope.layout = data.layout;
               if(data.layout && data.layout.length == 0) {
                   $scope.layoutEmpty = true;
@@ -237,44 +237,45 @@ define(['angular', 'jquery'], function(angular, $) {
          }
 
           $scope.sortableOptions = {
-              delay:250,
-              cursorAt : {top: 30, left: 30},
+              delay: 250,
+              cursorAt: {top: 30, left: 30},
               stop: function(e, ui) {
                   if(ui.item.sortable.dropindex != ui.item.sortable.index) {
-
-                      var node = $scope.layout[ui.item.sortable.dropindex];
+                      let node = $scope.layout[ui.item.sortable.dropindex];
                       if(console) {
-                        console.log("Change happened, logging move of " + node.fname + " from " + ui.item.sortable.index + " to " + ui.item.sortable.dropindex);
+                        console.log('Change happened, logging move of ' + node.fname + ' from ' + ui.item.sortable.index + ' to ' + ui.item.sortable.dropindex);
                       }
-                      //index, length, movingNodeId, previousNodeId, nextNodeId
-                      var prevNodeId = ui.item.sortable.dropindex != 0 ? $scope.layout[ui.item.sortable.dropindex - 1].nodeId : "";
-                      var nextNodeId = ui.item.sortable.dropindex != $scope.layout.length - 1 ? $scope.layout[ui.item.sortable.dropindex + 1].nodeId : "";
+                      // index, length, movingNodeId, previousNodeId, nextNodeId
+                      let prevNodeId = ui.item.sortable.dropindex != 0 ? $scope.layout[ui.item.sortable.dropindex - 1].nodeId : '';
+                      let nextNodeId = ui.item.sortable.dropindex != $scope.layout.length - 1 ? $scope.layout[ui.item.sortable.dropindex + 1].nodeId : '';
                       layoutService.moveStuff(ui.item.sortable.dropindex, $scope.layout.length, node.nodeId, prevNodeId, nextNodeId);
                   }
-              }
+              },
           };
 
           init();
         }]);
 
-    app.controller('NewStuffController', ['$scope', 'layoutService', function ($scope, layoutService){
+    app.controller('NewStuffController', ['$scope', 'layoutService', function($scope, layoutService) {
         $scope.newStuffArray = [];
-        layoutService.getNewStuffFeed().then(function(result){
+        layoutService.getNewStuffFeed().then(function(result) {
             $scope.newStuffArray = result;
         });
 
         this.show = function(stuff) {
-            var date = new Date(stuff.expireYr, stuff.expireMon, stuff.expireDay);
-            var today = new Date();
+            let date = new Date(stuff.expireYr, stuff.expireMon, stuff.expireDay);
+            let today = new Date();
             return date >= today;
-        }
+        };
     }]);
 
-    app.controller('GoToAppsController', ['$location',function($location){
-      this.redirectToApps = function(){$location.path("/apps");};
+    app.controller('GoToAppsController', ['$location', function($location) {
+      this.redirectToApps = function() {
+$location.path('/apps');
+};
     }]);
 
-    app.controller('ToggleController',[
+    app.controller('ToggleController', [
         '$localStorage',
         '$scope',
         '$location',
@@ -283,8 +284,7 @@ define(['angular', 'jquery'], function(angular, $) {
                               $scope,
                               $location,
                               miscService,
-                              APP_FLAGS){
-
+                              APP_FLAGS) {
         // scope functions
         $scope.switchMode = function(mode) {
           $localStorage.layoutMode = mode;
@@ -295,7 +295,7 @@ define(['angular', 'jquery'], function(angular, $) {
         // event handler for mode toggle
         $scope.toggleMode = function(expandedMode) {
           $scope.expandedMode = expandedMode;
-          var mode = expandedMode ? 'expanded' : 'compact';
+          let mode = expandedMode ? 'expanded' : 'compact';
           $scope.switchMode(mode);
         };
 
@@ -313,7 +313,7 @@ define(['angular', 'jquery'], function(angular, $) {
               if(APP_FLAGS[$localStorage.layoutMode]) {
                 $location.path('/' + $localStorage.layoutMode);
               } else {
-                console.log("Something is weird, resetting to default layout view");
+                console.log('Something is weird, resetting to default layout view');
                 $scope.switchMode(APP_FLAGS.defaultView);
               }
             }
@@ -323,5 +323,4 @@ define(['angular', 'jquery'], function(angular, $) {
     }]);
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/directives.js
@@ -1,60 +1,58 @@
 'use strict';
 
-define(['angular', 'require'], function(angular, require){
+define(['angular', 'require'], function(angular, require) {
+    let app = angular.module('my-app.layout.directives', []);
 
-    var app = angular.module('my-app.layout.directives', []);
-
-    app.directive('portletIcon', function(){
+    app.directive('portletIcon', function() {
         return {
-            restrict : 'E',
-            templateUrl : require.toUrl('./partials/portlet-icon.html')
-        }
+            restrict: 'E',
+            templateUrl: require.toUrl('./partials/portlet-icon.html'),
+        };
     });
 
-    app.directive('defaultCard', function(){
+    app.directive('defaultCard', function() {
         return {
-            restrict : 'E',
-            templateUrl : require.toUrl('./partials/default-card.html')
-        }
+            restrict: 'E',
+            templateUrl: require.toUrl('./partials/default-card.html'),
+        };
     });
 
-    app.directive('pithyContentCard', function(){
+    app.directive('pithyContentCard', function() {
         return {
-            restrict : 'E',
-            templateUrl : require.toUrl('./partials/pithy-content-card.html') //FIXME: this doesn't exist
-        }
+            restrict: 'E',
+            templateUrl: require.toUrl('./partials/pithy-content-card.html'), // FIXME: this doesn't exist
+        };
     });
 
-    app.directive('marketplaceLight', function(){
+    app.directive('marketplaceLight', function() {
         return{
             restrict: 'E',
-            templateUrl: require.toUrl('./partials/marketplace-light.html')
-        }
+            templateUrl: require.toUrl('./partials/marketplace-light.html'),
+        };
     });
 
-    app.directive('homeHeader', function(){
+    app.directive('homeHeader', function() {
         return{
             restrict: 'E',
-            templateUrl: require.toUrl('./partials/home-header.html')
-        }
+            templateUrl: require.toUrl('./partials/home-header.html'),
+        };
     });
 
-    app.directive('exampleWidgets', function(){
+    app.directive('exampleWidgets', function() {
         return{
             restrict: 'E',
-            templateUrl: require.toUrl('./partials/example-widgets.html')
-        }
+            templateUrl: require.toUrl('./partials/example-widgets.html'),
+        };
     });
 
-    app.directive('homeToggle', function(){
+    app.directive('homeToggle', function() {
         return {
             restrict: 'E',
             templateUrl: require.toUrl('./partials/home-toggle.html'),
-            controller: 'ToggleController'
+            controller: 'ToggleController',
         };
     });
 
     return app;
-
 });
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/list/route.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/list/route.js
@@ -1,6 +1,4 @@
-define(['require'], function(require){
-
-    return {templateUrl: require.toUrl('./partials/home-list-view.html')}
-
+define(['require'], function(require) {
+    return {templateUrl: require.toUrl('./partials/home-list-view.html')};
 });
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/route.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/route.js
@@ -1,5 +1,3 @@
-define(['require'], function(require){
-
-    return {templateUrl: require.toUrl('./partials/default-view.html')}
-
+define(['require'], function(require) {
+    return {templateUrl: require.toUrl('./partials/default-view.html')};
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -1,63 +1,62 @@
 'use strict';
 
 define(['angular', 'jquery'], function(angular, $) {
-    var app = angular.module('my-app.layout.services', []);
-    var accessDeniedTemplate="<p><strong>Sorry, you're not authorized to access this.</p>    <br><br>    <div class=\"center\"><i class='fa fa-exclamation-triangle fa-5x'></i></div>    <p>If you're here by accident, head back to your My-UW <a href='/web'>homepage</a>.</p>    <p>For help with authorization, contact the <a href=\"https://kb.wisc.edu/helpdesk\">DoIT Help Desk</a>.</p>";
+    let app = angular.module('my-app.layout.services', []);
+    let accessDeniedTemplate='<p><strong>Sorry, you\'re not authorized to access this.</p>    <br><br>    <div class="center"><i class=\'fa fa-exclamation-triangle fa-5x\'></i></div>    <p>If you\'re here by accident, head back to your My-UW <a href=\'/web\'>homepage</a>.</p>    <p>For help with authorization, contact the <a href="https://kb.wisc.edu/helpdesk">DoIT Help Desk</a>.</p>';
 
-    app.factory('sharedPortletService', function () {
-        var property = {};
+    app.factory('sharedPortletService', function() {
+        let property = {};
 
         return {
-            getProperty: function () {
+            getProperty: function() {
                 return property;
             },
             setProperty: function(value) {
                 property = value;
-            }
+            },
         };
     });
 
-    app.factory('layoutService', ['$sce','$http', 'miscService', 'mainService', '$sessionStorage', '$q', 'SERVICE_LOC', function($sce, $http, miscService, mainService, $sessionStorage, $q, SERVICE_LOC) {
-        var addToHome = function addToHomeFunction(portlet) {
-            var fname = portlet.fname;
-            var tabName = SERVICE_LOC.layoutTab;
+    app.factory('layoutService', ['$sce', '$http', 'miscService', 'mainService', '$sessionStorage', '$q', 'SERVICE_LOC', function($sce, $http, miscService, mainService, $sessionStorage, $q, SERVICE_LOC) {
+        let addToHome = function addToHomeFunction(portlet) {
+            let fname = portlet.fname;
+            let tabName = SERVICE_LOC.layoutTab;
             return $.ajax({
-                url: SERVICE_LOC.base + "layout?action=addPortlet&fname=" + fname + "&tabName=" + tabName,
-                type: "POST",
+                url: SERVICE_LOC.base + 'layout?action=addPortlet&fname=' + fname + '&tabName=' + tabName,
+                type: 'POST',
                 data: null,
-                dataType: "json",
+                dataType: 'json',
                 async: true,
-                success: function (request, text) {
+                success: function(request, text) {
                     console.log('Added ' + portlet.fname + ' successfully');
                     miscService.pushGAEvent('Layout Modification', 'Add', portlet.name);
                     return true;
                 },
-                error: function (request, text, error) {
+                error: function(request, text, error) {
                     console.warn('failed to add app to home.');
                     return false;
-                }
+                },
             });
         };
 
-        var removeFromHome = function removeFromHomeFunction(nodeId, title) {
+        let removeFromHome = function removeFromHomeFunction(nodeId, title) {
             return $.ajax({
-                url: SERVICE_LOC.base + "layout?action=removeElement&elementID=" + nodeId,
-                type: "POST",
+                url: SERVICE_LOC.base + 'layout?action=removeElement&elementID=' + nodeId,
+                type: 'POST',
                 data: null,
-                dataType: "json",
+                dataType: 'json',
                 async: true,
-                success: function (request, text){
-                    console.log("removed " + title + ' successfully.');
+                success: function(request, text) {
+                    console.log('removed ' + title + ' successfully.');
                     miscService.pushGAEvent('Layout Modification', 'Remove', title);
                 },
                 error: function(request, text, error) {
-                }
+                },
             });
-
         };
 
-        var checkLayoutCache = function() {
-            var userPromise = mainService.getUser();
+        let checkLayoutCache = function() {
+            let userPromise = mainService.getUser();
             return userPromise.then(function(user) {
                 if ($sessionStorage.sessionKey === user.sessionKey && $sessionStorage.layout) {
                     return $sessionStorage.layout;
@@ -67,8 +66,8 @@ define(['angular', 'jquery'], function(angular, $) {
             });
         };
 
-        var storeLayoutInCache = function(data) {
-            var userPromise = mainService.getUser();
+        let storeLayoutInCache = function(data) {
+            let userPromise = mainService.getUser();
             userPromise.then(function(user) {
                 $sessionStorage.sessionKey = user.sessionKey;
                 $sessionStorage.layout = data;
@@ -76,9 +75,9 @@ define(['angular', 'jquery'], function(angular, $) {
         };
 
 
-        var getLayout = function() {
+        let getLayout = function() {
             return checkLayoutCache().then(function(data) {
-                var successFn, errorFn, defer;
+                let successFn, errorFn, defer;
 
                 // first, check the local storage...
                 if (data) {
@@ -88,7 +87,7 @@ define(['angular', 'jquery'], function(angular, $) {
                 }
 
                 successFn = function(result) {
-                    var data =  result.data;
+                    let data = result.data;
                     storeLayoutInCache(data);
                     return data;
                 };
@@ -102,12 +101,12 @@ define(['angular', 'jquery'], function(angular, $) {
             });
         };
 
-        var getApp = function(fname) {
+        let getApp = function(fname) {
             return $http.get(SERVICE_LOC.base + 'portlet/' +fname + '.json').then(
                 function(result) {
-                    return  result;
-                } ,
-                function(reason){
+                    return result;
+                },
+                function(reason) {
                     miscService.redirectUser(reason.status, 'getApp call');
                     if(reason.status === 403) {
                       reason.deniedTemplate = $sce.trustAsHtml(accessDeniedTemplate);
@@ -116,46 +115,46 @@ define(['angular', 'jquery'], function(angular, $) {
                 }
             );
         };
-        var moveStuff = function moveStuffFunction(index, length, sourceId, previousNodeId, nextNodeId) {
-            var insertNode = function(sourceId, previousNodeId, nextNodeId){
-                var saveOrderURL = SERVICE_LOC.base + "layout?action=movePortletAjax"
-                    + "&sourceId=" + sourceId
-                    + "&previousNodeId=" + previousNodeId
-                    + "&nextNodeId=" + nextNodeId;
+        let moveStuff = function moveStuffFunction(index, length, sourceId, previousNodeId, nextNodeId) {
+            let insertNode = function(sourceId, previousNodeId, nextNodeId) {
+                let saveOrderURL = SERVICE_LOC.base + 'layout?action=movePortletAjax'
+                    + '&sourceId=' + sourceId
+                    + '&previousNodeId=' + previousNodeId
+                    + '&nextNodeId=' + nextNodeId;
                 console.log(saveOrderURL);
                 $.ajax({
                     url: saveOrderURL,
-                    type: "POST",
+                    type: 'POST',
                     data: null,
-                    dataType: "json",
+                    dataType: 'json',
                     async: true,
-                    success: function (){
-                        console.log("layout move successful.");
+                    success: function() {
+                        console.log('layout move successful.');
                     },
                     error: function(request, text, error) {
-                        console.error("Error persisting move " + saveOrderURL);
-                    }
+                        console.error('Error persisting move ' + saveOrderURL);
+                    },
                 });
             };
 
             insertNode(sourceId, previousNodeId, nextNodeId);
         };
 
-        var getNewStuffFeed = function() {
-            return $http.get(SERVICE_LOC.newstuffInfo, {cache : true}).then(
+        let getNewStuffFeed = function() {
+            return $http.get(SERVICE_LOC.newstuffInfo, {cache: true}).then(
                 function(result) {
-                    return  result.data.stuff;
-                } ,
-                function(reason){
+                    return result.data.stuff;
+                },
+                function(reason) {
                     miscService.redirectUser(reason.status, 'new stuff json feed call');
                 }
             );
         };
 
-        var getWidgetJson = function(portlet) {
-            return $http.get(portlet.widgetURL,{ cache : true}).then(
+        let getWidgetJson = function(portlet) {
+            return $http.get(portlet.widgetURL, {cache: true}).then(
                 function(result) {
-                    var data = result.data;
+                    let data = result.data;
                     if(data) {
                         if(data.result) {
                             portlet.widgetData = data.result;
@@ -163,42 +162,42 @@ define(['angular', 'jquery'], function(angular, $) {
                         if(data.content) {
                             portlet.widgetContent = data.content;
                         }
-                        console.log(portlet.fname + "'s widget data came back with data");
+                        console.log(portlet.fname + '\'s widget data came back with data');
                     }
                     return data;
                 },
                 function(reason) {
-                    miscService.redirectUser(reason.status, 'widget json for ' + portlet.fname + " failed.");
+                    miscService.redirectUser(reason.status, 'widget json for ' + portlet.fname + ' failed.');
                 }
             );
         };
 
 
-        var getExclusiveMarkup = function(portlet) {
-            return $http.get(SERVICE_LOC.context + '/p/' + portlet.fname + '/exclusive/render.uP',{ cache : true}).then(
+        let getExclusiveMarkup = function(portlet) {
+            return $http.get(SERVICE_LOC.context + '/p/' + portlet.fname + '/exclusive/render.uP', {cache: true}).then(
                     function(result) {
-                        var data = result.data;
+                        let data = result.data;
                         if(data) {
                             portlet.exclusiveContent = $sce.trustAsHtml(data);
-                            console.log(portlet.fname + "'s exclusive data came back with data");
+                            console.log(portlet.fname + '\'s exclusive data came back with data');
                         }else{
-                            portlet.exclusiveContent="<div class=\"alert alert-danger\" role=\"alert\">This service is unavailable right now. Please check back later.</div>";
+                            portlet.exclusiveContent='<div class="alert alert-danger" role="alert">This service is unavailable right now. Please check back later.</div>';
                         }
 
                         return data;
                     },
                     function(reason) {
-                        if(reason.status===403){
+                        if(reason.status===403) {
                             portlet.exclusiveContent=$sce.trustAsHtml(accessDeniedTemplate);
                         }else{
-                           miscService.redirectUser(reason.status, 'exclusive markup for ' + portlet.fname + " failed.");
+                           miscService.redirectUser(reason.status, 'exclusive markup for ' + portlet.fname + ' failed.');
                        }
                     }
                 );
-        }
+        };
 
-          var getRSSJsonified = function(feedURL) {
-            // This is a hack. 
+          let getRSSJsonified = function(feedURL) {
+            // This is a hack.
             // It would be maybe healthier to enhance RSS widget to
             // support
             // 1. configure explicitly with URL that generates the JSON
@@ -208,22 +207,21 @@ define(['angular', 'jquery'], function(angular, $) {
             // Whereas this hack repurposes existing configuration for (3)
             // to do (1).
           return $http.get(feedURL);
-        }
+        };
 
         return {
-            getLayout : getLayout,
-            getApp : getApp,
-            moveStuff : moveStuff,
-            getNewStuffFeed : getNewStuffFeed,
-            addToHome : addToHome,
-            removeFromHome : removeFromHome,
-            getWidgetJson : getWidgetJson,
-            getExclusiveMarkup : getExclusiveMarkup,
-            getRSSJsonified : getRSSJsonified
-        }
+            getLayout: getLayout,
+            getApp: getApp,
+            moveStuff: moveStuff,
+            getNewStuffFeed: getNewStuffFeed,
+            addToHome: addToHome,
+            removeFromHome: removeFromHome,
+            getWidgetJson: getWidgetJson,
+            getExclusiveMarkup: getExclusiveMarkup,
+            getRSSJsonified: getRSSJsonified,
+        };
 
     }]);
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/spec/layout_controller_spec.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/spec/layout_controller_spec.js
@@ -1,23 +1,21 @@
 'use strict';
 define(['angular-mocks', 'portal', 'my-app'], function() {
+    describe('LayoutController', function() {
+      let scope;
+      let controller;
+      let $localStorage;
+      let $location;
+      let $sessionStorage;
+      let rootScope;
+      let layoutService;
+      let miscService;
+      let sharedPortletService;
+      let httpBackend;
+      let groupURL;
+      let loginSilentURL;
 
-
-    describe("LayoutController", function() {
-      var scope;
-      var controller;
-      var $localStorage;
-      var $location;
-      var $sessionStorage;
-      var rootScope;
-      var layoutService;
-      var miscService;
-      var sharedPortletService;
-      var httpBackend;
-      var groupURL;
-      var loginSilentURL;
-
-      var q;
-      var deferred;
+      let q;
+      let deferred;
 
       // load the marketplace controller
       beforeEach(function() {
@@ -33,66 +31,63 @@ define(['angular-mocks', 'portal', 'my-app'], function() {
         $sessionStorage = _$sessionStorage_;
         httpBackend = _$httpBackend_;
         layoutService = {
-                'getLayout' : function() {
+                'getLayout': function() {
                      deferred = q.defer();
                      return deferred.promise;
-
-                }
+                },
         };
         miscService = {
-                'pushPageview' : function() {
+                'pushPageview': function() {
                     return;
-                }
+                },
         };
 
         groupURL = _SERVICE_LOC_.groupURL;
         loginSilentURL = _SERVICE_LOC_.loginSilentURL;
 
         sharedPortletService = {};
-        controller = $controller('LayoutController', {'$localStorage' : $localStorage,
+        controller = $controller('LayoutController', {'$localStorage': $localStorage,
                                                       '$scope': scope,
                                                       '$rootScope': rootScope,
-                                                      '$location' : $location,
-                                                      '$sessionStorage' : $sessionStorage,
-                                                      'layoutService' : layoutService,
-                                                      'miscService' : miscService,
-                                                      'sharedPortletService' : sharedPortletService,
-                                                      'APP_FLAGS' : _APP_FLAGS_
+                                                      '$location': $location,
+                                                      '$sessionStorage': $sessionStorage,
+                                                      'layoutService': layoutService,
+                                                      'miscService': miscService,
+                                                      'sharedPortletService': sharedPortletService,
+                                                      'APP_FLAGS': _APP_FLAGS_,
                                                       });
       }));
 
 
-
-      it("should set layout to something not null", function() {
+      it('should set layout to something not null', function() {
           expect(scope.layout).toBeTruthy();
       });
 
-      it("should set layoutEmpty to false initially", function() {
+      it('should set layoutEmpty to false initially', function() {
           expect(scope.layoutEmpty).toBe(false);
       });
 
-      it("should set layoutEmpty to true after return empty layout", function() {
+      it('should set layoutEmpty to true after return empty layout', function() {
           httpBackend.whenGET(groupURL).respond([]);
-          httpBackend.whenGET('/base/my-app/layout/partials/default-view.html').respond("<div></div>");
+          httpBackend.whenGET('/base/my-app/layout/partials/default-view.html').respond('<div></div>');
           controller.init();
-          scope.$apply(function(){
-              deferred.resolve({"layout" : []});
+          scope.$apply(function() {
+              deferred.resolve({'layout' : []});
           });
           expect(scope.layoutEmpty).toBe(true);
       });
 
-      it("should set layoutEmpty to false after return non empty layout", function() {
+      it('should set layoutEmpty to false after return non empty layout', function() {
           httpBackend.whenGET(groupURL).respond([]);
-          httpBackend.whenGET('/base/my-app/layout/partials/default-view.html').respond("<div></div>");
+          httpBackend.whenGET('/base/my-app/layout/partials/default-view.html').respond('<div></div>');
           controller.init();
           if(loginSilentURL) {
-            httpBackend.whenGET(loginSilentURL).respond({"status" : "success", "username" : "admin"});
+            httpBackend.whenGET(loginSilentURL).respond({'status' : 'success', 'username' : 'admin'});
           }
-          scope.$apply(function(){
-              deferred.resolve({"layout" : [{"fake" : true}]});
+          scope.$apply(function() {
+              deferred.resolve({'layout' : [{'fake' : true}]});
           });
           expect(scope.layoutEmpty).toBe(false);
       });
     });
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/spec/toggle_controller_spec.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/spec/toggle_controller_spec.js
@@ -1,101 +1,104 @@
 'use strict';
 define(['angular-mocks', 'portal', 'my-app'], function() {
+    describe('ToggleController', function() {
+      let scope;
+      let controller;
+      let $localStorage;
+      let $location;
+      let miscService;
+      let APP_FLAGS;
+      let currentPath;
+      let gaPageViewHits;
 
-    describe("ToggleController", function() {
-      var scope;
-      var controller;
-      var $localStorage;
-      var $location;
-      var miscService;
-      var APP_FLAGS;
-      var currentPath;
-      var gaPageViewHits;
-      
-    
+
       // load the marketplace controller
       beforeEach(function() {
         module('portal');
         module('my-app');
       });
-      
+
       beforeEach(inject(function(_$rootScope_, $controller, _$localStorage_, _APP_FLAGS_) {
         scope = _$rootScope_.$new();
         $localStorage = _$localStorage_;
         APP_FLAGS = _APP_FLAGS_;
-        currentPath = "/";
+        currentPath = '/';
         gaPageViewHits = 0;
         $location = {
-            'path' : function(newPath) {
+            'path': function(newPath) {
                 if(newPath) {
                     currentPath = newPath;
                 } else {
                     return path;
                 }
             },
-            'url' : function() {
+            'url': function() {
                 return currentPath;
-            }
-        }; 
-        
-        miscService = { 
-                        'pushPageview' : function() { gaPageViewHits++; console.log($location.url()); return;},
-                        'pushGAEvent' : function(){ return;}
+            },
+        };
+
+        miscService = {
+                        'pushPageview': function() {
+ gaPageViewHits++; console.log($location.url()); return;
+},
+                        'pushGAEvent': function() {
+ return;
+},
                       };
-        
-        controller = $controller('ToggleController', {'$localStorage' : $localStorage, 
+
+        controller = $controller('ToggleController', {'$localStorage': $localStorage,
                                                       '$scope': scope,
-                                                      '$location' : $location,
-                                                      'miscService' : miscService,
-                                                      'APP_FLAGS' : APP_FLAGS
+                                                      '$location': $location,
+                                                      'miscService': miscService,
+                                                      'APP_FLAGS': APP_FLAGS,
                                                       });
       }));
-      
-      it("should have toggle set", function() {
+
+      it('should have toggle set', function() {
           expect(scope.toggle).toBeTruthy();
       });
-      
-      it("should switch to default if layoutMode is set to something weird", function() {
-          $localStorage.layoutMode = 'fishy'; //basically not list or widgets
+
+      it('should switch to default if layoutMode is set to something weird', function() {
+          $localStorage.layoutMode = 'fishy'; // basically not list or widgets
           controller.init();
-          
-          //verify it was reset properly
+
+          // verify it was reset properly
           expect($localStorage.layoutMode === APP_FLAGS.defaultView);
       });
-      
-      it("should redirect if you go somewhere you are not supposed to be.", function(){
-          //setup
+
+      it('should redirect if you go somewhere you are not supposed to be.', function() {
+          // setup
           $location.path('/expanded');
           $localStorage.layoutMode = 'compact';
-          //execute init
+          // execute init
           controller.init();
-          
+
           expect($location.url()).toBe('/compact');
       });
-      
-      it("should redirect you if you switch modes and have a new layoutMode", function() {
-        //setup
+
+      it('should redirect you if you switch modes and have a new layoutMode', function() {
+        // setup
         $location.path('/expanded');
         controller.init();
-        
-        //switch!
+
+        // switch!
         scope.switchMode('compact');
         controller.init();
-        
-        //validate
+
+        // validate
         expect($localStorage.layoutMode).toBe('compact');
         expect($location.url()).toBe('/compact');
       });
-      
-      it("should only have page hits if it didn't redirect", function() {
-        //setup
+
+      it('should only have page hits if it didn\'t redirect', function() {
+        // setup
         gaPageViewHits = 0;
         $localStorage.layoutMode = 'expanded';
         $location.path('/compact');
         controller.init();
-        
-        //verify redirect happened
+
+        // verify redirect happened
         expect($location.url()).toBe('/expanded');
-        controller.init();//fire again due to redirect
+        controller.init();// fire again due to redirect
       });
     });
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/controllers.js
@@ -2,7 +2,7 @@
 
 define(['angular', 'jquery', 'require'], function(angular, $, require) {
 
-    var app = angular.module('my-app.layout.static.controllers', []);
+    let app = angular.module('my-app.layout.static.controllers', []);
 
     app.controller('ExclusiveContentController', ['$location',
                                                   '$sessionStorage',
@@ -11,7 +11,7 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                                                   '$scope',
                                                   'layoutService',
                                                   'sharedPortletService',
-                                                  function ($location,
+                                                  function($location,
                                                             $sessionStorage,
                                                             $routeParams,
                                                             $rootScope,
@@ -19,9 +19,9 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                                                             layoutService,
                                                             sharedPortletService) {
         $scope.portlet = sharedPortletService.getProperty() || {};
-        var that = this;
-        that.getPortlet = function (fname, portlets) {
-            for (var p in portlets) {
+        let that = this;
+        that.getPortlet = function(fname, portlets) {
+            for (let p in portlets) {
                 if (portlets[p].fname == fname) {
                   return portlets[p];
                 }
@@ -29,7 +29,7 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
             return {};
         };
 
-        var endFn = function(){
+        let endFn = function() {
           $scope.loaded = true;
           $scope.empty = $scope.portlet.exclusiveContent
                           && $scope.portlet.exclusiveContent.length > 0 ? false : true;
@@ -42,8 +42,8 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                 $scope.portlet = that.getPortlet($routeParams.fname, $rootScope.layout);
             }
             if (typeof $scope.portlet.fname === 'undefined') {
-                layoutService.getApp($routeParams.fname).then(function (result) {
-                    var data = result.data;
+                layoutService.getApp($routeParams.fname).then(function(result) {
+                    let data = result.data;
                     $scope.portlet = data.portlet;
                     if (typeof $scope.portlet === 'undefined' ||
                         typeof $scope.portlet.fname === 'undefined') {
@@ -59,11 +59,11 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                         }
                     } else {
                         $scope.loaded = true;
-                        layoutService.getExclusiveMarkup($scope.portlet).then(endFn,endFn);
+                        layoutService.getExclusiveMarkup($scope.portlet).then(endFn, endFn);
                     }
                 });
             } else {
-                layoutService.getExclusiveMarkup($scope.portlet).then(endFn,endFn);
+                layoutService.getExclusiveMarkup($scope.portlet).then(endFn, endFn);
             }
 
         }
@@ -77,7 +77,7 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         '$scope',
         'layoutService',
         'sharedPortletService',
-        function ($location,
+        function($location,
                   $sessionStorage,
                   $routeParams,
                   $rootScope,
@@ -86,9 +86,9 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                   sharedPortletService) {
             $scope.portlet = sharedPortletService.getProperty() || {};
             $scope.loaded = false;
-            var that = this;
-            that.getPortlet = function (fname, portlets) {
-                for (var p in portlets) {
+            let that = this;
+            that.getPortlet = function(fname, portlets) {
+                for (let p in portlets) {
                     if (portlets[p].fname == fname) {
                         return portlets[p];
                     }
@@ -103,8 +103,8 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                     $scope.loaded = true;
                 }
                 if (typeof $scope.portlet.fname === 'undefined') {
-                    layoutService.getApp($routeParams.fname).then(function (result) {
-                        var data = result.data;
+                    layoutService.getApp($routeParams.fname).then(function(result) {
+                        let data = result.data;
                         $scope.portlet = data.portlet;
                         if (typeof $scope.portlet === 'undefined' ||
                             typeof $scope.portlet.fname === 'undefined') {
@@ -129,46 +129,46 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
               $scope.loaded = true;
             }
 
-            this.addToHome = function (portlet) {
-                var ret = layoutService.addToHome(portlet);
-                ret.success(function (request, text) {
+            this.addToHome = function(portlet) {
+                let ret = layoutService.addToHome(portlet);
+                ret.success(function(request, text) {
                     $('.fname-' + portlet.fname).html('<span style="color : green;"><i class="fa fa-check"></i> Added Successfully</span>').prop('disabled', true);
-                    $scope.$apply(function () {
+                    $scope.$apply(function() {
                         if (typeof $sessionStorage.marketplace !== 'undefined') {
-                            var marketplaceEntries = $.grep($sessionStorage.marketplace, function (e) {
-                                return e.fname === portlet.fname
+                            let marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) {
+                                return e.fname === portlet.fname;
                             });
                             if (marketplaceEntries.length > 0) {
                                 marketplaceEntries[0].hasInLayout = true;
                             }
                         }
 
-                        //reset layout due to modifications
+                        // reset layout due to modifications
                         $rootScope.layout = null;
                         $sessionStorage.layout = null;
 
                     });
                 })
-                    .error(function (request, text, error) {
+                    .error(function(request, text, error) {
                         $('.fname-' + portlet.fname).html('<span style="color : red;">Issue adding to home, please try again later</span>');
                     });
             };
 
-            this.inLayout = function () {
-                var layout = $rootScope.layout;
-                var ret = false;
+            this.inLayout = function() {
+                let layout = $rootScope.layout;
+                let ret = false;
                 if (!layout) {
-                    //get layout
-                    layoutService.getLayout().then(function (data) {
+                    // get layout
+                    layoutService.getLayout().then(function(data) {
                         $rootScope.layout = data.layout;
-                        var portlets = $.grep($rootScope.layout, function (e) {
-                            return e.fname === $routeParams.fname
+                        let portlets = $.grep($rootScope.layout, function(e) {
+                            return e.fname === $routeParams.fname;
                         });
-                        $scope.inFavorites = portlets.length > 0; //change scope variable to trigger apply
+                        $scope.inFavorites = portlets.length > 0; // change scope variable to trigger apply
                     });
                 } else {
-                    var portlets = $.grep($rootScope.layout, function (e) {
-                        return e.fname === $routeParams.fname
+                    let portlets = $.grep($rootScope.layout, function(e) {
+                        return e.fname === $routeParams.fname;
                     });
                     ret = portlets.length > 0;
                 }

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/directives.js
@@ -2,20 +2,20 @@
 
 define(['angular', 'require'], function(angular, require) {
 
-    var app = angular.module('my-app.layout.static.directives', []);
+    let app = angular.module('my-app.layout.static.directives', []);
 
-    app.directive('staticContentCard', function () {
+    app.directive('staticContentCard', function() {
         return {
             restrict: 'E',
-            templateUrl: require.toUrl('./partials/static-content-card.html')
-        }
+            templateUrl: require.toUrl('./partials/static-content-card.html'),
+        };
     });
 
-    app.directive('staticContentCardMax', function () {
+    app.directive('staticContentCardMax', function() {
         return {
             restrict: 'E',
-            templateUrl: require.toUrl('./partials/static-content-card-max.html')
-        }
+            templateUrl: require.toUrl('./partials/static-content-card-max.html'),
+        };
     });
 
     return app;

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/static/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/static/routes.js
@@ -1,9 +1,7 @@
-define(['require'], function(require){
-
+define(['require'], function(require) {
     return {
-             staticMax : {templateUrl: require.toUrl('./partials/static-content-max.html')},
-             exclusiveMax : {templateUrl: require.toUrl('./partials/static-content-exclusive.html')}
-            }
-
+             staticMax: {templateUrl: require.toUrl('./partials/static-content-max.html')},
+             exclusiveMax: {templateUrl: require.toUrl('./partials/static-content-exclusive.html')},
+            };
 });
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/controllers.js
@@ -1,40 +1,38 @@
 'use strict';
 
-define(['angular'], function (angular) {
+define(['angular'], function(angular) {
+  let app = angular.module('my-app.layout.widget.controllers', []);
 
-  var app = angular.module('my-app.layout.widget.controllers', []);
-
-  app.controller('OptionLinkController', ['$scope', 'layoutService', function ($scope, layoutService) {
-
-    var configInit = function () {
+  app.controller('OptionLinkController', ['$scope', 'layoutService', function($scope, layoutService) {
+    let configInit = function() {
       if (!$scope.config) {
-        //setting up defaults since config doesn't exist
+        // setting up defaults since config doesn't exist
         $scope.config = {
           singleElement: false,
           arrayName: 'array',
           value: 'value',
-          display: 'display'
+          display: 'display',
         };
       }
     };
 
-    var populateWidgetContent = function () {
+    let populateWidgetContent = function() {
       if ($scope.portlet.widgetURL && $scope.portlet.widgetType) {
-        //fetch portlet widget json
+        // fetch portlet widget json
         $scope.portlet.widgetData = [];
 
-        layoutService.getWidgetJson($scope.portlet).then(function (data) {
+        layoutService.getWidgetJson($scope.portlet).then(function(data) {
           if (data) {
             console.log(data);
-            //set init
+            // set init
             if ($scope.config.singleElement) {
-              //set the default selected url
+              // set the default selected url
               $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.value];
             } else if ($scope.portlet.widgetData[$scope.config.arrayName] && $scope.portlet.widgetData[$scope.config.arrayName].length > 0) {
               $scope.portlet.selectedUrl = $scope.portlet.widgetData[$scope.config.arrayName][0][$scope.config.value];
             }
           } else {
-            console.warn("Got nothing back from widget fetch for " + $scope.portlet.fname);
+            console.warn('Got nothing back from widget fetch for ' + $scope.portlet.fname);
           }
         });
       }
@@ -43,101 +41,100 @@ define(['angular'], function (angular) {
     populateWidgetContent();
   }]);
 
-  app.controller('LTILaunchController', ['$scope', 'layoutService', 'keyValueService', '$q', '$sce', function ($scope, layoutService, keyValueService, $q, $sce) {
+  app.controller('LTILaunchController', ['$scope', 'layoutService', 'keyValueService', '$q', '$sce', function($scope, layoutService, keyValueService, $q, $sce) {
     $scope.loading = false;
-    var init = function () {
+    let init = function() {
       $scope.loading = true;
-      layoutService.getWidgetJson($scope.portlet).then(function (data) {
+      layoutService.getWidgetJson($scope.portlet).then(function(data) {
         $scope.loading = false;
         if (data) {
           $scope.formInputs = data.formInputs;
           $scope.formAction = $sce.trustAsResourceUrl(data.action);
         }
-      }, function () {
+      }, function() {
         $scope.loading = false;
       });
-    }
+    };
     init();
   }]);
 
-  app.controller('WeatherController', ['$scope', 'layoutService', 'keyValueService', '$q', function ($scope, layoutService, keyValueService, $q) {
+  app.controller('WeatherController', ['$scope', 'layoutService', 'keyValueService', '$q', function($scope, layoutService, keyValueService, $q) {
     $scope.weatherData = [];
     $scope.loading = false;
-    $scope.fetchKey = "userWeatherPreference";
+    $scope.fetchKey = 'userWeatherPreference';
     $scope.currentUnits = 'F';
     $scope.nextUnits = 'C';
 
-    var populateWidgetContent = function () {
+    let populateWidgetContent = function() {
       if ($scope.portlet.widgetURL && $scope.portlet.widgetType) {
         $scope.loading = true;
-        //fetch portlet widget json
+        // fetch portlet widget json
         $scope.portlet.widgetData = [];
-        var widgetPromise = layoutService.getWidgetJson($scope.portlet);
-        var preferencePromise = keyValueService.getValue($scope.fetchKey);
+        let widgetPromise = layoutService.getWidgetJson($scope.portlet);
+        let preferencePromise = keyValueService.getValue($scope.fetchKey);
 
-        $q.all([widgetPromise, preferencePromise]).then(function (data) {
+        $q.all([widgetPromise, preferencePromise]).then(function(data) {
           $scope.loading = false;
 
           if (data) {
             console.log(data);
-            var allTheWeathers = data[0];
-            var myPref = data[1];
+            let allTheWeathers = data[0];
+            let myPref = data[1];
             $scope.portlet.widgetData = allTheWeathers.weathers;
             $scope.weatherData = $scope.portlet.widgetData;
             $scope.currentUnits = 'F';
             $scope.nextUnits = 'C';
-            var userPreference = myPref.userWeatherPreference;
-            if(userPreference ===null ||userPreference === "" || typeof userPreference === "undefined") {
+            let userPreference = myPref.userWeatherPreference;
+            if(userPreference ===null ||userPreference === '' || typeof userPreference === 'undefined') {
               userPreference = 'F';
             }
-            
-            while(userPreference != $scope.currentUnits){
+
+            while(userPreference != $scope.currentUnits) {
               $scope.cycleUnits();
             }
           } else {
             $scope.error = true;
-            console.warn("Got nothing back from widget fetch");
+            console.warn('Got nothing back from widget fetch');
           }
-        }, function () {
+        }, function() {
           $scope.loading = false;
           $scope.error = true;
         });
       }
     };
 
-    $scope.cycleUnits = function (){
+    $scope.cycleUnits = function() {
+      let userPreference = $scope.nextUnits;
 
-      var userPreference = $scope.nextUnits;
 
-
-      if(userPreference === 'F'){
+      if(userPreference === 'F') {
         $scope.changeKToF();
         $scope.currentUnits = 'F';
         $scope.nextUnits = 'C';
       }
 
-      if(userPreference === 'C'){
+      if(userPreference === 'C') {
         $scope.changeFToC();
         $scope.currentUnits = 'C';
         $scope.nextUnits = 'K';
       }
 
-      if(userPreference === 'K'){
+      if(userPreference === 'K') {
         $scope.changeCToK();
         $scope.currentUnits = 'K';
         $scope.nextUnits = 'F';
       }
 
-      var value = {};
+      let value = {};
       value.userWeatherPreference = $scope.currentUnits;
       keyValueService.setValue($scope.fetchKey, value);
     };
 
-    $scope.changeFToC = function () {
-      for (var i = 0; i < $scope.weatherData.length; i++) {
+    $scope.changeFToC = function() {
+      for (let i = 0; i < $scope.weatherData.length; i++) {
         $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature - 32) * (5 / 9);
 
-        for (var j = 0; j < $scope.weatherData[i].forecast.length; j++) {
+        for (let j = 0; j < $scope.weatherData[i].forecast.length; j++) {
           $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature - 32) * (5 / 9);
           $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature - 32) * (5 / 9);
         }
@@ -145,55 +142,55 @@ define(['angular'], function (angular) {
     };
 
     $scope.changeCToK = function() {
-      for (var i = 0; i < $scope.weatherData.length; i++) {
-        $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature + 273) ;
+      for (let i = 0; i < $scope.weatherData.length; i++) {
+        $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature + 273);
 
-        for (var j = 0; j < $scope.weatherData[i].forecast.length; j++) {
+        for (let j = 0; j < $scope.weatherData[i].forecast.length; j++) {
           $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature + 273);
           $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature + 273);
         }
       }
     };
 
-    $scope.changeKToF = function(){
+    $scope.changeKToF = function() {
       $scope.changeKToC();
       $scope.changeCToF();
     };
 
     $scope.changeKToC = function() {
-      for (var i = 0; i < $scope.weatherData.length; i++) {
-        $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature - 273) ;
+      for (let i = 0; i < $scope.weatherData.length; i++) {
+        $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature - 273);
 
-        for (var j = 0; j < $scope.weatherData[i].forecast.length; j++) {
+        for (let j = 0; j < $scope.weatherData[i].forecast.length; j++) {
           $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature - 273);
           $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature - 273);
         }
       }
     };
 
-    $scope.changeCToF = function () {
-      for (var i = 0; i < $scope.weatherData.length; i++) {
+    $scope.changeCToF = function() {
+      for (let i = 0; i < $scope.weatherData.length; i++) {
         $scope.weatherData[i].currentWeather.temperature = ($scope.weatherData[i].currentWeather.temperature) * (9 / 5) + 32;
 
-        for (var j = 0; j < $scope.weatherData[i].forecast.length; j++) {
+        for (let j = 0; j < $scope.weatherData[i].forecast.length; j++) {
           $scope.weatherData[i].forecast[j].highTemperature = ($scope.weatherData[i].forecast[j].highTemperature) * (9 / 5) + 32;
           $scope.weatherData[i].forecast[j].lowTemperature = ($scope.weatherData[i].forecast[j].lowTemperature) * (9 / 5) + 32;
         }
       }
-    }
-    console.log("Config: " + $scope.portlet.widgetConfig);
+    };
+    console.log('Config: ' + $scope.portlet.widgetConfig);
     populateWidgetContent();
     $scope.details = false;
   }]);
 
-  app.controller('GenericWidgetController', ['$scope', 'layoutService', function ($scope, layoutService) {
+  app.controller('GenericWidgetController', ['$scope', 'layoutService', function($scope, layoutService) {
     $scope.loading = false;
-    var populateWidgetContent = function () {
+    let populateWidgetContent = function() {
       if ($scope.portlet.widgetURL && $scope.portlet.widgetType) {
         $scope.loading = true;
-        //fetch portlet widget json
+        // fetch portlet widget json
         $scope.portlet.widgetData = [];
-        layoutService.getWidgetJson($scope.portlet).then(function (data) {
+        layoutService.getWidgetJson($scope.portlet).then(function(data) {
           $scope.loading = false;
           if (data) {
             $scope.portlet.widgetData = data;
@@ -202,24 +199,24 @@ define(['angular'], function (angular) {
               $scope.isEmpty = true;
             } else if ($scope.portlet.widgetConfig && $scope.portlet.widgetConfig.evalString
               && eval($scope.portlet.widgetConfig.evalString)) {
-              //ideally this would do a check on an embedded object for emptiness
-              //example : '$scope.content.report.length === 0'
+              // ideally this would do a check on an embedded object for emptiness
+              // example : '$scope.content.report.length === 0'
               $scope.isEmpty = true;
             }
           } else {
-            console.warn("Got nothing back from widget fetch from " + $scope.portlet.widgetURL);
+            console.warn('Got nothing back from widget fetch from ' + $scope.portlet.widgetURL);
             $scope.isEmpty = true;
           }
-        }, function () {
+        }, function() {
           $scope.loading = false;
         });
       }
     };
 
-    $scope.filteredArray = function (array, objectVar, strings) {
+    $scope.filteredArray = function(array, objectVar, strings) {
       if (array && objectVar && strings) {
-        return array.filter(function (letter) {
-          for (var i = 0; i < strings.length; i++) {
+        return array.filter(function(letter) {
+          for (let i = 0; i < strings.length; i++) {
             if (letter[objectVar].indexOf(strings[i]) != -1) {
               return true;
             }
@@ -235,18 +232,17 @@ define(['angular'], function (angular) {
       $scope.template = $scope.portlet.widgetTemplate;
       $scope.isEmpty = false;
       $scope.portlet.widgetData = [];
-      console.log("Config for " + $scope.portlet.fname + ": " + $scope.portlet.widgetConfig);
+      console.log('Config for ' + $scope.portlet.fname + ': ' + $scope.portlet.widgetConfig);
       populateWidgetContent();
     } else {
-      console.error($scope.portlet.fname + " said its a widget, but no template defined.");
+      console.error($scope.portlet.fname + ' said its a widget, but no template defined.');
       $scope.isEmpty = true;
     }
   }]);
 
-  app.controller("RSSWidgetController", ['$scope', 'layoutService', function ($scope, layoutService) {
-
-    $scope.getPrettyDate = function (dateString) {
-      var dte;
+  app.controller('RSSWidgetController', ['$scope', 'layoutService', function($scope, layoutService) {
+    $scope.getPrettyDate = function(dateString) {
+      let dte;
       if (dateString) {
         dte = new Date(dateString);
       } else {
@@ -255,7 +251,7 @@ define(['angular'], function (angular) {
       return dte;
     };
 
-    var init = function () {
+    let init = function() {
       $scope.loading = true;
       if ($scope.portlet && $scope.portlet.widgetURL && $scope.portlet.widgetType) {
         if (!$scope.config) {
@@ -271,11 +267,11 @@ define(['angular'], function (angular) {
         }
 
         if (!$scope.config.showShowing) {
-          //default must be false as falsy is weird
+          // default must be false as falsy is weird
           $scope.config.showShowing = false;
         }
 
-        var successFn = function (result) {
+        let successFn = function(result) {
           $scope.loading = false;
           $scope.data = result.data;
 
@@ -296,7 +292,7 @@ define(['angular'], function (angular) {
           }
         };
 
-        var errorFn = function (data) {
+        let errorFn = function(data) {
           $scope.error = true;
           $scope.isEmpty = true;
           $scope.loading = false;
@@ -306,18 +302,17 @@ define(['angular'], function (angular) {
     };
 
     init();
-
   }]);
 
-  //SearchWithLinksController
-  app.controller("SearchWithLinksController", ['$scope', '$sce', function ($scope, $sce) {
+  // SearchWithLinksController
+  app.controller('SearchWithLinksController', ['$scope', '$sce', function($scope, $sce) {
     $scope.secureURL = $sce.trustAsResourceUrl($scope.config.actionURL);
   }]);
 
-  //widget creator
-  app.controller("WidgetCreatorController", ['$scope', '$route', '$localStorage', function ($scope, $route, $localStorage) {
-    //general functions
-    var validJSON = function isValidJson(json) {
+  // widget creator
+  app.controller('WidgetCreatorController', ['$scope', '$route', '$localStorage', function($scope, $route, $localStorage) {
+    // general functions
+    let validJSON = function isValidJson(json) {
       try {
         JSON.parse(json);
         return true;
@@ -326,14 +321,14 @@ define(['angular'], function (angular) {
       }
     };
 
-    var init = function () {
+    let init = function() {
       $scope.storage.isEmpty = false;
       $scope.storage.portlet = $scope.storage.starterTemplates[0];
       $scope.storage.inited = true;
       $scope.portlet = $scope.storage.portlet;
     };
 
-    var retInit = function () {
+    let retInit = function() {
       $scope.portlet = $scope.storage.portlet;
       $scope.isEmpty = $scope.storage.isEmpty;
       if ($scope.storage.content && validJSON($scope.storage.content)) {
@@ -342,59 +337,58 @@ define(['angular'], function (angular) {
       } else {
         $scope.content = {};
         $scope.isEmpty = true;
-        $scope.errorJSON = $scope.storage.content ? "JSON NOT VALID" : "";
+        $scope.errorJSON = $scope.storage.content ? 'JSON NOT VALID' : '';
       }
       if ($scope.storage.widgetConfig && validJSON($scope.storage.widgetConfig)) {
         $scope.portlet.widgetConfig = JSON.parse($scope.storage.widgetConfig);
       } else {
-        $scope.errorConfigJSON = $scope.storage.widgetConfig ? "JSON NOT VALID" : "";
+        $scope.errorConfigJSON = $scope.storage.widgetConfig ? 'JSON NOT VALID' : '';
       }
 
       $scope.template = $scope.portlet.widgetTemplate;
-
     };
 
-    $scope.reload = function () {
+    $scope.reload = function() {
       $route.reload();
     };
 
-    $scope.clear = function () {
-      if (confirm("Are you sure, all your config will be cleared")) {
+    $scope.clear = function() {
+      if (confirm('Are you sure, all your config will be cleared')) {
         init();
         $route.reload();
       }
     };
 
-    $scope.changeTemplate = function () {
+    $scope.changeTemplate = function() {
       $scope.storage.content = $scope.storage.starterTemplate.contentIsJSON ? JSON.stringify($scope.storage.starterTemplate.content) : $scope.storage.starterTemplate.content;
       $scope.storage.portlet = $scope.storage.starterTemplate;
       $scope.storage.widgetConfig = JSON.stringify($scope.storage.starterTemplate.widgetConfig);
       $scope.reload();
     };
 
-    var initialize = function () {
+    let initialize = function() {
       $localStorage.widgetCreator = $localStorage.widgetCreator || {};
-      $scope.storage = $localStorage.widgetCreator; //makes the widget creator stuff contained
+      $scope.storage = $localStorage.widgetCreator; // makes the widget creator stuff contained
 
-      //mock the widget controller
+      // mock the widget controller
       $scope.widgetCtrl = {
-        portletType: function (portlet) {
+        portletType: function(portlet) {
           if (portlet.type) {
             return portlet.type;
           }
           return 'WIDGET_CREATOR';
-        }
+        },
       };
       $scope.storage.starterTemplates = [
         {
           id: 4,
-          type: "WIDGET_CREATOR",
-          title: "Custom",
+          type: 'WIDGET_CREATOR',
+          title: 'Custom',
           hasWidgetURL: false,
-          description: "This super cool portlet can change lives.",
+          description: 'This super cool portlet can change lives.',
           widgetConfig: {},
           jsonSample: {},
-          url: 'www.example.com'
+          url: 'www.example.com',
         },
         {
           id: 1,
@@ -404,28 +398,28 @@ define(['angular'], function (angular) {
           jsonSample: false,
           url: 'www.example.com',
           widgetConfig: {
-            "actionURL": "https://rprg.wisc.edu/search/",
-            "actionTarget": "_blank",
-            "actionParameter": "q",
-            "launchText": "Go to resource guide",
-            "links": [
+            'actionURL': 'https://rprg.wisc.edu/search/',
+            'actionTarget': '_blank',
+            'actionParameter': 'q',
+            'launchText': 'Go to resource guide',
+            'links': [
               {
-                "title": "Get started",
-                "href": "https://rprg.wisc.edu/phases/initiate/",
-                "icon": "fa-map-o",
-                "target": "_blank",
-                "rel": "noopener noreferrer"
+                'title': 'Get started',
+                'href': 'https://rprg.wisc.edu/phases/initiate/',
+                'icon': 'fa-map-o',
+                'target': '_blank',
+                'rel': 'noopener noreferrer'
               },
               {
-                "title": "Resources",
-                "href": "https://rprg.wisc.edu/category/resource/",
-                "icon": "fa-th-list",
-                "target": "_blank",
-                "rel": "noopener noreferrer"
-              }
-            ]
+                'title': 'Resources',
+                'href': 'https://rprg.wisc.edu/category/resource/',
+                'icon': 'fa-th-list',
+                'target': '_blank',
+                'rel': 'noopener noreferrer'
+              },
+            ],
           },
-          hasWidgetURL: false
+          hasWidgetURL: false,
         },
         {
           id: 2,
@@ -440,10 +434,10 @@ define(['angular'], function (angular) {
             showdate: true,
             titleLim: 40,
             dateFormat: 'MM-dd-yyyy',
-            showShowing: true
+            showShowing: true,
           },
           hasWidgetURL: true,
-          widgetURL: ""
+          widgetURL: ''
         },
         {
           id: 3,
@@ -453,27 +447,27 @@ define(['angular'], function (angular) {
           jsonSample: false,
           hasWidgetURL: false,
           widgetConfig: {
-            "launchText": "Launch the Full App",
-            "additionalText": "Additional Text",
-            "links": [
+            'launchText': 'Launch the Full App',
+            'additionalText': 'Additional Text',
+            'links': [
               {
-                "title": "The Google",
-                "href": "http://www.google.com",
-                "icon": "fa-google",
-                "target": "_blank",
-                "rel": "noopener noreferrer"
+                'title': 'The Google',
+                'href': 'http://www.google.com',
+                'icon': 'fa-google',
+                'target': '_blank',
+                'rel': 'noopener noreferrer'
               },
               {
-                "title": "Bing",
-                "href": "http://www.bing.com",
-                "icon": "fa-bed",
-                "target": "_blank",
-                "rel": "noopener noreferrer"
-              }
-            ]
+                'title': 'Bing',
+                'href': 'http://www.bing.com',
+                'icon': 'fa-bed',
+                'target': '_blank',
+                'rel': 'noopener noreferrer'
+              },
+            ],
           },
-          description: 'A simple list of links'
-        }
+          description: 'A simple list of links',
+        },
       ];
 
       if (!$scope.storage.inited) {
@@ -487,5 +481,4 @@ define(['angular'], function (angular) {
   }]);
 
   return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/directives.js
@@ -1,8 +1,7 @@
 'use strict';
 
 define(['angular', 'require'], function(angular, require) {
-
-    var app = angular.module('my-app.layout.widget.directives', []);
+    let app = angular.module('my-app.layout.widget.directives', []);
 
     /**
      * <option-link> directive is used to display widget content.
@@ -14,63 +13,63 @@ define(['angular', 'require'], function(angular, require) {
     *             display : 'display' // what to display in the drop down
     *         }
      */
-    app.directive('optionLink', function () {
+    app.directive('optionLink', function() {
         return {
             restrict: 'E',
             scope: {
                 portlet: '=app',
-                config: '=config'
+                config: '=config',
             },
             templateUrl: require.toUrl('./partials/option-link.html'),
-            controller: 'OptionLinkController'
-        }
+            controller: 'OptionLinkController',
+        };
     });
 
-    app.directive('weather', function () {
+    app.directive('weather', function() {
         return {
             restrict: 'E',
             scope: {
                 portlet: '=app',
-                config: '=config'
+                config: '=config',
             },
             templateUrl: require.toUrl('./partials/weather.html'),
-            controller: 'WeatherController'
-        }
+            controller: 'WeatherController',
+        };
     });
 
-    app.directive('lol', function () {
+    app.directive('lol', function() {
         return {
             restrict: 'E',
             scope: {
                 portlet: '=app',
-                config: '=config'
+                config: '=config',
             },
-            templateUrl: require.toUrl('./partials/lol.html')
-        }
+            templateUrl: require.toUrl('./partials/lol.html'),
+        };
     });
 
-    app.directive('swl', function () {
+    app.directive('swl', function() {
         return {
             restrict: 'E',
             scope: {
                 portlet: '=app',
-                config: '=config'
+                config: '=config',
             },
             templateUrl: require.toUrl('./partials/search-with-links.html'),
-            controller: 'SearchWithLinksController'
-        }
+            controller: 'SearchWithLinksController',
+        };
     });
-    
-    app.directive('ltiLaunch', function(){
+
+    app.directive('ltiLaunch', function() {
       return {
         restrict: 'E',
         scope: {
             portlet: '=app',
-            config: '=config'
+            config: '=config',
         },
         templateUrl: require.toUrl('./partials/lti-launch.html'),
-        controller: 'LTILaunchController'
-      }
+        controller: 'LTILaunchController',
+      };
     });
 
     /**
@@ -82,26 +81,26 @@ define(['angular', 'require'], function(angular, require) {
                - dateFormat : The date format, see https://docs.angularjs.org/api/ng/filter/date
                - showShowing : show the Showing x of y (default false)
     **/
-    app.directive('rss', function () {
+    app.directive('rss', function() {
         return {
             restrict: 'E',
             scope: {
                 portlet: '=app',
-                config: '=config'
+                config: '=config',
             },
-            templateUrl: require.toUrl('./partials/rssfeed.html')
-        }
+            templateUrl: require.toUrl('./partials/rssfeed.html'),
+        };
     });
 
     /**
       Just the widget Card, gets the portlet from the scope.
       Object must be in the portlet
     **/
-    app.directive('widgetCard', function(){
+    app.directive('widgetCard', function() {
         return {
-            restrict : 'E',
-            templateUrl : require.toUrl('./partials/widget-card.html')
-        }
+            restrict: 'E',
+            templateUrl: require.toUrl('./partials/widget-card.html'),
+        };
     });
 
     /**
@@ -109,8 +108,8 @@ define(['angular', 'require'], function(angular, require) {
       * fname : the fname of the object you wish to display
       */
     app.component('widget', {
-      bindings : {
-        fname : '<'
+      bindings: {
+        fname: '<',
       },
       templateUrl: require.toUrl('./partials/single-widget-component.html'),
       controllerAs: 'widgetCtrl',
@@ -118,12 +117,12 @@ define(['angular', 'require'], function(angular, require) {
                            $controller,
                            $location,
                            layoutService) {
-        var that = this;
-        $scope.portlet = { title: 'loading...'};
+        let that = this;
+        $scope.portlet = {title: 'loading...'};
         $scope.cantRemove = true;
         this.$onInit = function() {
-          var base = $controller('BaseWidgetFunctionsController', { $scope : $scope, childController : that });
-        }
+          let base = $controller('BaseWidgetFunctionsController', {$scope: $scope, childController: that});
+        };
 
         this.$onChanges = function(changesObj) {
           if(changesObj
@@ -131,9 +130,9 @@ define(['angular', 'require'], function(angular, require) {
               && changesObj.fname.currentValue
               && changesObj.fname.currentValue
                   !== changesObj.fname.previousValue) {
-            var fname = changesObj.fname.currentValue;
-            layoutService.getApp(fname).then(function (result) {
-                var data = result.data;
+            let fname = changesObj.fname.currentValue;
+            layoutService.getApp(fname).then(function(result) {
+                let data = result.data;
                 $scope.portlet = data.portlet;
                 if (typeof $scope.portlet === 'undefined' ||
                     typeof $scope.portlet.fname === 'undefined') {
@@ -148,12 +147,11 @@ define(['angular', 'require'], function(angular, require) {
                 }
             });
           }
-        }
+        };
 
 
-      }
+      },
     });
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/widget/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/widget/routes.js
@@ -1,14 +1,12 @@
-define(['require'], function(require){
-
+define(['require'], function(require) {
     return {
-      widgetView : {templateUrl: require.toUrl('./partials/home-widget-view.html')},
-      widgetFullScreen : {
+      widgetView: {templateUrl: require.toUrl('./partials/home-widget-view.html')},
+      widgetFullScreen: {
                            template: '<div class="widget-middle"><widget fname="$routeParams.fname"></widget></div>',
-                           controller: function($routeParams, $scope){
+                           controller: function($routeParams, $scope) {
                              $scope.$routeParams = $routeParams;
-                           }
+                           },
                          },
-      widgetCreator : {templateUrl: require.toUrl('./partials/widget-creator.html')}
-    }
-
+      widgetCreator: {templateUrl: require.toUrl('./partials/widget-creator.html')},
+    };
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/main.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/main.js
@@ -31,11 +31,10 @@ define([
     './rating/controllers',
     './search/controllers',
     './search/directives',
-    './search/services'
+    './search/services',
 ], function(angular, require, marketplaceRoutes, listRoute, notificationsRoute, portalSettingsRoutes,
 			featuresRoute, aboutRoute, layoutRoute, staticRoutes, widgetRoutes, searchRoutes) {
-
-    var app = angular.module('my-app', [
+    let app = angular.module('my-app', [
         'app-config',
         'web-config',
         'my-app.layout.controllers',
@@ -56,7 +55,7 @@ define([
         'ngRoute',
         'ngSanitize',
         'ngStorage',
-        'portal'
+        'portal',
     ]);
 
     // TODO: Think of a more extensible approach such that frame and app can each manage their own routing without conflict
@@ -83,5 +82,4 @@ define([
 
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/controllers.js
@@ -1,32 +1,30 @@
 'use strict';
 
 define(['angular', 'jquery', 'require'], function(angular, $, require) {
-
-  var app = angular.module('my-app.marketplace.controllers', []);
+  let app = angular.module('my-app.marketplace.controllers', []);
 
   app.controller('marketplaceCommonFunctions', ['googleCustomSearchService', 'miscSearchService', 'layoutService', 'marketplaceService',
-    'miscService', 'MISC_URLS', '$sessionStorage', '$localStorage','$rootScope', '$scope', '$routeParams', '$timeout', '$location',
+    'miscService', 'MISC_URLS', '$sessionStorage', '$localStorage', '$rootScope', '$scope', '$routeParams', '$timeout', '$location',
     function(googleCustomSearchService, miscSearchService, layoutService, marketplaceService, miscService, MISC_URLS, $sessionStorage,
              $localStorage, $rootScope, $scope, $routeParams, $timeout, $location) {
-
-      var currentThemePrimary = ($sessionStorage.portal.theme && $sessionStorage.portal.theme.materialTheme) ? $sessionStorage.portal.theme.materialTheme.primary['500'] : {value: ['0', '0', '0']};
+      let currentThemePrimary = ($sessionStorage.portal.theme && $sessionStorage.portal.theme.materialTheme) ? $sessionStorage.portal.theme.materialTheme.primary['500'] : {value: ['0', '0', '0']};
       $scope.primaryColorRgb = 'rgb('+ currentThemePrimary.value[0] + ',' + currentThemePrimary.value[1] + ',' + currentThemePrimary.value[2] + ')';
 
       $scope.navToDetails = function(marketplaceEntry, location) {
         marketplaceService.setFromInfo(location, $scope.searchTerm);
-        $location.path("apps/details/"+ marketplaceEntry.fname);
+        $location.path('apps/details/'+ marketplaceEntry.fname);
       };
 
       $scope.isStatic = function(portlet) {
-        return portlet.maxUrl.indexOf('portal') !== -1 //max url is a portal hit
+        return portlet.maxUrl.indexOf('portal') !== -1 // max url is a portal hit
           && portlet.portletName // there is a portletName
-          && portlet.portletName.indexOf('cms') != -1; //the portlet is static content portlet
+          && portlet.portletName.indexOf('cms') != -1; // the portlet is static content portlet
       };
 
       $scope.getLaunchURL = function(marketplaceEntry) {
-        var layoutObj = marketplaceEntry.layoutObject;
+        let layoutObj = marketplaceEntry.layoutObject;
         if($rootScope.GuestMode && !marketplaceEntry.hasInLayout) {
-          return $scope.loginToAuthPage + '/web/apps/details/'+ marketplaceEntry.fname
+          return $scope.loginToAuthPage + '/web/apps/details/'+ marketplaceEntry.fname;
         } else if(layoutObj.altMaxUrl == false && (layoutObj.renderOnWeb || $localStorage.webPortletRender)) {
           return 'exclusive/' + layoutObj.fname;
         } else if(layoutObj.altMaxUrl == false && $scope.isStatic(marketplaceEntry)) {
@@ -37,16 +35,18 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
       };
 
       $scope.addToHome = function addToHome(portlet) {
-        var fname = portlet.fname;
-        var ret = layoutService.addToHome(portlet);
-        ret.success(function (request, text){
-          $('.fname-'+fname).html('<i class="fa fa-check"></i> Added Successfully').prop('disabled',true).removeClass('btn-add').addClass('btn-added');
-          $scope.$apply(function(){
-            var marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) { return e.fname === portlet.fname});
+        let fname = portlet.fname;
+        let ret = layoutService.addToHome(portlet);
+        ret.success(function(request, text) {
+          $('.fname-'+fname).html('<i class="fa fa-check"></i> Added Successfully').prop('disabled', true).removeClass('btn-add').addClass('btn-added');
+          $scope.$apply(function() {
+            let marketplaceEntries = $.grep($sessionStorage.marketplace, function(e) {
+ return e.fname === portlet.fname
+});
             if(marketplaceEntries.length > 0) {
               marketplaceEntries[0].hasInLayout = true;
             }
-            $rootScope.layout = null; //reset layout due to modifications
+            $rootScope.layout = null; // reset layout due to modifications
             $sessionStorage.layout = null;
           });
         })
@@ -59,17 +59,17 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         return marketplaceService.portletMatchesSearchTerm(portlet, $scope.searchTerm, {
           searchDescription: true,
           searchKeywords: true,
-          defaultReturn : true
+          defaultReturn: true,
         });
       };
 
-      $scope.selectFilter = function (filter,category) {
+      $scope.selectFilter = function(filter, category) {
         $scope.sortParameter = filter;
         $scope.categoryToShow = category;
         $scope.showCategories = false;
         if (filter === 'popular') {
           $scope.selectedFilter = 'popular';
-          $scope.sortParameter = ['-rating','-userRated'];
+          $scope.sortParameter = ['-rating', '-userRated'];
         }
         if (filter === 'az') {
           $scope.selectedFilter = 'az';
@@ -81,8 +81,7 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
           $scope.showCategories = true;
         }
 
-        miscService.pushGAEvent('Marketplace','Tab Select',filter);
-
+        miscService.pushGAEvent('Marketplace', 'Tab Select', filter);
       };
 
       $scope.slideTabs = function(direction) {
@@ -97,24 +96,24 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
       };
 
       this.setupSearchTerm = function() {
-        var tempFilterText = '', filterTextTimeout;
+        let tempFilterText = '', filterTextTimeout;
         $scope.searchTerm = marketplaceService.getInitialFilter();
-        if($routeParams.initFilter !== null && ($scope.searchTerm === null || $scope.searchTerm === "")) {
+        if($routeParams.initFilter !== null && ($scope.searchTerm === null || $scope.searchTerm === '')) {
           $scope.searchTerm = $routeParams.initFilter;
         } else {
-          marketplaceService.initialFilter("");
+          marketplaceService.initialFilter('');
         }
         $scope.searchText = $scope.searchTerm;
-        var initFilter = false;
-        //delay on the filter
-        $scope.$watch('searchText', function (val) {
+        let initFilter = false;
+        // delay on the filter
+        $scope.$watch('searchText', function(val) {
           if (filterTextTimeout) $timeout.cancel(filterTextTimeout);
 
           tempFilterText = val;
           filterTextTimeout = $timeout(function() {
             $scope.searchTerm = tempFilterText;
             if(initFilter && $scope.searchTerm) {
-              miscService.pushGAEvent('Search','Filter',$scope.searchTerm);
+              miscService.pushGAEvent('Search', 'Filter', $scope.searchTerm);
             } else {
               initFilter = true;
             }
@@ -123,40 +122,39 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
       };
 
       this.initializeConstants = function() {
-        //initialize constants
-        googleCustomSearchService.getPublicWebSearchURL().then(function(webSearchURL){
+        // initialize constants
+        googleCustomSearchService.getPublicWebSearchURL().then(function(webSearchURL) {
           $scope.webSearchUrl = webSearchURL;
         });
-        googleCustomSearchService.getDomainResultsLabel().then(function(domainResultsLabel){
+        googleCustomSearchService.getDomainResultsLabel().then(function(domainResultsLabel) {
           $scope.domainResultsLabel = domainResultsLabel;
         });
-        miscSearchService.getKBSearchURL().then(function(kbSearchURL){
+        miscSearchService.getKBSearchURL().then(function(kbSearchURL) {
           $scope.kbSearchUrl = kbSearchURL;
         });
-        miscSearchService.getEventSearchURL().then(function(eventsSearchURL){
+        miscSearchService.getEventSearchURL().then(function(eventsSearchURL) {
           $scope.eventsSearchUrl = eventsSearchURL;
         });
-        miscSearchService.getHelpDeskHelpURL().then(function(helpdeskURL){
+        miscSearchService.getHelpDeskHelpURL().then(function(helpdeskURL) {
           $scope.helpdeskUrl = helpdeskURL;
         });
         $scope.directorySearchUrl = MISC_URLS.directorySearchURL;
         $scope.feedbackUrl = MISC_URLS.feedbackURL;
         $scope.loginToAuthPage = MISC_URLS.myuwHome;
-      }
-    }
+      };
+    },
   ]);
 
-  var currentPage = 'market';
-  var currentCategory = '';
+  let currentPage = 'market';
+  let currentCategory = '';
 
   app.controller('MarketplaceController', [
-    '$rootScope','$scope', '$controller', 'marketplaceService',
+    '$rootScope', '$scope', '$controller', 'marketplaceService',
     function($rootScope, $scope, $controller, marketplaceService) {
+      let base = $controller('marketplaceCommonFunctions', {$scope: $scope});
 
-      var base = $controller('marketplaceCommonFunctions', { $scope : $scope });
-
-      var init = function(){
-        //init variables
+      let init = function() {
+        // init variables
         $scope.portlets = [];
         marketplaceService.getPortlets().then(function(data) {
           $scope.portlets = data.portlets;
@@ -165,13 +163,13 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
 
         base.setupSearchTerm();
 
-        //initialize variables
+        // initialize variables
 
         $scope.searchResultLimit = 20;
         $scope.showAll = $rootScope.GuestMode || false;
         if(currentPage === 'details') {
           // Empty string indicates no categories, show all portlets
-          $scope.categoryToShow = "";
+          $scope.categoryToShow = '';
           // Default filter is to sort by category for marketplaceDetails back to marketplace
           $scope.selectedFilter = 'category';
           // To sort by category, angular will use name to filter
@@ -186,11 +184,11 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
             $scope.categoryToShow = '';
         } else {
           // Empty string indicates no categories, show all portlets
-          $scope.categoryToShow = "";
+          $scope.categoryToShow = '';
           // Default filter is to sort by popularity
           $scope.selectedFilter = 'popular';
           // To sort by popularity, angular will use portlet.rating to filter
-          $scope.sortParameter = ['-rating','-userRated'];
+          $scope.sortParameter = ['-rating', '-userRated'];
           // Hide category selection div by default
           $scope.showCategories = false;
         }
@@ -198,43 +196,42 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
         base.initializeConstants();
       };
 
-      //run functions
+      // run functions
       init();
-    } ]);
+    }]);
 
   app.controller('MarketplaceDetailsController', [
       '$controller', '$scope', '$routeParams', '$mdDialog', 'marketplaceService',
       'SERVICE_LOC',
       function($controller, $scope, $routeParams, $mdDialog, marketplaceService,
                SERVICE_LOC) {
-
-        $controller('marketplaceCommonFunctions', { $scope : $scope });
+        $controller('marketplaceCommonFunctions', {$scope: $scope});
 
         $scope.specifyCategory = function(category) {
           currentCategory=category;
           currentPage='details';
         };
 
-        var figureOutBackStuff = function() {
-          var fromInfo = marketplaceService.getFromInfo();
+        let figureOutBackStuff = function() {
+          let fromInfo = marketplaceService.getFromInfo();
           if(fromInfo.term) {
-            //from somewhere
-            if("Search" === fromInfo.searchOrBrowse && fromInfo.term) {
-              //if from search and term is populated, return to search
-              $scope.backText = "Search Results for " + fromInfo.term;
-              $scope.backURL = "apps/search/" + fromInfo.term;
+            // from somewhere
+            if('Search' === fromInfo.searchOrBrowse && fromInfo.term) {
+              // if from search and term is populated, return to search
+              $scope.backText = 'Search Results for ' + fromInfo.term;
+              $scope.backURL = 'apps/search/' + fromInfo.term;
             } else {
-              //assuming from browse
-              $scope.backText = "Browse";
-              $scope.backURL = "apps/browse/" + fromInfo.term;
+              // assuming from browse
+              $scope.backText = 'Browse';
+              $scope.backURL = 'apps/browse/' + fromInfo.term;
             }
 
-            //reset services
-            marketplaceService.setFromInfo(undefined,undefined);
+            // reset services
+            marketplaceService.setFromInfo(undefined, undefined);
           } else {
-            //direct hit, will go back to browse
-            $scope.backURL="apps";
-            $scope.backText="Browse";
+            // direct hit, will go back to browse
+            $scope.backURL='apps';
+            $scope.backText='Browse';
           }
         };
 
@@ -244,14 +241,14 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
             templateUrl: require.toUrl('./partials/rating-review-admin.html'),
             parent: angular.element(document.body),
             scope: $scope,
-            preserveScope : true,
-            clickOutsideToClose:true,
-            fullscreen: false
+            preserveScope: true,
+            clickOutsideToClose: true,
+            fullscreen: false,
           });
         };
 
         // init
-        var init = function() {
+        let init = function() {
           $scope.loading = true;
           figureOutBackStuff();
           $scope.obj = [];
@@ -267,7 +264,7 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
               $scope.portlet = result;
               $scope.error = false;
             }
-          }, function(reason){
+          }, function(reason) {
             $scope.loading = false;
             $scope.error = true;
           });
@@ -279,28 +276,27 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
   app.controller('MarketplaceRatingReviewAdminController', [
     '$scope', 'marketplaceService',
     function($scope, marketplaceService) {
-      var init = function(){
+      let init = function() {
         $scope.ratings = [];
-        marketplaceService.getAllRatings($scope.portlet.fname).then(function(ratings){
-          if(!ratings){
+        marketplaceService.getAllRatings($scope.portlet.fname).then(function(ratings) {
+          if(!ratings) {
             return;
           }
           $scope.ratings = ratings;
           $scope.average =0;
           $scope.totalReviews = 0;
-          angular.forEach(ratings, function(value, key){
+          angular.forEach(ratings, function(value, key) {
             $scope.average+= value.rating;
             if(value.review) {
               $scope.totalReviews += 1;
             }
           });
           $scope.average = Math.round($scope.average / ratings.length);
-        })
+        });
       };
 
       init();
     }]);
 
   return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/directives.js
@@ -1,29 +1,27 @@
 'use strict';
 
 define(['angular', 'require'], function(angular, require) {
-
-    var app = angular.module('my-app.marketplace.directives', []);
+    let app = angular.module('my-app.marketplace.directives', []);
     app.directive('marketplaceEntry', function() {
         return {
-            restrict : 'E',
-            templateUrl : require.toUrl('./partials/marketplace-entry.html')
-        }
+            restrict: 'E',
+            templateUrl: require.toUrl('./partials/marketplace-entry.html'),
+        };
     });
 
   app.directive('marketplaceNoResults', function() {
     return {
-      restrict : 'E',
-      templateUrl : require.toUrl('./partials/marketplace-no-results.html')
-    }
+      restrict: 'E',
+      templateUrl: require.toUrl('./partials/marketplace-no-results.html'),
+    };
   });
 
   app.directive('marketplaceLoadMore', function() {
     return {
-      restrict : 'E',
-      templateUrl : require.toUrl('./partials/marketplace-load-more.html')
-    }
+      restrict: 'E',
+      templateUrl: require.toUrl('./partials/marketplace-load-more.html'),
+    };
   });
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/routes.js
@@ -1,13 +1,11 @@
-define(['require'], function(require){
-
+define(['require'], function(require) {
     return {
         main: {
-            templateUrl: require.toUrl('./partials/marketplace.html')
+            templateUrl: require.toUrl('./partials/marketplace.html'),
         },
         details: {
-            templateUrl: require.toUrl('./partials/marketplace-details.html')
-        }
-    }
-
+            templateUrl: require.toUrl('./partials/marketplace-details.html'),
+        },
+    };
 });
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/services.js
@@ -1,55 +1,54 @@
 'use strict';
 
 define(['angular', 'jquery'], function(angular, $) {
+    let app = angular.module('my-app.marketplace.services', []);
 
-    var app = angular.module('my-app.marketplace.services', []);
+    app.factory('marketplaceService', ['$q', '$http', '$sessionStorage', 'layoutService', 'miscService', 'mainService', 'SERVICE_LOC', 'APP_FLAGS', function($q, $http, $sessionStorage, layoutService, miscService, mainService, SERVICE_LOC, APP_FLAGS) {
+        let marketplacePromise;
+        // local variables
+        let filter = '';
+        let fromSearchTerm = '';
+        let fromSearchOrBrowse = '';
 
-    app.factory('marketplaceService', ['$q', '$http','$sessionStorage', 'layoutService', 'miscService', 'mainService', 'SERVICE_LOC', 'APP_FLAGS', function($q, $http, $sessionStorage, layoutService, miscService, mainService, SERVICE_LOC, APP_FLAGS) {
-        var marketplacePromise;
-        //local variables
-        var filter = "";
-        var fromSearchTerm = "";
-        var fromSearchOrBrowse = "";
+        // public functions
 
-        //public functions
-
-        var initialFilter = function(theFilter) {
+        let initialFilter = function(theFilter) {
             filter = theFilter;
         };
 
-        var getInitialFilter = function(){
+        let getInitialFilter = function() {
             return filter;
         };
 
         /**
          * Sets the information about where they came from
          */
-        var setFromInfo = function(searchOrBrowse, term) {
+        let setFromInfo = function(searchOrBrowse, term) {
           fromSearchTerm = term;
           fromSearchOrBrowse = searchOrBrowse;
         };
         /**
          * Gets the information about where they came from
          */
-        var getFromInfo = function() {
-          return {term: fromSearchTerm, searchOrBrowse : fromSearchOrBrowse};
+        let getFromInfo = function() {
+          return {term: fromSearchTerm, searchOrBrowse: fromSearchOrBrowse};
         };
 
-        var checkMarketplaceCache = function() {
-            var userPromise = mainService.getUser();
+        let checkMarketplaceCache = function() {
+            let userPromise = mainService.getUser();
             return userPromise.then(function(user) {
                 if ($sessionStorage.sessionKey === user.sessionKey && $sessionStorage.marketplace) {
                     return {
-                        portlets : $sessionStorage.marketplace,
-                        categories : $sessionStorage.categories
+                        portlets: $sessionStorage.marketplace,
+                        categories: $sessionStorage.categories,
                     };
                 }
                 return null;
             });
         };
 
-        var storeMarketplaceInCache = function(data) {
-            var userPromise = mainService.getUser();
+        let storeMarketplaceInCache = function(data) {
+            let userPromise = mainService.getUser();
             userPromise.then(function(user) {
                 $sessionStorage.sessionKey = user.sessionKey;
                 $sessionStorage.marketplace = data.portlets;
@@ -57,9 +56,9 @@ define(['angular', 'jquery'], function(angular, $) {
             });
         };
 
-        var getPortlets = function () {
+        let getPortlets = function() {
             return checkMarketplaceCache().then(function(data) {
-                var successFn, errorFn, defer;
+                let successFn, errorFn, defer;
 
                 // first, check the local storage...
                 if (data) {
@@ -81,9 +80,9 @@ define(['angular', 'jquery'], function(angular, $) {
                     return marketplacePromise;
                 }
 
-                successFn =function(data){
-                    var result = {};
-                    postProcessing(result,data);
+                successFn =function(data) {
+                    let result = {};
+                    postProcessing(result, data);
                     storeMarketplaceInCache(result);
                     return result;
                 };
@@ -93,31 +92,31 @@ define(['angular', 'jquery'], function(angular, $) {
                 };
 
                 // no caching...  request from the server
-                marketplacePromise = $q.all([$http.get(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + SERVICE_LOC.marketplace.entries, {cache : true}), layoutService.getLayout()]).then(successFn,errorFn);
+                marketplacePromise = $q.all([$http.get(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + SERVICE_LOC.marketplace.entries, {cache: true}), layoutService.getLayout()]).then(successFn, errorFn);
                 return marketplacePromise;
             });
-
         };
 
         /**
           returns portlet if one exists in user's marketplace, or goes and gets entry from server
         **/
-        var getPortlet = function (fname) {
-          var successFn, errorFn, defer;
-          //first check cache, if there use that (it'll be faster)
-          return checkMarketplaceCache().then(function(data){
+        let getPortlet = function(fname) {
+          let successFn, errorFn, defer;
+          // first check cache, if there use that (it'll be faster)
+          return checkMarketplaceCache().then(function(data) {
             if (data) {
                 defer = $q.defer();
-                //find portlet and resolve with it if exists
-                var portlets = $.grep(data.portlets, function(e) { return e.fname === fname});
-                var portlet = portlets ? portlets[0] : null;
+                // find portlet and resolve with it if exists
+                let portlets = $.grep(data.portlets, function(e) {
+ return e.fname === fname;});
+                let portlet = portlets ? portlets[0] : null;
                 defer.resolve(portlet);
                 return defer.promise;
             } else {
-              successFn =function(data){
-                var portlet = data[0].data.entry;
+              successFn =function(data) {
+                let portlet = data[0].data.entry;
                 if(portlet) {
-                  var layout = data[1];
+                  let layout = data[1];
                   processInLayout(portlet, layout);
                 }
                 return portlet;
@@ -127,37 +126,39 @@ define(['angular', 'jquery'], function(angular, $) {
                 miscService.redirectUser(reason.status, 'marketplace entry service call');
               };
 
-              return $q.all([$http.get(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + SERVICE_LOC.marketplace.entry + fname + ".json", {cache : true}),layoutService.getLayout()]).then(successFn, errorFn);
+              return $q.all([$http.get(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + SERVICE_LOC.marketplace.entry + fname + '.json', {cache: true}), layoutService.getLayout()]).then(successFn, errorFn);
             }
           });
         };
 
-        var getUserRating = function(fname) {
+        let getUserRating = function(fname) {
             return $http.get(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + fname + '/getRating').then(function(result) {
                 return result.data.rating;
             });
         };
 
-        var saveRating = function(fname, rating) {
-            return $http.post(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + fname + '/rating/' + rating.rating , {}, {params: {review : rating.review}}).
-                success(function(data, status, headers, config){
+        let saveRating = function(fname, rating) {
+            return $http.post(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + fname + '/rating/' + rating.rating, {}, {params: {review: rating.review}}).
+                success(function(data, status, headers, config) {
                   if(APP_FLAGS.debug) {
-                    console.log("successfully saved marketplace rating for " + fname + " with data " + rating);
+                    console.log('successfully saved marketplace rating for ' + fname + ' with data ' + rating);
                   }
                   return data;
                 }).
-                error(function(data, status, headers, config){
+                error(function(data, status, headers, config) {
                   if(APP_FLAGS.debug) {
-                    console.error("Failed to save marketplace rating for " + fname + " with data " + rating);
+                    console.error('Failed to save marketplace rating for ' + fname + ' with data ' + rating);
                   }
                   return data;
                 });
         };
 
-        //private functions
+        // private functions
 
         var processInLayout = function(portlet, layout) {
-          var inLayout = $.grep(layout, function(e) { return e.fname === portlet.fname}).length;
+          let inLayout = $.grep(layout, function(e) {
+ return e.fname === portlet.fname
+}).length;
           if (inLayout > 0) {
               portlet.hasInLayout = true;
           } else {
@@ -166,23 +167,21 @@ define(['angular', 'jquery'], function(angular, $) {
         };
 
         var postProcessing = function(result, data) {
-
             result.portlets = data[0].data.portlets;
 
-            var categories = [];
-            var layout = data[1].layout;
+            let categories = [];
+            let layout = data[1].layout;
 
 
-            $.each(result.portlets, function (index, cur){
-                //in layout check
+            $.each(result.portlets, function(index, cur) {
+                // in layout check
                 processInLayout(cur, layout);
 
-                //categories building
-                var categoriesOfThisPortlet = cur.categories;
+                // categories building
+                let categoriesOfThisPortlet = cur.categories;
 
-                $.each(categoriesOfThisPortlet, function(index, category){
-                    
-                    if ($.inArray(category, categories) == -1  && cur.canAdd == true) {
+                $.each(categoriesOfThisPortlet, function(index, category) {
+                    if ($.inArray(category, categories) == -1 && cur.canAdd == true) {
                         categories.push(category);
                     }
                 });
@@ -192,28 +191,28 @@ define(['angular', 'jquery'], function(angular, $) {
             result.layout = layout;
         };
 
-        var portletMatchesSearchTerm = function(portlet, searchTerm, opts) {
+        let portletMatchesSearchTerm = function(portlet, searchTerm, opts) {
             if (!searchTerm) {
                 return opts && opts.defaultReturn;
             }
 
-            var lowerSearchTerm = searchTerm.toLowerCase(); //create local var for searchTerm
+            let lowerSearchTerm = searchTerm.toLowerCase(); // create local var for searchTerm
 
-            if(portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {//check title
+            if(portlet.title.toLowerCase().indexOf(lowerSearchTerm) !== -1) {// check title
                 return true;
             }
 
             if (opts && opts.searchDescription) {
-                //check description match
+                // check description match
                 if(portlet.description && portlet.description.toLowerCase().indexOf(lowerSearchTerm) !== -1) {
                     return true;
                 }
             }
 
-            //last ditch effort, check keywords
+            // last ditch effort, check keywords
             if (opts && opts.searchKeywords) {
                 if (portlet.keywords) {
-                    for (var i = 0; i < portlet.keywords.length; i++) {
+                    for (let i = 0; i < portlet.keywords.length; i++) {
                         if (portlet.keywords[i].toLowerCase().indexOf(lowerSearchTerm) !== -1) {
                             return true;
                         }
@@ -223,8 +222,8 @@ define(['angular', 'jquery'], function(angular, $) {
             return false;
         };
 
-        var filterPortletsBySearchTerm = function(portletList, searchTerm, opts) {
-            var matches;
+        let filterPortletsBySearchTerm = function(portletList, searchTerm, opts) {
+            let matches;
 
             if (!angular.isArray(portletList)) {
                 return null;
@@ -240,29 +239,27 @@ define(['angular', 'jquery'], function(angular, $) {
             return matches;
         };
 
-        var getAllRatings = function(fname) {
+        let getAllRatings = function(fname) {
           return $http.get(SERVICE_LOC.base + SERVICE_LOC.marketplace.base + fname + '/ratings').then(function(result) {
               return result.data.ratings;
           });
-        }
+        };
 
-        //return list of avaliable functions
+        // return list of avaliable functions
         return {
-            getPortlet : getPortlet,
+            getPortlet: getPortlet,
             getPortlets: getPortlets,
             initialFilter: initialFilter,
             getInitialFilter: getInitialFilter,
-            getUserRating : getUserRating,
-            saveRating : saveRating,
-            getAllRatings : getAllRatings,
+            getUserRating: getUserRating,
+            saveRating: saveRating,
+            getAllRatings: getAllRatings,
             filterPortletsBySearchTerm: filterPortletsBySearchTerm,
             portletMatchesSearchTerm: portletMatchesSearchTerm,
-            setFromInfo : setFromInfo,
-            getFromInfo : getFromInfo
+            setFromInfo: setFromInfo,
+            getFromInfo: getFromInfo,
         };
-
     }]);
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/rating/components.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/rating/components.js
@@ -1,8 +1,7 @@
 'use strict';
 
 define(['angular', 'jquery', 'require'], function(angular, $, require) {
-
-    var app = angular.module('my-app.rating.components', []);
+    let app = angular.module('my-app.rating.components', []);
 
     /**
      * <rating-button portlet='portletObject'
@@ -11,31 +10,30 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
      * portlet object usage : { fname, title}
      */
     app.component('ratingButton', {
-      bindings : {
-        portlet : '<',
-        buttonText : '@',
-        buttonClasses : '@'
+      bindings: {
+        portlet: '<',
+        buttonText: '@',
+        buttonClasses: '@',
       },
       templateUrl: require.toUrl('./partials/rating-button.html'),
       controllerAs: 'ratingCtrl',
       controller: function($scope,
                            $location,
                            $mdDialog) {
-
            this.$onInit = function() {
-             //initialize
+             // initialize
              $scope.openModal = function() {
                $mdDialog.show({
                    controller: 'RatingsModalController',
                    templateUrl: require.toUrl('./partials/rating-review.html'),
                    parent: angular.element(document.body),
                    scope: $scope,
-                   preserveScope : true,
-                   clickOutsideToClose:true,
-                   fullscreen: false
+                   preserveScope: true,
+                   clickOutsideToClose: true,
+                   fullscreen: false,
                });
              };
-           }
+           };
 
            this.$onChanges = function(changesObj) {
              if(changesObj
@@ -45,8 +43,7 @@ define(['angular', 'jquery', 'require'], function(angular, $, require) {
                      !== changesObj.portlet.previousValue) {
                $scope.portlet = changesObj.portlet.currentValue;
              }
-           }
-      }
+           };
+      },
     });
-
   });

--- a/angularjs-portal-home/src/main/webapp/my-app/rating/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/rating/controllers.js
@@ -1,56 +1,53 @@
 'use strict';
 
 define(['angular', 'jquery', 'require'], function(angular, $, require) {
-
-    var app = angular.module('my-app.rating.controllers', []);
+    let app = angular.module('my-app.rating.controllers', []);
 
     app.controller('RatingsModalController', [
         '$scope', 'marketplaceService', '$mdDialog',
-        function($scope, marketplaceService, $mdDialog){
-
-            var init = function(){
+        function($scope, marketplaceService, $mdDialog) {
+            let init = function() {
               $scope.loading = true;
               marketplaceService.getUserRating($scope.portlet.fname)
                 .then(function(data) {
-                  var rating = data;
+                  let rating = data;
                   if (rating !== null) {
                       $scope.rating = rating;
                       $scope.rating.previouslyRated=true;
                       $scope.loading = false;
                   } else {
                       $scope.rating = {
-                                       "rating" : 0,
-                                       "review" : "",
-                                       "previouslyRated": false
+                                       'rating' : 0,
+                                       'review' : '',
+                                       'previouslyRated': false,
                                       };
                       $scope.loading = false;
                   }
-                }).catch(function(){
+                }).catch(function() {
                   $scope.loading = false;
                   $scope.rating = {
-                                   "rating" : 0,
-                                   "review" : "",
-                                   "previouslyRated": false
+                                   'rating' : 0,
+                                   'review' : '',
+                                   'previouslyRated': false,
                                   };
                 });
             };
 
             init();
 
-            $scope.ok = function () {
+            $scope.ok = function() {
               marketplaceService.saveRating($scope.portlet.fname, $scope.rating)
-                .then(function(){
+                .then(function() {
                   $mdDialog.hide();
                   $scope.saved = true;
                 })
-                .catch(function(){
-                  $scope.error = "Issue saving rating";
+                .catch(function() {
+                  $scope.error = 'Issue saving rating';
                 });
             };
 
-            $scope.cancel = function () {
+            $scope.cancel = function() {
               $mdDialog.cancel();
             };
-
         }]);
   });

--- a/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/controllers.js
@@ -1,14 +1,13 @@
 'use strict';
 
 define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'], function(angular) {
-
-    var app = angular.module('my-app.search.controllers', ['portal.search.controllers', 'my-app.marketplace.controllers']);
-    app.controller('SearchController', [ 'marketplaceService', '$location', '$scope', '$localStorage', function(marketplaceService, $location, $scope, $localStorage) {
+    let app = angular.module('my-app.search.controllers', ['portal.search.controllers', 'my-app.marketplace.controllers']);
+    app.controller('SearchController', ['marketplaceService', '$location', '$scope', '$localStorage', function(marketplaceService, $location, $scope, $localStorage) {
         $scope.initialFilter = '';
         $scope.filterMatches = [];
         $scope.portletListLoading = true;
         if($localStorage && $localStorage.typeaheadSearch) {
-            marketplaceService.getPortlets().then(function(data){
+            marketplaceService.getPortlets().then(function(data) {
                 $scope.portlets = data.portlets;
                 $scope.portletListLoading = false;
             });
@@ -23,16 +22,16 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         });
 
         $scope.onSelect = function(portlet) {
-            $location.path("apps/details/"+ portlet.fname);
-            $scope.initialFilter = "";
+            $location.path('apps/details/'+ portlet.fname);
+            $scope.initialFilter = '';
             $scope.showSearch = false;
             $scope.showSearchFocus = false;
         };
 
-        $scope.submit = function(){
-            if($scope.initialFilter != "") {
-                $location.path("apps/search/"+ $scope.initialFilter);
-                $scope.initialFilter = "";
+        $scope.submit = function() {
+            if($scope.initialFilter != '') {
+                $location.path('apps/search/'+ $scope.initialFilter);
+                $scope.initialFilter = '';
                 $scope.showSearch = false;
                 $scope.showSearchFocus = false;
             }
@@ -40,19 +39,19 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
     }]);
 
     app.controller('SearchResultController',
-     ['$location', '$rootScope', '$scope', '$controller','marketplaceService', 'googleCustomSearchService', 'directorySearchService','PortalSearchService',
-     function($location, $rootScope, $scope, $controller,marketplaceService, googleCustomSearchService, directorySearchService, PortalSearchService) {
-      var base = $controller('marketplaceCommonFunctions', {$scope : $scope});
+     ['$location', '$rootScope', '$scope', '$controller', 'marketplaceService', 'googleCustomSearchService', 'directorySearchService', 'PortalSearchService',
+     function($location, $rootScope, $scope, $controller, marketplaceService, googleCustomSearchService, directorySearchService, PortalSearchService) {
+      let base = $controller('marketplaceCommonFunctions', {$scope: $scope});
 
-      var initWiscEduSearch = function(){
+      let initWiscEduSearch = function() {
         googleCustomSearchService.googleSearch($scope.searchTerm).then(
-          function(data){
+          function(data) {
             if(data && data.results) {
               $scope.googleResults = data.results;
-              if(data.estimatedResultCount){
+              if(data.estimatedResultCount) {
                 $scope.googleResultsEstimatedCount = data.estimatedResultCount;
               }
-              if(!data.estimatedResultCount || data.estimatedResultCount == 0){
+              if(!data.estimatedResultCount || data.estimatedResultCount == 0) {
                   $scope.googleEmptyResults = true;
               }
             }
@@ -60,38 +59,38 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         );
       };
 
-      var initDirectorySearch = function(){
+      let initDirectorySearch = function() {
         $scope.wiscDirectoryLoading = true;
         directorySearchService.directorySearch($scope.searchTerm).then(
-          function(results){
+          function(results) {
             $scope.wiscDirectoryLoading = false;
-            if(results){
+            if(results) {
               if(results.records && results.count) {
                 $scope.wiscDirectoryResults = results.records;
                 $scope.wiscDirectoryResultCount = results.count;
               } else {
                 $scope.wiscDirectoryResultsEmpty = true;
               }
-              if(results.errors && results.errors[0] && results.errors[0].code && results.errors[1] && results.errors[1].error_msg){
-                if(results.errors[0].code == 4){
+              if(results.errors && results.errors[0] && results.errors[0].code && results.errors[1] && results.errors[1].error_msg) {
+                if(results.errors[0].code == 4) {
                   $scope.wiscDirectoryTooManyResults = true;
                 }
                 $scope.wiscDirectoryErrorMessage= results.errors[1].error_msg;
               }
             }
-          }, function(){
+          }, function() {
             $scope.wiscDirectoryLoading = false;
             $scope.wiscDirectoryError = true;
           }
         );
       };
 
-      var initwiscDirectoryResultLimit = function(){
+      let initwiscDirectoryResultLimit = function() {
           $scope.wiscDirectoryResultLimit = 3;
       };
 
-      var init = function(){
-        $scope.sortParameter = ['-rating','-userRated'];
+      let init = function() {
+        $scope.sortParameter = ['-rating', '-userRated'];
         initwiscDirectoryResultLimit();
         $scope.myuwResults = [];
         $scope.googleResults = [];
@@ -106,42 +105,40 @@ define(['angular', 'portal/search/controllers', 'my-app/marketplace/controllers'
         $scope.searchResultLimit = 20;
         $scope.showAll = $rootScope.GuestMode || false;
         base.setupSearchTerm();
-        PortalSearchService.setQuery($scope.searchTerm); //in case the search field is not set for whatever reason, reset it
+        PortalSearchService.setQuery($scope.searchTerm); // in case the search field is not set for whatever reason, reset it
         base.initializeConstants();
-        //get marketplace entries
+        // get marketplace entries
         marketplaceService.getPortlets().then(function(data) {
             $scope.myuwResults = data.portlets;
         });
-        $scope.$watchGroup(['googleResultsEstimatedCount','myuwFilteredResults.length', 'wiscDirectoryResultCount'], function(){
+        $scope.$watchGroup(['googleResultsEstimatedCount', 'myuwFilteredResults.length', 'wiscDirectoryResultCount'], function() {
           $scope.totalCount = 0;
           if($scope.googleResultsEstimatedCount) {
             $scope.totalCount+= parseInt($scope.googleResultsEstimatedCount);
           }
-          if($scope.myuwFilteredResults){
+          if($scope.myuwFilteredResults) {
             $scope.totalCount+= parseInt($scope.myuwFilteredResults.length);
           }
-          if($scope.wiscDirectoryResultCount){
+          if($scope.wiscDirectoryResultCount) {
             $scope.totalCount+= parseInt($scope.wiscDirectoryResultCount);
           }
         });
       };
       init();
-      
-      googleCustomSearchService.googleSearchEnabled().then(function(googleSearchEnabled){
+
+      googleCustomSearchService.googleSearchEnabled().then(function(googleSearchEnabled) {
           $scope.googleSearchEnabled = googleSearchEnabled;
-          if(googleSearchEnabled){
+          if(googleSearchEnabled) {
               initWiscEduSearch();
           }
       });
-      directorySearchService.directorySearchEnabled().then(function(directoryEnabled){
+      directorySearchService.directorySearchEnabled().then(function(directoryEnabled) {
           $scope.directoryEnabled = directoryEnabled;
-          if(directoryEnabled){
+          if(directoryEnabled) {
               initDirectorySearch();
           }
       });
-      
     }]);
 
     return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/search/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/directives.js
@@ -1,30 +1,28 @@
 'use strict';
 
 define(['angular', 'require'], function(angular, require) {
-
-  var app = angular.module('my-app.search.directives', []);
+  let app = angular.module('my-app.search.directives', []);
 
   app.directive('marketplaceResults', function() {
     return {
-      restrict : 'E',
-      templateUrl : require.toUrl('./partials/marketplace-results.html')
-    }
+      restrict: 'E',
+      templateUrl: require.toUrl('./partials/marketplace-results.html'),
+    };
   });
 
   app.directive('directoryResults', function() {
     return {
-      restrict : 'E',
-      templateUrl : require.toUrl('./partials/directory-results.html')
-    }
+      restrict: 'E',
+      templateUrl: require.toUrl('./partials/directory-results.html'),
+    };
   });
 
   app.directive('campusDomainResults', function() {
     return {
-      restrict : 'E',
-      templateUrl : require.toUrl('./partials/campus-domain-results.html')
-    }
+      restrict: 'E',
+      templateUrl: require.toUrl('./partials/campus-domain-results.html'),
+    };
   });
 
   return app;
-
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/search/routes.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/routes.js
@@ -1,11 +1,9 @@
-define(['require'], function(require){
-
+define(['require'], function(require) {
     return {
         search: {
             templateUrl: require.toUrl('./partials/search-results.html'),
             controller: 'SearchResultController',
-            searchParam: 'initFilter'
-        }
-    }
-
+            searchParam: 'initFilter',
+        },
+    };
 });

--- a/angularjs-portal-home/src/main/webapp/my-app/search/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/services.js
@@ -1,213 +1,171 @@
 'use strict';
 
 define(['angular', 'jquery'], function(angular, $) {
+    let app = angular.module('my-app.search.services', []);
 
-    var app = angular.module('my-app.search.services', []);
-    
-    app.factory('googleCustomSearchService', ['$http', '$q', 'PortalGroupService', 'filterFilter', 'miscSearchService', 'miscService', 'SERVICE_LOC', 
-                                              function($http, $q, PortalGroupService, filterFilter, miscSearchService, miscService, SERVICE_LOC){
-        
-      var googleSearchURLPromise;
-      var googleSearchEnabledPromise;
-      var webSearchURLPromise;
-      var domainResultsLabelPromise;
-      
-      function getDomainResultsLabel(){
-        var successFn, errorFn;
-        if(domainResultsLabelPromise){
+    app.factory('googleCustomSearchService', ['$http', '$q', 'PortalGroupService', 'filterFilter', 'miscSearchService', 'miscService', 'SERVICE_LOC',
+                                              function($http, $q, PortalGroupService, filterFilter, miscSearchService, miscService, SERVICE_LOC) {
+      let googleSearchURLPromise;
+      let googleSearchEnabledPromise;
+      let webSearchURLPromise;
+      let domainResultsLabelPromise;
+
+      function getDomainResultsLabel() {
+        let successFn, errorFn;
+        if(domainResultsLabelPromise) {
           return domainResultsLabelPromise;
         }
-        successFn = function(groups){
-          return miscSearchService.getSearchURLS(groups).then(function(result){
-            if(result && result.domainResultsLabel){
+        successFn = function(groups) {
+          return miscSearchService.getSearchURLS(groups).then(function(result) {
+            if(result && result.domainResultsLabel) {
               return result.domainResultsLabel;
-            }
-            else{
+            }            else{
               return null;
             }
-          })
+          });
         };
-        errorFn = function(reason){
+        errorFn = function(reason) {
           miscService.redirectUser(reason.status, 'Could not get appropriate domain results label');
-        }
+        };
         domainResultsLabelPromise = PortalGroupService.getGroups().then(successFn, errorFn);
         return domainResultsLabelPromise;
       }
-      
+
       /**
        * Returns a public web search url. Useful for 'See more results here'
        */
-      function getPublicWebSearchURL(){
-          var successFn, errorFn;
-          if(webSearchURLPromise){
+      function getPublicWebSearchURL() {
+          let successFn, errorFn;
+          if(webSearchURLPromise) {
             return webSearchURLPromise;
           }
-          successFn = function(groups){
-            return miscSearchService.getSearchURLS(groups).then(function(result){
-              if(result && result.webSearchURL){
+          successFn = function(groups) {
+            return miscSearchService.getSearchURLS(groups).then(function(result) {
+              if(result && result.webSearchURL) {
                 return result.webSearchURL;
-              }
-              else{
+              }              else{
                 return null;
               }
-            })
+            });
           };
-          errorFn = function(reason){
+          errorFn = function(reason) {
             miscService.redirectUser(reason.status, 'Could not get appropriate public web search url');
-          }
+          };
           webSearchURLPromise = PortalGroupService.getGroups().then(successFn, errorFn);
           return webSearchURLPromise;
       }
-      
+
       function googleSearch(term) {
-        return getGoogleSearchURL().then(function(googleSearchURL){
-          return $q(function(resolve, reject){
-            if(googleSearchURL){
-              return $http.get(googleSearchURL + "&q=" + term).then(
-                function(response){
-                  var data = {
-                    results : null,
-                    estimatedResultCount : null
+        return getGoogleSearchURL().then(function(googleSearchURL) {
+          return $q(function(resolve, reject) {
+            if(googleSearchURL) {
+              return $http.get(googleSearchURL + '&q=' + term).then(
+                function(response) {
+                  let data = {
+                    results: null,
+                    estimatedResultCount: null,
                   };
-                  //Standardize data
-                  if(response.data){
-                    //Find the results
-                    if(response.data.results){ //uwrf
+                  // Standardize data
+                  if(response.data) {
+                    // Find the results
+                    if(response.data.results) { // uwrf
                         data.results = response.data.results;
-                    }else if(response.data.responseData && response.data.responseData.results){ //uwmad
+                    }else if(response.data.responseData && response.data.responseData.results) { // uwmad
                         data.results = response.data.responseData.results;
                     }
-                    //Find the estimated count
-                    if(response.data.cursor && response.data.cursor.estimatedResultCount){ //uwrf
+                    // Find the estimated count
+                    if(response.data.cursor && response.data.cursor.estimatedResultCount) { // uwrf
                         data.estimatedResultCount = response.data.cursor.estimatedResultCount;
-                    }else if(response.data.responseData && response.data.responseData.cursor && response.data.responseData.cursor.estimatedResultCount){ //uwmad
+                    }else if(response.data.responseData && response.data.responseData.cursor && response.data.responseData.cursor.estimatedResultCount) { // uwmad
                         data.estimatedResultCount = response.data.responseData.cursor.estimatedResultCount;
                     }
-                  
                   }
                   resolve(data);
                 }
               );
             }else{
-              reject("User has no group for google URL search");
+              reject('User has no group for google URL search');
             }
           });
         });
-      };
+      }
       
       /**
        * Returns a promise that will return a googleSearchURL if any exist
        * for a users group or null if one does not exists.
        */
       function getGoogleSearchURL() {
-        var successFn, errorFn;
-        
-        if(googleSearchURLPromise){
+        let successFn, errorFn;
+
+        if(googleSearchURLPromise) {
           return googleSearchURLPromise;
         }
-        
-        successFn = function(groups){
-          return miscSearchService.getSearchURLS(groups).then(function(result){
-            if(result && result.googleSearchURL){
+
+        successFn = function(groups) {
+          return miscSearchService.getSearchURLS(groups).then(function(result) {
+            if(result && result.googleSearchURL) {
               return result.googleSearchURL;
-            }
-            else{
+            }            else{
               return null;
             }
-          })
+          });
         };
-        
-        errorFn = function(reason){
+
+        errorFn = function(reason) {
           miscService.redirectUser(reason.status, 'Could not get appropriate google search url');
-        }
-        
+        };
+
         googleSearchURLPromise = PortalGroupService.getGroups().then(successFn, errorFn);
-        
+
         return googleSearchURLPromise;
       }
-      
+
       /**
        * Returns promise that will return true or false if there exists
        * a directorySearchURL for any of the users groups
        */
       function googleSearchEnabled() {
-        var successFn, errorFn;
-        
-        if(googleSearchEnabledPromise){
+        let successFn, errorFn;
+
+        if(googleSearchEnabledPromise) {
           return googleSearchEnabledPromise;
         }
-        
-        successFn = function(googleSearchURL){
-          if(googleSearchURL){
+
+        successFn = function(googleSearchURL) {
+          if(googleSearchURL) {
             return true;
           }else{
             return false;
           }
-        }
-        
-        errorFn = function(response){
-          console.log("error determing if google search is enabled: " +  response.status);
+        };
+
+        errorFn = function(response) {
+          console.log('error determing if google search is enabled: ' + response.status);
           return false;
-        }
-        
+        };
+
         googleSearchEnabledPromise = getGoogleSearchURL().then(successFn, errorFn);
         return googleSearchEnabledPromise;
-      };
+      }
       
       return {
-        googleSearch : googleSearch,
-        googleSearchEnabled : googleSearchEnabled,
-        getPublicWebSearchURL : getPublicWebSearchURL,
-        getDomainResultsLabel : getDomainResultsLabel
+        googleSearch: googleSearch,
+        googleSearchEnabled: googleSearchEnabled,
+        getPublicWebSearchURL: getPublicWebSearchURL,
+        getDomainResultsLabel: getDomainResultsLabel,
       };
     }]);
-    
-    app.factory('miscSearchService', ['$q', '$sessionStorage', 'PortalGroupService', 'filterFilter', 'SEARCH_CONFIG', 
-                                      function($q, $sessionStorage, PortalGroupService, filterFilter, SEARCH_CONFIG){
-      
-      function getKBSearchURL(){
+
+    app.factory('miscSearchService', ['$q', '$sessionStorage', 'PortalGroupService', 'filterFilter', 'SEARCH_CONFIG',
+                                      function($q, $sessionStorage, PortalGroupService, filterFilter, SEARCH_CONFIG) {
+      function getKBSearchURL() {
         return PortalGroupService.getGroups().then(
-          function(groups){
+          function(groups) {
             return getSearchURLS(groups).then(
-              function(result){
-                if(result && result.kbSearchURL){
+              function(result) {
+                if(result && result.kbSearchURL) {
                   return result.kbSearchURL;
-                }
-                else{
-                  return null;
-                }
-              }
-            );
-          }
-        );
-      }
-      
-      function getEventSearchURL(){
-        return PortalGroupService.getGroups().then(
-          function(groups){
-            return getSearchURLS(groups).then(
-              function(result){
-                if(result && result.eventsSearchURL){
-                  return result.eventsSearchURL;
-                }
-                else{
-                  return null;
-                }
-              }
-            );
-          }
-        );
-      }
-      
-      function getHelpDeskHelpURL(){
-        return PortalGroupService.getGroups().then(
-          function(groups){
-            return getSearchURLS(groups).then(
-              function(result){
-                if(result && result.helpdeskURL){
-                  return result.helpdeskURL;
-                }
-                else{
+                }                else{
                   return null;
                 }
               }
@@ -216,16 +174,48 @@ define(['angular', 'jquery'], function(angular, $) {
         );
       }
 
-      function getSearchURLS(groups){
+      function getEventSearchURL() {
+        return PortalGroupService.getGroups().then(
+          function(groups) {
+            return getSearchURLS(groups).then(
+              function(result) {
+                if(result && result.eventsSearchURL) {
+                  return result.eventsSearchURL;
+                }                else{
+                  return null;
+                }
+              }
+            );
+          }
+        );
+      }
+
+      function getHelpDeskHelpURL() {
+        return PortalGroupService.getGroups().then(
+          function(groups) {
+            return getSearchURLS(groups).then(
+              function(result) {
+                if(result && result.helpdeskURL) {
+                  return result.helpdeskURL;
+                }                else{
+                  return null;
+                }
+              }
+            );
+          }
+        );
+      }
+
+      function getSearchURLS(groups) {
         return $q(function(resolve, reject) {
-          if($sessionStorage.search){
+          if($sessionStorage.search) {
             resolve($sessionStorage.search);
           }
-          for(var i = 0; i < SEARCH_CONFIG.length; i++){
-            var searchURLS = SEARCH_CONFIG[i];
-            var searchGroup = searchURLS.group;
-            var filterTest = filterFilter(groups, {name: searchGroup});
-            if(filterTest && filterTest.length >0){
+          for(let i = 0; i < SEARCH_CONFIG.length; i++) {
+            let searchURLS = SEARCH_CONFIG[i];
+            let searchGroup = searchURLS.group;
+            let filterTest = filterFilter(groups, {name: searchGroup});
+            if(filterTest && filterTest.length >0) {
               $sessionStorage.search = searchURLS;
               resolve(searchURLS);
             }
@@ -233,106 +223,101 @@ define(['angular', 'jquery'], function(angular, $) {
           resolve(null);
         });
       }
-      
+
       return {
           getSearchURLS: getSearchURLS,
           getKBSearchURL: getKBSearchURL,
-          getEventSearchURL : getEventSearchURL,
-          getHelpDeskHelpURL : getHelpDeskHelpURL
+          getEventSearchURL: getEventSearchURL,
+          getHelpDeskHelpURL: getHelpDeskHelpURL,
       };
     }]);
-    
+
     app.factory('directorySearchService', [
-         '$http', '$q', 'PortalGroupService', 'miscSearchService', 'filterFilter', 'miscService', 
-         function($http, $q, PortalGroupService, miscSearchService, filterFilter, miscService){
-        
-        var directoryUrlPromise;
-        var directorySearchEnabledPromise;
-        
+         '$http', '$q', 'PortalGroupService', 'miscSearchService', 'filterFilter', 'miscService',
+         function($http, $q, PortalGroupService, miscSearchService, filterFilter, miscService) {
+        let directoryUrlPromise;
+        let directorySearchEnabledPromise;
+
         function directorySearch(term) {
-          return getDirectorySearchURL().then(function(searchDirectoryURL){
-            return $q(function(resolve, reject){
-              if(searchDirectoryURL){
-                return $http.get(searchDirectoryURL + "/?name=" + term).then(
-                  function(response){
+          return getDirectorySearchURL().then(function(searchDirectoryURL) {
+            return $q(function(resolve, reject) {
+              if(searchDirectoryURL) {
+                return $http.get(searchDirectoryURL + '/?name=' + term).then(
+                  function(response) {
                     return resolve(response.data);
                   },
-                  function(response){
-                    return reject("error searching the directory: " +  response.status);
+                  function(response) {
+                    return reject('error searching the directory: ' + response.status);
                   }
                 );
               }else{
-                return reject("User has no group for directory search");
+                return reject('User has no group for directory search');
               }
-            })
+            });
           });
-        };
+        }
         
         /**
          * Returns promise that will return true or false if there exists
          * a directorySearchURL for any of the users groups
          */
         function directorySearchEnabled() {
-            var successFn, errorFn;
-            
-            if(directorySearchEnabledPromise){
+            let successFn, errorFn;
+
+            if(directorySearchEnabledPromise) {
               return directorySearchEnabledPromise;
             }
-            
-            successFn = function(directoryURL){
-              if(directoryURL){
+
+            successFn = function(directoryURL) {
+              if(directoryURL) {
                 return true;
               }else{
                 return false;
               }
-            }
-            
-            errorFn = function(response){
-              console.log("error determing if directory search is enabled: " +  response.status);
+            };
+
+            errorFn = function(response) {
+              console.log('error determing if directory search is enabled: ' + response.status);
               return false;
-            }
-            
+            };
+
             directorySearchEnabledPromise = getDirectorySearchURL().then(successFn, errorFn);
             return directorySearchEnabledPromise;
         }
-        
+
         /**
          * Returns a promise that will return a directorySearchURL if any exist
          * for a users group or null if one does not exists.
          */
         function getDirectorySearchURL() {
-          var successFn, errorFn;
-          
-          if(directoryUrlPromise){
+          let successFn, errorFn;
+
+          if(directoryUrlPromise) {
             return directoryUrlPromise;
           }
-          
-          successFn = function(groups){
-            return miscSearchService.getSearchURLS(groups).then(function(result){
-                if(result && result.directorySearchURL){
+
+          successFn = function(groups) {
+            return miscSearchService.getSearchURLS(groups).then(function(result) {
+                if(result && result.directorySearchURL) {
                     return result.directorySearchURL;
-                }
-                else{
+                }                else{
                     return null;
                 }
-            })
+            });
           };
-          
-          errorFn = function(reason){
+
+          errorFn = function(reason) {
             miscService.redirectUser(reason.status, 'search directory url call');
-          }
-          
+          };
+
           directoryUrlPromise = PortalGroupService.getGroups().then(successFn, errorFn);
-          
+
           return directoryUrlPromise;
         }
-        
+
         return {
-          directorySearch : directorySearch,
-          directorySearchEnabled : directorySearchEnabled
+          directorySearch: directorySearch,
+          directorySearchEnabled: directorySearchEnabled,
         };
-        
-        
       }]);
-    
 });


### PR DESCRIPTION
:notebook: Note that the Google styleguide recommends some ES6 features be preferred over their ES5 counterparts.
If you do not want to drop ES5 support or add a transpiler [the ES6 rules](https://github.com/google/eslint-config-google/blob/master/index.js#L279-L315) should be disabled. :no_entry_sign: 