### PR TITLE
MUMUP-2895 fix missing ratings, and added some logic from MUMUP-2437…

### DIFF
--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -58,6 +58,10 @@
 
         .rating {
           margin-left: 0;
+          cursor: default;
+          [role="button"] {
+            cursor: default;
+          }
         }
 
         a.md-button:hover {
@@ -369,6 +373,10 @@
 
   .rating {
     margin-left: 0;
+    cursor: default;
+    [role="button"] {
+      cursor: default;
+    }
   }
 
   .desc-item {

--- a/angularjs-portal-home/src/main/webapp/css/marketplace.less
+++ b/angularjs-portal-home/src/main/webapp/css/marketplace.less
@@ -59,6 +59,7 @@
         .rating {
           margin-left: 0;
           cursor: default;
+
           [role="button"] {
             cursor: default;
           }
@@ -374,6 +375,7 @@
   .rating {
     margin-left: 0;
     cursor: default;
+
     [role="button"] {
       cursor: default;
     }

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -82,6 +82,10 @@
 
     .rating {
       margin-left: 20px;
+      cursor: default;
+      [role="button"] {
+        cursor: default;
+      }
     }
   }
 }

--- a/angularjs-portal-home/src/main/webapp/css/search-results.less
+++ b/angularjs-portal-home/src/main/webapp/css/search-results.less
@@ -83,6 +83,7 @@
     .rating {
       margin-left: 20px;
       cursor: default;
+
       [role="button"] {
         cursor: default;
       }

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -53,13 +53,13 @@
                     <div class="desc-item">
                         <h3 tabindex="0" class="md-title">Ratings</h3>
                         <span ng-if="$storage.linkRatingsApi">
-                            <rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
+                            <span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
 
                             ( <md-button ng-click="clickRatingReviewAdmin()">{{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span></md-button> )
 
                         </span>
                         <span ng-if="!$storage.linkRatingsApi">
-                            <rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
+                            <span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
                             ( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
                         </span>
                         <br>

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -61,7 +61,7 @@
 
   <!-- RATINGS ROW -->
 	<p>
-		<rating ng-model="portlet.rating" readonly="true" class="rating"></rating>
+		<span uib-rating ng-model="portlet.rating" read-only="true" class="rating"></span>
 		( {{::portlet.userRated}} rating<span ng-if="portlet.userRated !== 1">s</span> )
 	</p>
 

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/rating-review-admin.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/rating-review-admin.html
@@ -14,7 +14,7 @@
     <md-subheader style="background-color: #ccc;"><h3>Individual Ratings/Reviews</h3></md-subheader>
     <md-list-item class="md-4-line" ng-repeat="rating in ratings" ng-click="null">
       <div class="md-list-item-text" layout="column">
-        <h4><rating ng-model="rating.rating" readonly="true" class="rating"></rating></h4>
+        <h4><span uib-rating ng-model="rating.rating" read-only="true" class="rating"></span></h4>
         <p>{{rating.review}} <span ng-if="!rating.review" style='font-style: italic;'>No review given</span></p>
       </div>
     </md-list-item>

--- a/angularjs-portal-home/src/main/webapp/my-app/search/partials/marketplace-results.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/search/partials/marketplace-results.html
@@ -19,6 +19,6 @@
     </md-button>
     <span ng-if="portlet.canAdd && portlet.hasInLayout && !GuestMode" class="added"><i class="fa fa-check"></i> Added to home</span>
     <md-button class="md-default" aria-label="See more about {{portlet.title}}" ng-click='navToDetails(portlet, "Search")'>Details</md-button>
-    <span><rating ng-model="portlet.rating" readonly="true" class="rating"></rating></span>
+    <span><span uib-rating ng-if="portlet.userRating" ng-model="portlet.rating" read-only="true" class="rating"></span></span>
   </p>
 </div>


### PR DESCRIPTION
… to search results

The ratings went missing when we updated angular-ui-bootstrap.  This updates our code to use the new api.

I also added a ng-if on 0 ratings in search results.  Search results was the only instance that didn't explicitly say how many ratings there were.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
