### PR TITLE
MUMUP-2898 Adds compact mode back in

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/directives.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/directives.js
@@ -3,6 +3,14 @@
 define(['angular', 'require'], function(angular, require) {
     var app = angular.module('my-app.layout.directives', []);
 
+    // Compact Mode
+    app.directive('defaultCard', function() {
+      return {
+        restrict: 'E',
+        templateUrl: require.toUrl('./partials/default-card.html'),
+      };
+    });
+
     app.directive('portletIcon', function() {
         return {
             restrict: 'E',

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/default-card.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/default-card.html
@@ -1,0 +1,23 @@
+<md-card class="list-content" id="portlet-id-{{::portlet.nodeId}}">
+  <md-button class="widget-action widget-info md-icon-button" aria-label="see a brief description of this app">
+    <md-tooltip md-direction="top" class="widget-action-tooltip">
+      {{portlet.description}}
+    </md-tooltip>
+    <md-icon>info</md-icon>
+  </md-button>
+  <md-button class="widget-action widget-remove md-icon-button"
+             aria-label="remove {{ portlet.title }} widget from your home screen"
+             ng-click="layoutCtrl.removePortlet(portlet.nodeId, portlet.title)"
+             ng-hide="GuestMode || cantRemove">
+    <md-icon>close</md-icon>
+  </md-button>
+
+  <a aria-labelledby="appTitle_portlet.title-{{::portlet.nodeId}}" tabindex="0" ng-href="{{ layoutCtrl.renderURL(portlet) }}" target="{{::portlet.target}}">
+    <div class="icon-container">
+      <portlet-icon></portlet-icon>
+    </div>
+    <div class="list-item-container">
+      <h4 id="appTitle_portlet.title-{{::portlet.nodeId}}">{{ ::portlet.title }}</h4>
+    </div>
+  </a>
+</md-card>


### PR DESCRIPTION
I accidentally deleted the greatly named default-card.  Turns out that they're actually used for compact mode.  Added a comment.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
