### PR TITLE
Cache dependencies to reduce download time on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,3 +14,7 @@ script:
   - npm run lint-js
   - npm run lint-md
   - npm run lint-less
+cache:
+  directories:
+    - $HOME/.m2
+    - node_modules


### PR DESCRIPTION
One of the main remaining slow downs on Travis is download time of maven and npm dependencies.
This PR sets up [Travis CI caching](https://docs.travis-ci.com/user/caching/), which stores necessary files in an S3 bucket that is mounted at the start of each build.
Reducing time spent fetching files from maven central and the npm registry.

:notebook: initial PR will show a slower build time as the S3 cache is generated, future PRs and commits will show the speed up.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
