### PR TITLE
Acknowledge contributors

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,8 @@ This documentation describes [AngularJS-Portal](https://github.com/UW-Madison-Do
 
 [![Apereo Incubating badge](https://img.shields.io/badge/Apereo-Incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)
 
+Many [contributors](contributors.md) make this project possible.
+
 ## Features
 
 ### Home page

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,117 +1,20 @@
 This project gratefully acknowledges its contributors, including:
 
-<!-- using headings for accessibility; abusing h3s because bigger headings too ugly. It's a compromise. -->
-
-### Tim Levett ( @timlevett )
-
-+ Release engineering.
-+ Widget types, including RSS type.
-+ Configurability.
-+ Analytics.
-
-### Jared Hanstra ( @jhanstra )
-
-+ Responsive design.
-+ Accessibility.
-+ Widget types.
-+ Priority notifications.
-+ Pop-ups.
-+ Analytics.
-
-### Tim Vertein ( @vertein )
-
-+ Release engineering.
-+ Email, debit account balance widgets.
-+ Search.
-+ Layout, drag-and-drop.
-+ Configurability.
-+ Analytics.
-+ Dependency management.
-+ Bugfixes.
-
-### Andrew Petro ( @apetro )
-
-+ Release engineering.
-+ Apereo incubation.
-+ Accessibility.
-+ Documentation.
-+ Bugfixes.
-
-
-### Josh Helmer ( @jhelmer-unicon )
-
-+ Typeahead search proof-of-concept.
-
-### Ahad Zaman ( @Daha7 )
-
-+ Payroll Information widget.
-+ Configurability.
-+ Bugfixes.
-
-### Nick Blair ( @nblair )
-
-+ Build engineering
-+ Tweaks improving framework for building apps
-
-### Paul Erickson ( @paulerickson )
-
-+ Testing automation
-+ Dependency management
-+ Build engineering
-+ Bugfixes
-
-### Tim Zodrow:
-
-+ Tweaks to dependency and repository metadata.
-
-### Jianyi Liu ( @jiayinjx )
-
-+ Accessibility.
-+ Bugfixes.
-+ Loading indicator enhancements.
-
-
-### Doug Reed ( @Doug-Reed )
-
-+ RSS widget enhancements.
-+ Weather widget support for Kelvin
-+ Bugfixes.
-+ Error handling.
-
-### Kim Miller ( @kimmiller )
-
-+ Example announcement.
-
-### Zeke Witter ( @thevoiceofzeke )
-
-+ Widget maintenance mode.
-+ Accessibility.
-+ Code quality improvements.
-+ Refactoring.
-+ Documentation.
-+ Build engineering.
-+ Bugfixes.
-
-### Benito Gonzalez ( @bjagg )
-
-+ Tweaks to make the product work better with vanilla uPortal.
-
-### Jim Helwig ( @jimhelwig )
-
-+ Normalized Apereo incubating badge.
-
-### Christian Murphy ( @ChristianMurphy )
-
-+ Code quality improvements and automation.
-+ Build engineering.
-
-### David Sibley ( @davidmsibley )
-
-+ Code quality improvements and automation.
-+ Bugfixes
++ Tim Levett ( @timlevett )
++ Jared Hanstra ( @jhanstra )
++ Tim Vertein ( @vertein )
++ Andrew Petro ( @apetro )
++ Josh Helmer ( @jhelmer-unicon )
++ Ahad Zaman ( @Daha7 )
++ Nick Blair ( @nblair )
++ Paul Erickson ( @paulerickson )
++ Jianyi Liu ( @jiayinjx )
++ Doug Reed ( @Doug-Reed )
++ Kim Miller ( @kimmiller )
++ Zeke Witter ( @thevoiceofzeke )
++ Benito Gonzalez ( @bjagg )
++ Jim Helwig ( @jimhelwig )
++ Christian Murphy ( @ChristianMurphy )
++ David Sibley ( @davidmsibley )
 
 (Roughly in order of first contribution).
-
-(Acknowledgements above are intended to give the flavor of the contributions and are not all-including.)
-
-No doubt contributions, especially those other than direct source code submissions, have been overlooked in these acknowledgements. Contributions not acknowledged here are nonetheless appreciated (and please do suggest how these acknowledgements can be more complete.)

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -18,3 +18,7 @@ This project gratefully acknowledges its contributors, including:
 + David Sibley ( @davidmsibley )
 
 (Roughly in order of first contribution).
+
+(See also [GitHub's report on Contributors][]; ways of contributing that don't surface into GitHub reporting are also valued.)
+
+[GitHub's report on Contributors]: github.com/UW-Madison-DoIT/angularjs-portal/graphs/contributors

--- a/docs/contributors.md
+++ b/docs/contributors.md
@@ -1,0 +1,117 @@
+This project gratefully acknowledges its contributors, including:
+
+<!-- using headings for accessibility; abusing h3s because bigger headings too ugly. It's a compromise. -->
+
+### Tim Levett ( @timlevett )
+
++ Release engineering.
++ Widget types, including RSS type.
++ Configurability.
++ Analytics.
+
+### Jared Hanstra ( @jhanstra )
+
++ Responsive design.
++ Accessibility.
++ Widget types.
++ Priority notifications.
++ Pop-ups.
++ Analytics.
+
+### Tim Vertein ( @vertein )
+
++ Release engineering.
++ Email, debit account balance widgets.
++ Search.
++ Layout, drag-and-drop.
++ Configurability.
++ Analytics.
++ Dependency management.
++ Bugfixes.
+
+### Andrew Petro ( @apetro )
+
++ Release engineering.
++ Apereo incubation.
++ Accessibility.
++ Documentation.
++ Bugfixes.
+
+
+### Josh Helmer ( @jhelmer-unicon )
+
++ Typeahead search proof-of-concept.
+
+### Ahad Zaman ( @Daha7 )
+
++ Payroll Information widget.
++ Configurability.
++ Bugfixes.
+
+### Nick Blair ( @nblair )
+
++ Build engineering
++ Tweaks improving framework for building apps
+
+### Paul Erickson ( @paulerickson )
+
++ Testing automation
++ Dependency management
++ Build engineering
++ Bugfixes
+
+### Tim Zodrow:
+
++ Tweaks to dependency and repository metadata.
+
+### Jianyi Liu ( @jiayinjx )
+
++ Accessibility.
++ Bugfixes.
++ Loading indicator enhancements.
+
+
+### Doug Reed ( @Doug-Reed )
+
++ RSS widget enhancements.
++ Weather widget support for Kelvin
++ Bugfixes.
++ Error handling.
+
+### Kim Miller ( @kimmiller )
+
++ Example announcement.
+
+### Zeke Witter ( @thevoiceofzeke )
+
++ Widget maintenance mode.
++ Accessibility.
++ Code quality improvements.
++ Refactoring.
++ Documentation.
++ Build engineering.
++ Bugfixes.
+
+### Benito Gonzalez ( @bjagg )
+
++ Tweaks to make the product work better with vanilla uPortal.
+
+### Jim Helwig ( @jimhelwig )
+
++ Normalized Apereo incubating badge.
+
+### Christian Murphy ( @ChristianMurphy )
+
++ Code quality improvements and automation.
++ Build engineering.
+
+### David Sibley ( @davidmsibley )
+
++ Code quality improvements and automation.
++ Bugfixes
+
+(Roughly in order of first contribution).
+
+(Acknowledgements above are intended to give the flavor of the contributions and are not all-including.)
+
+No doubt contributions, especially those other than direct source code submissions, have been overlooked in these acknowledgements. Contributions not acknowledged here are nonetheless appreciated (and please do suggest how these acknowledgements can be more complete.)


### PR DESCRIPTION
Add docs page gratefully acknowledging the contributors.

Initial draft had more detail, but after reflecting on [the page on credit in Producing Open Source Software](http://producingoss.com/en/credit.html), pivoted to minimalist.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
