### PR TITLE
Clarify releasing under Apache rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Portal with Angular
+# uPortal-home
 
 [![Join the chat at https://gitter.im/UW-Madison-DoIT/angularjs-portal](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/UW-Madison-DoIT/angularjs-portal?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Build Status](https://travis-ci.org/UW-Madison-DoIT/angularjs-portal.svg)](https://travis-ci.org/UW-Madison-DoIT/angularjs-portal)
@@ -10,6 +10,8 @@
 
 ### What is this?
 This is an Angular approach to the dashboard view of uPortal. This dashboard will work along side uPortal, more of a companion app. It utilizes the uPortal rest APIs to collect layout info. It pulls notifications from the notification portlet resource URL.
+
+"uPortal-home" is somewhere in the process of a name change from its old name, "AngularJS-Portal".
 
 See [this project's documentation](http://uw-madison-doit.github.io/angularjs-portal/).
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,11 @@
 [![Coverage Status](https://coveralls.io/repos/UW-Madison-DoIT/angularjs-portal/badge.svg?branch=master&service=github)](https://coveralls.io/github/UW-Madison-DoIT/angularjs-portal?branch=master)
 [![Code Climate](https://codeclimate.com/github/UW-Madison-DoIT/angularjs-portal/badges/gpa.svg)](https://codeclimate.com/github/UW-Madison-DoIT/angularjs-portal)
 [![codeclimate.com Issue Count](https://codeclimate.com/github/UW-Madison-DoIT/angularjs-portal/badges/issue_count.svg)](https://codeclimate.com/github/UW-Madison-DoIT/angularjs-portal)
-[![Apereo Incubating badge](https://img.shields.io/badge/apereo-incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)
 [![uPortal ecosystem incubating badge](https://img.shields.io/badge/uPortal%20ecosystem-incubating-blue.svg)](http://uw-madison-doit.github.io/angularjs-portal/apereo-incubation.html)
+
+
+[![Apereo Incubating badge](https://www.apereo.org/sites/default/files/Incubation%20Logos/incubating%20w-out%20logo%2015mar17.png)](https://www.apereo.org/content/projects-currently-incubation)
+
 
 ### What is this?
 This is an Angular approach to the dashboard view of uPortal. This dashboard will work along side uPortal, more of a companion app. It utilizes the uPortal rest APIs to collect layout info. It pulls notifications from the notification portlet resource URL.

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@ This documentation describes [AngularJS-Portal](https://github.com/UW-Madison-Do
 
 [AngularJS-Portal is an Apereo Incubating project](apereo-incubation.md) in the uPortal ecosystem.
 
-[![Apereo Incubating badge](https://img.shields.io/badge/Apereo-Incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)
+[![Apereo Incubating badge](https://www.apereo.org/sites/default/files/Incubation%20Logos/incubating%20w%20logo%2015MAR17.png)](https://www.apereo.org/content/projects-currently-incubation)
 
 Many [contributors](contributors.md) make this project possible.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,5 +40,9 @@ Search app directory entries, the web (with Google Custom Search integration), o
 ## Integration with uPortal
 + [Silent Login Configuration](silent-login.md)
 
+## Developing
+
++ [On releasing](releasing.md)
+
 
 [uPortal]: http://jasig.github.io/uPortal/

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -43,7 +43,6 @@ Most major contributors have ICLAs on file.
 Next actions:
 
 + Audit for CLA completeness of contributors
-+ Document CLA requirements in `CONTRIBUTING.md`
 + Potentially implement cla-assistant.io with the wrinkle of it asking contributors to attest to their compliance with the external-to-CLA-assistant CLA agreement process. (Click-through assurance that demonstrated CLA agreement through more arduous process, not click-through agreement to CLA.)
 
 #### 4.1.4 Name trademark clarity

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -42,7 +42,7 @@ Most major contributors have ICLAs on file.
 
 Next actions:
 
-+ Audit for CLA completeness of contributors
++ Follow up with past Contributors to secure CLAs
 + Potentially implement cla-assistant.io with the wrinkle of it asking contributors to attest to their compliance with the external-to-CLA-assistant CLA agreement process. (Click-through assurance that demonstrated CLA agreement through more arduous process, not click-through agreement to CLA.)
 
 #### 4.1.4 Name trademark clarity

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -2,7 +2,7 @@
 
 AngularJS-portal [is presently][Apereo projects currently in incubation] in [Apereo Incubation][], aspiring to be an [Apereo][] project in the [uPortal][] ecosystem.
 
-[![Apereo Incubating badge](https://img.shields.io/badge/apereo-incubating-blue.svg)](https://www.apereo.org/content/projects-currently-incubation)
+[![Apereo Incubating badge](https://www.apereo.org/sites/default/files/Incubation%20Logos/incubating%20w-out%20logo%2015mar17.png)](https://www.apereo.org/content/projects-currently-incubation)
 
 + Incubation requested: [2016-11-21][incubation@ proposal]
 + Apereo Board approved for incubation: [2016-12-20][2016-12-20 Apereo Board meeting minutes]

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -7,6 +7,8 @@ AngularJS-portal [is presently][Apereo projects currently in incubation] in [Ape
 + Incubation requested: [2016-11-21][incubation@ proposal]
 + Apereo Board approved for incubation: [2016-12-20][2016-12-20 Apereo Board meeting minutes]
 + Entered incubation (initial conference call): 2017-03-13.
++ Subsequent check-in calls: [2017-04-10][2017-04-10 incubation status call], [2017-05-25 at 10a NYC (scheduled)][2017-04-10 incubation status call].
+
 
 ## Project status vis a vis exit criteria
 
@@ -198,4 +200,5 @@ Next actions:
 [uPortal]: https://www.apereo.org/projects/uportal
 [incubation@ proposal]: https://groups.google.com/a/apereo.org/d/msg/incubation/tPBN3-YSSPM/Xk4yghH1AwAJ
 [2016-12-20 Apereo Board meeting minutes]: https://www.apereo.org/sites/default/files/meeting_minutes/2016/Apereo%20Board%20Minutes%20-%20Dec%202016%20-%20002.pdf
+[2017-04-10 incubation status call]: https://groups.google.com/a/apereo.org/d/msg/uportal-user/rN76LaT-VGQ/dikxNY9wAQAJ
 [exit criteria]: https://www.apereo.org/content/apereo-incubation-process#S4

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,13 @@
+# Releasing uPortal-home
+
+## Apache release rules
+
+This project has [adopted Apache rules][] with necessary or pragmatic local adaptations.
+
+Release authorization, or the delegation of release authority to one or more release engineers, should be documented by [a suitable vote][Apache Release Policy re Release Approval] of [the uPortal-home Committers][] on [uportal-dev@][].
+
+
+[adopted Apache rules]: https://github.com/UW-Madison-DoIT/angularjs-portal/blob/master/committers.md#rules
+[Apache Release Policy re Release Approval]: http://www.apache.org/legal/release-policy.html#release-approval
+[the uPortal-home Committers]: https://github.com/UW-Madison-DoIT/angularjs-portal/blob/master/committers.md#who-are-the-committers
+[uportal-dev@]: https://groups.google.com/a/apereo.org/forum/#!forum/uportal-dev


### PR DESCRIPTION
**This is nuanced and is going to need Committer follow-up on `uportal-dev@` after merge.**

+ Adds releasing page, noting that we've adopted Apache rules and linking them for releases.
+ Raises awareness of in-progress project name change.
+ Tweaks Apereo Incubation badge to [the new preferred badge implementation](https://groups.google.com/a/apereo.org/d/msg/incubation/p2h2ypnATO0/vsv9zzx9EQAJ).

*Not* my intention: add a lot of painful friction to releasing.

My intention: more open source project "legitimacy" through following the process and policies we are trying to adopt.

So, specifically, what I think needs to happen is:

+ In general, more talking about `uPortal-home` release engineering on `uportal-dev@`.
+ In specific, a vote of the Committers authorizing at least @vertein and perhaps all Committers to execute releases as needed using their best judgement. We're not yet ready for a PMC vote with 72 hours to gel for every release. And that rigor is not yet justified. The Committers explicitly authorizing release engineers lends legitimacy to the thing we've actually been doing and realistically will continue to do for now. 
+ Openness to revisiting this to be less wild west about releasing when more care becomes more feasible and more justified.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
