### PR TITLE
Document implementing with vanilla uPortal master

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,27 +32,8 @@ This file contains your server side proxy configurations. See the example file f
 + run `mvn clean package` from the root directory to build the war files.
 
 #### Building, Deploying, and Running with [Apereo uPortal](https://github.com/Jasig/uPortal)
-+ Download, build, and run uPortal on your server
-+ Setup [autodeploy](https://github.com/UW-Madison-DoIT/angularjs-portal/blob/master/README.md#deploying-to-a-running-local-tomcat)
-+ cd to angularjs-portal root directory
-+ Unix based systems, run : `./build.sh master`
-+ Windows based systems, run :
-```
-copy angularjs-portal-home/src/main/webapp/js/app-config.js angularjs-portal-home/src/main/webapp/js/app-config.js.bak
-copy angularjs-portal-home/src/main/webapp/js/master-app-config.js angularjs-portal-home/src/main/webapp/js/app-config.js
-mvn package
-cd angularjs-portal-home
-mvn tomcat7:deploy  #or redeploy depending if this is a consecutive run
-```
-+ navigate to localhost:8080/uPortal
-+ Login via any user that has access to the Welcome Tab in uPortal.  If you want to use admin, you have to comment out the admin restricting part in the [welcome tab layout](https://github.com/Jasig/uPortal/blob/master/uportal-war/src/main/data/quickstart_entities/fragment-layout/welcome-lo.fragment-layout.xml)
-+ navigate to localhost:8080/web
 
-Angularjs-portal is a different front end than the one supplied with [Apereo uPortal](https://github.com/Jasig/uPortal).
-As of now, portlet rendering still takes place via uPortal's rendering pipeline.
-The [theming] (http://uw-madison-doit.github.io/uw-frame/latest/#/md/theming) comes from the [uw-frame dependency](https://github.com/UW-Madison-DoIT/uw-frame).
-
-University of Wisconsin styles the portal theme to look similar for a seamless transition between this webapp and the portal webapp.
+See [documentation site][GitHub Pages site].
 
 ### Modules
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ This is an Angular approach to the dashboard view of uPortal. This dashboard wil
 
 "uPortal-home" is somewhere in the process of a name change from its old name, "AngularJS-Portal".
 
-See [this project's documentation](http://uw-madison-doit.github.io/angularjs-portal/).
+See [this project's documentation][GitHub Pages site].
 
 #### Resources for understanding what you can do with `angularjs-portal`:
 
@@ -97,3 +97,5 @@ Drop angularjs-portal-home/target/web.war in the Tomcat instance that runs uPort
 
 [MyUW Overview slide deck]: http://go.wisc.edu/qwg5r1
 [Tomcat docs re Maven plugin]: http://tomcat.apache.org/maven-plugin-2.0/tomcat7-maven-plugin/plugin-info.html
+
+[GitHub Pages site]: http://uw-madison-doit.github.io/angularjs-portal/

--- a/angularjs-portal-home/src/main/webapp/js/README.md
+++ b/angularjs-portal-home/src/main/webapp/js/README.md
@@ -1,0 +1,20 @@
+# What are these files?
+
+(This is not comprehensive documentation on how to configure AngularJS-portal -- see the documentation site both for this project and [for the `uw-frame` project][uw-frame configuration docs] it overlays upon. Rather, this is directory-local reminder of what these files are.)
+
+## `override.js`
+
+Configuration of the uPortal-app-framework aka `uw-frame` for use in this application. `uPortal-home` is itself a uPortal-app-framework application so it needs to configure the framework same as other applications and it additionally configures some home-specific stuff. The out of the box version of `override.js` should work for localhost development.
+
+## `master-override.js`
+This file doesn't itself do anything. It's just an example. It's the configuration that you'd put in `override.js` to configure for use with vanilla uPortal.
+
+## `web-config.js`
+
+uPortal-home configuration about being uPortal-home (rather than the `override.js` about being a uPortal-app-framework app.)
+
+## `login-config.js`
+
+Configuration specific to `uPortal-home` delegating to uPortal for user login. See [documentation](http://uw-madison-doit.github.io/angularjs-portal/silent-login.html).
+
+[uw-frame configuration docs]: http://uw-madison-doit.github.io/uw-frame/configuration.html

--- a/angularjs-portal-home/src/main/webapp/js/master-override.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-override.js
@@ -1,8 +1,7 @@
 define(['angular'], function(angular) {
-  /* Keep in sync with docs/markdown/configuration.md*/
 
   return angular.module('override', [])
-        // see configuration.md for howto
+
         .constant('OVERRIDE', {
           'APP_FLAGS': {
             'enableToggle': true,

--- a/angularjs-portal-home/src/main/webapp/js/master-override.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-override.js
@@ -21,7 +21,7 @@ define(['angular'], function(angular) {
             'newstuffInfo': '/web/staticFeeds/new-stuff.json',
             'context': '/uPortal/',
             'base': '/uPortal/api/',
-            'layout': 'layout.json',
+            'layout': 'api/v4-3/dlm/layout.json',
             'layoutTab': 'Welcome',
             'marketplace': {
                 'base': 'marketplace/',

--- a/angularjs-portal-home/src/main/webapp/js/master-override.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-override.js
@@ -28,6 +28,11 @@ define(['angular'], function(angular) {
                 'entry': 'entry/',
                 'entries': 'entries.json',
             },
+            'widgetApi': {
+              'entry': '/uPortal/api/marketplace/entry/',
+              'entrySuffix': '.json',
+              'entries': '/uPortal/api/marketplace/entries.json',
+            },
             'notificationsURL': '/web/staticFeeds/notifications.json',
             'groupURL': '/uPortal/api/groups',
             'kvURL': null,

--- a/angularjs-portal-home/src/main/webapp/js/master-override.js
+++ b/angularjs-portal-home/src/main/webapp/js/master-override.js
@@ -1,7 +1,5 @@
 define(['angular'], function(angular) {
-
   return angular.module('override', [])
-
         .constant('OVERRIDE', {
           'APP_FLAGS': {
             'enableToggle': true,

--- a/angularjs-portal-home/src/main/webapp/js/override.js
+++ b/angularjs-portal-home/src/main/webapp/js/override.js
@@ -1,8 +1,5 @@
 define(['angular'], function(angular) {
-  /* Keep in sync with docs/markdown/configuration.md*/
-
   return angular.module('override', [])
-        // see configuration.md for howto
         .constant('OVERRIDE', {
           'APP_FLAGS': {
             'enableToggle': true,

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -124,6 +124,7 @@ define(['angular', 'jquery'], function(angular, $) {
           } else if ($.isArray(data.layout)) { // layoutDoc
             result.layout = data.layout;
           }
+
           return result;
         };
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,12 @@ This documentation describes [AngularJS-Portal](https://github.com/UW-Madison-Do
 
 Many [contributors](contributors.md) make this project possible.
 
+## Demoing and implementing
+
+You can partially demonstrate `uPortal-home` without a backing server, using provided stub example data. See the root `README.md` for how; start with that simplest possible local demo.
+
+Of course for a more sophisticated demo or to adopt for real you will need to [configure your `uPortal-home` to work with a `uPortal` instance](with-uportal.md).
+
 ## Features
 
 ### Home page

--- a/docs/with-uportal.md
+++ b/docs/with-uportal.md
@@ -148,14 +148,16 @@ Tada! It'll render the `uPortal-home` home page with some widgets on it.
 
 ## Portlet registry as app directory
 
-
+TODO.
 
 ## Widgets as portlet-definition metadata
 
-
+TODO.
 
 ## uPortal-home and Portlets
 
-
+TODO.
 
 ## Redirecting from uPortal to uPortal-home
+
+TODO.

--- a/docs/with-uportal.md
+++ b/docs/with-uportal.md
@@ -1,0 +1,300 @@
+# uPortal-home and uPortal
+
+`uPortal-home` is an alternative user experience layer for use with `uPortal`. `uPortal-home` is entirely static front end HTML/CSS/JavaScript for users to exercise in their web browsers. To be interesting, it needs to connect up with services provided by server-side components, including those in `uPortal`.
+
+This documentation is about how to use `uPortal-home` with `uPortal`.
+
+The uPortal project is an ecosystem of open source software products, communities, participants, and adopters. `uPortal-home` is one organism in this wider ecosystem.
+
+## uPortal?
+
+uPortal a software product implementing the server-side portions of an enterprise portal, with facilities for user authentication, user attribute gathering, groups and permissions, user layouts, content directory modeling, containing JSR-286 Portlets, and administrative functions over all of this.
+
+## Getting uPortal
+
+Clone the uPortal Git repository. This will get you the latest `master` branch code, which is the bleeding edge code that will eventually become a uPortal 5.0.0 release.
+
+## Basic localhost demonstration
+
+### The server: uPortal
+
+uPortal itself should provide great documentation about how to obtain, install, implement it.
+
+Here are some crib notes for spinning up a local demo environment:
+
+Have a Tomcat Java Servlet Container. Tomcat should provide great documentation about... but the short version is download it, unzip it. Version `8.5.15` worked for me.
+
+You'll have to configure Tomcat a bit to uPortal's needs:
+
+In `catalina.properties`:
+
+```
+shared.loader=${catalina.base}/shared/lib/*.jar
+```
+
+In `context.xml`, add the `sessionCookiePath` attribute to the `Context` element, with value `"/"`.
+
+```xml
+<Context sessionCookiePath="/">
+```
+
+and add a `Resources` element to increase Tomcat's cache size to accommodate uPortal's bulk:
+
+```xml
+  <Resources cachingAllowed="true" cacheMaxSize="100000" />
+</Context>
+```
+
+Configure uPortal `build.properties` to know where your Tomcat is.
+
+You're going to need a couple terminals:
+
+In one terminal, in the root directory of your checked out uPortal codebase, run an HSQL server so that uPortal has a database to depend upon.
+
+```
+ant hsql
+```
+
+In another terminal, in that same root directory of your checked out uPortal codebase, initialize your uPortal.
+
+```shell
+ant initportal
+```
+
+After it downloads dependencies, builds, and deploys to Tomcat, in a third terminal or so start Tomcat.
+
+Check it out: at `http://localhost:8080/uPortal` you've got a uPortal.
+
+### The client: `uPortal-home`
+
+Now that you've got uPortal running, go ahead and stop Tomcat again.
+
+Configure for operation against a localhost uPortal: in source `angularjs-portal-home/src/main/webapp/js/`, replace the contents of  `override.js` with the contents of `master-override.js`.
+
+Build `uPortal-home` to a .war file with
+
+```shell
+mvn clean package
+```
+
+
+Drop `angularjs-portal-home/target/web.war` in the Tomcat instance that runs uPortal and fire it up. Should just work.
+
+
+
+
+## Portlet registry as app directory
+
+
+
+## Widgets as portlet-definition metadata
+
+
+
+## uPortal-home and Portlets
+
+
+
+## Redirecting from uPortal to uPortal-home
+
+AngularJS-portal [is presently][Apereo projects currently in incubation] in [Apereo Incubation][], aspiring to be an [Apereo][] project in the [uPortal][] ecosystem.
+
+[![Apereo Incubating badge](https://www.apereo.org/sites/default/files/Incubation%20Logos/incubating%20w-out%20logo%2015mar17.png)](https://www.apereo.org/content/projects-currently-incubation)
+
++ Incubation requested: [2016-11-21][incubation@ proposal]
++ Apereo Board approved for incubation: [2016-12-20][2016-12-20 Apereo Board meeting minutes]
++ Entered incubation (initial conference call): 2017-03-13.
++ Subsequent check-in calls: [2017-04-10][2017-04-10 incubation status call], [2017-05-25 at 10a NYC (scheduled)][2017-04-10 incubation status call].
+
+
+## Project status vis a vis exit criteria
+
+(See [exit criteria][]).
+
+### 4.1 Legal
+
+#### 4.1.1 Out-bound licensing
+
+AngularJS-portal and uw-frame include the Apache 2 license (approved for Apereo outbound) as LICENSE, but do not include the NOTICE file intended for inclusion with Apache2-licensed products.
+
+Next actions:
+
++ Add `NOTICE` file. (Requires some auditing to get its contents correct).
+
+#### 4.1.2 License marking
+
++ Partial but not verified-complete license marking.
++ Poor acknowledgement of dependency or inclusion licensing.
+
+Next actions:
+
++ Clean up marking source code with license
++ Automate source code header checking
++ Add NOTICE file. Audit inclusions and dependencies to get its contents right.
++ Automate `NOTICE` file checking
+
+#### 4.1.3 Contributor License Agreements
+
+Most major contributors have ICLAs on file.
+
+Next actions:
+
++ Follow up with past Contributors to secure CLAs
++ Potentially implement cla-assistant.io with the wrinkle of it asking contributors to attest to their compliance with the external-to-CLA-assistant CLA agreement process. (Click-through assurance that demonstrated CLA agreement through more arduous process, not click-through agreement to CLA.)
+
+#### 4.1.4 Name trademark clarity
+
+Next actions:
+
++ New software product names that better reflect nature and do not infringe on others' trademarks.
++ Names should reflect uPortal commitment and represent how the product should
+be used.
++ Proposed names:
+  + `uw-frame` → `uPortal-app-framework`
+    + The uPortal App Framework will house common functionality to be leveraged
+      by uPortal Apps.
+    + Institutions can provide a custom `uPortal-app-framework-config`
+    + Developers can create their own uPortal Apps drawing from common
+      configuration, style and functionality.
+  + `angularjs-portal` → `uPortal-home`
+    + uPortal Home will be a standard uPortal App that handles layout of the
+      framework widgets for a cohesive user experience.
+    + Developers provide `uPortal-home-config` for environment specific
+      configuration.
+
+### 4.2 Community
+
+#### a. Level of community involvement
+
+> What is the number of participants? What level of participation is there? What activities do participants undertake or what artifacts have they created?)
+
+
+Next actions:
+
++ Open, public incubation status check-in conference call.
++ Move GitHub repositories to a uPortal-project context
+
+#### b. Organization of community
+
+> What roles are in place? Who occupies those roles? How do those roles interact among one another and with the community?
+
+Next actions:
+
++ Re-commit to using Gitter.im for chat.
+
+#### c. Operation of community
+
+> What activities/events/artifacts are created/managed by the project to foster participation and development? How are decisions made?
+
+Next actions:
+
++ Formalize recognition of committership
++ Pre-conference seminar and presentations at Open Apereo 2017.
+
+### 4.3 Governance
+
+No formal governance is documented.
+
+Next actions:
+
++ Formalize recognition of committership
++ Formalize relationship of committership with uPortal-steering
+
+### 4.4 Voting practices
+
+No formal voting practices are documented.
+
+Next actions:
+
++ Formalize adoption of Apache rules
+
+### 4.5 Conflict resolution policy
+
+No formal conflict resolution policy is in place.
+
+Next actions:
+
++ Adopt a conflict resolution policy (or inherit from uPortal)
+
+### 4.6 Release planning
+
+Releases come together organically. They're simply the changes from the accepted Pull Requests since the prior release, with Semantic Versioning observed.
+
+Next actions:
+
++ Further document release planning, beyond just release execution.
++ Further document adoption of Semantic Versioning.
++ Start looking a few more milestones out
++ Consider adopting a predictable release cadence
+
+### 4.7 Successful release during Incubation
+
+AngularJS-portal has had many releases.
+
+Let's say Incubation starts for this purpose after governance and licensing is squared and the repos are moved to a uPortal-project context. Successfully releasing after those changes are in place will demonstrate that the product can still release under the new arrangements.
+
+### 4.8 Alignment and synergy with other Apereo software products
+
+Depends on and leverages uPortal.
+
+Aspires to depend on and leverage more feasible microservices and hopes to evolve with uPortal itself in this direction.
+
+Next actions:
+
++ Factor out app directory as a microservice
++ Factor out user layout as a microservice
+
+### 4.9 Infrastructure
+
+#### a. Version control
+
+Using GitHub repositories.
+
+Next actions:
+
++ Move GitHub repositories to a non-UW-Madison-specific organizational context.
+
+#### b. Issue tracking
+
+Intend to use GitHub issue tracking for product issue tracking.
+
+Next actions:
+
++ Use GitHub issue tracking for product management in earnest. (This subset of) MyUW Scrum team user stories become references to public issue tracker issues.
+
+#### c. Communications channels
+
+Currently piggyback on uPortal email lists, only somewhat effectively.
+
+Next actions:
+
++ Use Incubation check-in meetings, making these open meetings and drawing in would-be participants.
++ Re-commit to using Gitter for project chat.
++ Consider advocating for an Apereo Discourse instance and adopt Discourse forums in lieu of traditional email list.
++ Consider how to better fit into existing uPortal email lists, or create new lists.
+
+#### d. Plans, directions, and objectives are readily identifiable
+
+Long range plans don't so much exist.
+
+Next actions:
+
++ Articulate product plans, directions, objectives
++ Navigate tension between product roadmapping and agile, organic discovery of product progress
+
+#### e. Website: current and with instructions for installation, configuration
+
+Both AngularJS-portal and uw-frame use GitHub Pages to generate documentation websites, including installation and configuration instructions. Documentation of the uPortal integration specifically is weak.
+
+Next actions:
+
++ Improve documentation helping with, no seriously, how do I adopt this with a vanilla uPortal
+
+[Apereo]: https://www.apereo.org/
+[Apereo Incubation]: https://www.apereo.org/incubation
+[Apereo projects currently in incubation]: https://www.apereo.org/content/projects-currently-incubation
+[uPortal]: https://www.apereo.org/projects/uportal
+[incubation@ proposal]: https://groups.google.com/a/apereo.org/d/msg/incubation/tPBN3-YSSPM/Xk4yghH1AwAJ
+[2016-12-20 Apereo Board meeting minutes]: https://www.apereo.org/sites/default/files/meeting_minutes/2016/Apereo%20Board%20Minutes%20-%20Dec%202016%20-%20002.pdf
+[2017-04-10 incubation status call]: https://groups.google.com/a/apereo.org/d/msg/uportal-user/rN76LaT-VGQ/dikxNY9wAQAJ
+[exit criteria]: https://www.apereo.org/content/apereo-incubation-process#S4

--- a/docs/with-uportal.md
+++ b/docs/with-uportal.md
@@ -16,15 +16,41 @@ Clone the uPortal Git repository. This will get you the latest `master` branch c
 
 ## Basic localhost demonstration
 
-### The server: uPortal
+### Tomcat
 
-uPortal itself should provide great documentation about how to obtain, install, implement it.
+You'll need a Servlet container to run uPortal. Because of uPortal's portlet container, that Servlet container probably needs to be Tomcat. Since you'll have a Tomcat anyway, we'll use that to serve up `uPortal-home` too.
 
-Here are some crib notes for spinning up a local demo environment:
-
-Have a Tomcat Java Servlet Container. Tomcat should provide great documentation about... but the short version is download it, unzip it. Version `8.5.15` worked for me.
+So download a Tomcat distribution. Version `8.5.15` worked for me.
 
 You'll have to configure Tomcat a bit to uPortal's needs:
+
+#### Aside: Maybe fixing a glitch in Tomcat 8.5
+
+I found the out of the box Tomcat 8.5.15 unstable, and that changing the connector implementation fixed the glitch.  You may not have this problem and not need to do this.
+
+In `server.xml`, change the `protocol` of the `Connector` to `org.apache.coyote.http11.Http11Nio2Protocol`.
+
+Before:
+
+```xml
+<Connector port="8080" protocol="HTTP/1.1"
+           connectionTimeout="20000"
+           redirectPort="8443" />
+
+```
+
+After:
+
+```xml
+<!-- <Connector port="8080" protocol="HTTP/1.1" -->
+<Connector port="8080" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+           connectionTimeout="20000"
+           redirectPort="8443" />
+```
+
+#### Configure shared loader
+
+uPortal needs to share libraries across webapps for its Portlet container to work.
 
 In `catalina.properties`:
 
@@ -32,22 +58,35 @@ In `catalina.properties`:
 shared.loader=${catalina.base}/shared/lib/*.jar
 ```
 
+##### Configure shared session cookies
+
 In `context.xml`, add the `sessionCookiePath` attribute to the `Context` element, with value `"/"`.
 
 ```xml
 <Context sessionCookiePath="/">
 ```
 
-and add a `Resources` element to increase Tomcat's cache size to accommodate uPortal's bulk:
+#### Configure bigger cache size
+
+Add a `Resources` element to increase Tomcat's cache size to accommodate uPortal's bulk:
 
 ```xml
   <Resources cachingAllowed="true" cacheMaxSize="100000" />
 </Context>
 ```
 
+#### Tell uPortal source where Tomcat is
+
 Configure uPortal `build.properties` to know where your Tomcat is.
 
+
+
+
+### The server: uPortal
+
 You're going to need a couple terminals:
+
+#### Run the HSQL database for uPortal
 
 In one terminal, in the root directory of your checked out uPortal codebase, run an HSQL server so that uPortal has a database to depend upon.
 
@@ -55,15 +94,21 @@ In one terminal, in the root directory of your checked out uPortal codebase, run
 ant hsql
 ```
 
+#### initportal
+
+WARNING: `initportal` is destructive, to data in the configured database and to deployed web applications in the configured Tomcat. Only `initportal` in contexts where you really mean it.
+
 In another terminal, in that same root directory of your checked out uPortal codebase, initialize your uPortal.
 
 ```shell
 ant initportal
 ```
 
-After it downloads dependencies, builds, and deploys to Tomcat, in a third terminal or so start Tomcat.
+#### Start Tomcat
 
-Check it out: at `http://localhost:8080/uPortal` you've got a uPortal.
+After uPortal downloads dependencies, builds, and deploys to Tomcat, in a third terminal or so start Tomcat.
+
+Check it out: at `http://localhost:8080/uPortal`; you've got a uPortal.
 
 ### The client: `uPortal-home`
 
@@ -74,14 +119,32 @@ Configure for operation against a localhost uPortal: in source `angularjs-portal
 Build `uPortal-home` to a .war file with
 
 ```shell
+npm install
+```
+
+and then
+
+```shell
 mvn clean package
 ```
 
+Drop the resulting `angularjs-portal-home/target/web.war` in the `webapps` directory of Tomcat.
 
-Drop `angularjs-portal-home/target/web.war` in the Tomcat instance that runs uPortal and fire it up. Should just work.
+Start Tomcat again.
 
+### The basic demo
 
+First, log into uPortal, say as `student`.
 
+<http://localhost:8080/uPortal>
+
+Then, navigate to /web.
+
+<http://localhost:8080/web>
+
+Tada! It'll render the `uPortal-home` home page with some widgets on it.
+
+(Currently the widgets won't work, but you'll at least see your layout. Working on getting the MyUW-local uPortal additions uPortal-home depends upon working in upstream...)
 
 ## Portlet registry as app directory
 
@@ -96,205 +159,3 @@ Drop `angularjs-portal-home/target/web.war` in the Tomcat instance that runs uPo
 
 
 ## Redirecting from uPortal to uPortal-home
-
-AngularJS-portal [is presently][Apereo projects currently in incubation] in [Apereo Incubation][], aspiring to be an [Apereo][] project in the [uPortal][] ecosystem.
-
-[![Apereo Incubating badge](https://www.apereo.org/sites/default/files/Incubation%20Logos/incubating%20w-out%20logo%2015mar17.png)](https://www.apereo.org/content/projects-currently-incubation)
-
-+ Incubation requested: [2016-11-21][incubation@ proposal]
-+ Apereo Board approved for incubation: [2016-12-20][2016-12-20 Apereo Board meeting minutes]
-+ Entered incubation (initial conference call): 2017-03-13.
-+ Subsequent check-in calls: [2017-04-10][2017-04-10 incubation status call], [2017-05-25 at 10a NYC (scheduled)][2017-04-10 incubation status call].
-
-
-## Project status vis a vis exit criteria
-
-(See [exit criteria][]).
-
-### 4.1 Legal
-
-#### 4.1.1 Out-bound licensing
-
-AngularJS-portal and uw-frame include the Apache 2 license (approved for Apereo outbound) as LICENSE, but do not include the NOTICE file intended for inclusion with Apache2-licensed products.
-
-Next actions:
-
-+ Add `NOTICE` file. (Requires some auditing to get its contents correct).
-
-#### 4.1.2 License marking
-
-+ Partial but not verified-complete license marking.
-+ Poor acknowledgement of dependency or inclusion licensing.
-
-Next actions:
-
-+ Clean up marking source code with license
-+ Automate source code header checking
-+ Add NOTICE file. Audit inclusions and dependencies to get its contents right.
-+ Automate `NOTICE` file checking
-
-#### 4.1.3 Contributor License Agreements
-
-Most major contributors have ICLAs on file.
-
-Next actions:
-
-+ Follow up with past Contributors to secure CLAs
-+ Potentially implement cla-assistant.io with the wrinkle of it asking contributors to attest to their compliance with the external-to-CLA-assistant CLA agreement process. (Click-through assurance that demonstrated CLA agreement through more arduous process, not click-through agreement to CLA.)
-
-#### 4.1.4 Name trademark clarity
-
-Next actions:
-
-+ New software product names that better reflect nature and do not infringe on others' trademarks.
-+ Names should reflect uPortal commitment and represent how the product should
-be used.
-+ Proposed names:
-  + `uw-frame` → `uPortal-app-framework`
-    + The uPortal App Framework will house common functionality to be leveraged
-      by uPortal Apps.
-    + Institutions can provide a custom `uPortal-app-framework-config`
-    + Developers can create their own uPortal Apps drawing from common
-      configuration, style and functionality.
-  + `angularjs-portal` → `uPortal-home`
-    + uPortal Home will be a standard uPortal App that handles layout of the
-      framework widgets for a cohesive user experience.
-    + Developers provide `uPortal-home-config` for environment specific
-      configuration.
-
-### 4.2 Community
-
-#### a. Level of community involvement
-
-> What is the number of participants? What level of participation is there? What activities do participants undertake or what artifacts have they created?)
-
-
-Next actions:
-
-+ Open, public incubation status check-in conference call.
-+ Move GitHub repositories to a uPortal-project context
-
-#### b. Organization of community
-
-> What roles are in place? Who occupies those roles? How do those roles interact among one another and with the community?
-
-Next actions:
-
-+ Re-commit to using Gitter.im for chat.
-
-#### c. Operation of community
-
-> What activities/events/artifacts are created/managed by the project to foster participation and development? How are decisions made?
-
-Next actions:
-
-+ Formalize recognition of committership
-+ Pre-conference seminar and presentations at Open Apereo 2017.
-
-### 4.3 Governance
-
-No formal governance is documented.
-
-Next actions:
-
-+ Formalize recognition of committership
-+ Formalize relationship of committership with uPortal-steering
-
-### 4.4 Voting practices
-
-No formal voting practices are documented.
-
-Next actions:
-
-+ Formalize adoption of Apache rules
-
-### 4.5 Conflict resolution policy
-
-No formal conflict resolution policy is in place.
-
-Next actions:
-
-+ Adopt a conflict resolution policy (or inherit from uPortal)
-
-### 4.6 Release planning
-
-Releases come together organically. They're simply the changes from the accepted Pull Requests since the prior release, with Semantic Versioning observed.
-
-Next actions:
-
-+ Further document release planning, beyond just release execution.
-+ Further document adoption of Semantic Versioning.
-+ Start looking a few more milestones out
-+ Consider adopting a predictable release cadence
-
-### 4.7 Successful release during Incubation
-
-AngularJS-portal has had many releases.
-
-Let's say Incubation starts for this purpose after governance and licensing is squared and the repos are moved to a uPortal-project context. Successfully releasing after those changes are in place will demonstrate that the product can still release under the new arrangements.
-
-### 4.8 Alignment and synergy with other Apereo software products
-
-Depends on and leverages uPortal.
-
-Aspires to depend on and leverage more feasible microservices and hopes to evolve with uPortal itself in this direction.
-
-Next actions:
-
-+ Factor out app directory as a microservice
-+ Factor out user layout as a microservice
-
-### 4.9 Infrastructure
-
-#### a. Version control
-
-Using GitHub repositories.
-
-Next actions:
-
-+ Move GitHub repositories to a non-UW-Madison-specific organizational context.
-
-#### b. Issue tracking
-
-Intend to use GitHub issue tracking for product issue tracking.
-
-Next actions:
-
-+ Use GitHub issue tracking for product management in earnest. (This subset of) MyUW Scrum team user stories become references to public issue tracker issues.
-
-#### c. Communications channels
-
-Currently piggyback on uPortal email lists, only somewhat effectively.
-
-Next actions:
-
-+ Use Incubation check-in meetings, making these open meetings and drawing in would-be participants.
-+ Re-commit to using Gitter for project chat.
-+ Consider advocating for an Apereo Discourse instance and adopt Discourse forums in lieu of traditional email list.
-+ Consider how to better fit into existing uPortal email lists, or create new lists.
-
-#### d. Plans, directions, and objectives are readily identifiable
-
-Long range plans don't so much exist.
-
-Next actions:
-
-+ Articulate product plans, directions, objectives
-+ Navigate tension between product roadmapping and agile, organic discovery of product progress
-
-#### e. Website: current and with instructions for installation, configuration
-
-Both AngularJS-portal and uw-frame use GitHub Pages to generate documentation websites, including installation and configuration instructions. Documentation of the uPortal integration specifically is weak.
-
-Next actions:
-
-+ Improve documentation helping with, no seriously, how do I adopt this with a vanilla uPortal
-
-[Apereo]: https://www.apereo.org/
-[Apereo Incubation]: https://www.apereo.org/incubation
-[Apereo projects currently in incubation]: https://www.apereo.org/content/projects-currently-incubation
-[uPortal]: https://www.apereo.org/projects/uportal
-[incubation@ proposal]: https://groups.google.com/a/apereo.org/d/msg/incubation/tPBN3-YSSPM/Xk4yghH1AwAJ
-[2016-12-20 Apereo Board meeting minutes]: https://www.apereo.org/sites/default/files/meeting_minutes/2016/Apereo%20Board%20Minutes%20-%20Dec%202016%20-%20002.pdf
-[2017-04-10 incubation status call]: https://groups.google.com/a/apereo.org/d/msg/uportal-user/rN76LaT-VGQ/dikxNY9wAQAJ
-[exit criteria]: https://www.apereo.org/content/apereo-incubation-process#S4


### PR DESCRIPTION
Documenting how to adopt with real live bleeding-edge `master` uPortal-that-will-be-5.0.0.

Documents

+ Configuring `uPortal-home` for integration with localhost `uPortal`.
+ Getting Tomcat, uPortal, and uPortal-home running together

TODOs for:

+ Digging into the integration, including how the portlet registry functions as the app directory backend, the portlet definitions contain the metadata driving widgets, how `uPortal-home` delegates to `uPortal` for some Portlet rendering, and how `uPortal` can delegate to `uPortal-home` for the home page experience.

----

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
