### PR TITLE
Detect and support layout.json v4-3

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -110,26 +110,19 @@ define(['angular', 'jquery'], function(angular, $) {
               return result;
             });
             if (tabs && 0 < tabs.length) {
-
               var columns = tabs[0].content;
-
               var portlets = [];
-
               function collectPortletsFromColumns(column) {
                 portlets = portlets.concat(column.content);
               }
-
               if ($.isArray(columns)) {
                 columns.forEach( collectPortletsFromColumns );
               }
-
               result.layout = portlets;
-
             }
           } else if ($.isArray(data.layout)) { // layoutDoc
             result.layout = data.layout;
           }
-
           return result;
         };
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -84,8 +84,11 @@ define(['angular', 'jquery'], function(angular, $) {
           var result = {
             'layout': [],
           };
+          // layout will map to an array of objects each with an fname field.
+          // those fnames represent, in order,
+          // the home page content for the user
           if ($.isPlainObject(data.layout) &&
-              $.isArray(data.layout.folders)) { // layout.json
+              $.isArray(data.layout.folders)) { // layout.json v1
             var folders = data.layout.folders.filter(function(el) {
               var result = false;
               if (el && SERVICE_LOC.layoutTab === el.title) {
@@ -96,9 +99,37 @@ define(['angular', 'jquery'], function(angular, $) {
             if (folders && 0 < folders.length) {
               result.layout = folders[0].portlets;
             }
+          } else if ($.isArray(data.layout.navigation.tabs)) { // v4-3
+            // var tabs will be tabs matching the layoutTab name
+            // expected to be an array with length 1
+            var tabs = data.layout.navigation.tabs.filter(function(el) {
+              var result = false;
+              if (el && SERVICE_LOC.layoutTab === el.name) {
+                result = true;
+              }
+              return result;
+            });
+            if (tabs && 0 < tabs.length) {
+
+              var columns = tabs[0].content;
+
+              var portlets = [];
+
+              function collectPortletsFromColumns(column) {
+                portlets = portlets.concat(column.content);
+              }
+
+              if ($.isArray(columns)) {
+                columns.forEach( collectPortletsFromColumns );
+              }
+
+              result.layout = portlets;
+
+            }
           } else if ($.isArray(data.layout)) { // layoutDoc
             result.layout = data.layout;
           }
+
           return result;
         };
 

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -112,11 +112,10 @@ define(['angular', 'jquery'], function(angular, $) {
             if (tabs && 0 < tabs.length) {
               var columns = tabs[0].content;
               var portlets = [];
-              function collectPortletsFromColumns(column) {
-                portlets = portlets.concat(column.content);
-              }
               if ($.isArray(columns)) {
-                columns.forEach( collectPortletsFromColumns );
+                columns.forEach( function(column) {
+                  portlets = portlets.concat(column.content);
+                });
               }
               result.layout = portlets;
             }

--- a/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/services.js
@@ -99,7 +99,9 @@ define(['angular', 'jquery'], function(angular, $) {
             if (folders && 0 < folders.length) {
               result.layout = folders[0].portlets;
             }
-          } else if ($.isArray(data.layout.navigation.tabs)) { // v4-3
+          } else if ( data.layout.navigation &&
+              $.isPlainObject(data.layout.navigation) &&
+              $.isArray(data.layout.navigation.tabs)) { // v4-3
             // var tabs will be tabs matching the layoutTab name
             // expected to be an array with length 1
             var tabs = data.layout.navigation.tabs.filter(function(el) {


### PR DESCRIPTION
Bit of progress peeled out from #633 .

Detects when the configured layout web service is uPortal DLM layout.json v4-3.

This implementation is ugly. It could maybe benefit specifically from a refactor to use `map` effectively, and definitely more generally from attention from someone more comfortable with idiomatic JavaScript.

More importantly: could benefit from refactoring to make the canonical representation of layout simply a flat array of String fnames, since that's all modern `uPortal-home` needs. That'd be huge.

Finally, no attempt at unit test coverage for this change. :/

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
