### PR TITLE
Add Chrome to CI, test with macOS and Ubuntu Trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,25 @@
 language: java
-jdk:
-  - oraclejdk7
-  - openjdk7
-  - oraclejdk8
 sudo: false
+
+matrix:
+  fast_finish: true
+  include:
+    - os: linux
+      dist: trusty
+      jdk: oraclejdk8
+    - os: linux
+      dist: trusty
+      jdk: openjdk7
+    - os: osx
+      osx_image: xcode8.3
+
+addons:
+  chrome: stable
+
 before_install:
   - nvm install node
   - npm install
+
 script:
   - mvn package
   - mvn checkstyle:check
@@ -14,6 +27,7 @@ script:
   - npm run lint-js
   - npm run lint-md
   - npm run lint-less
+
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
Resolve CI failure in #638 by adding Chrome 59+ to CI environment.
Adds macOS testing.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
