### PR TITLE
reverting to layoutdoc

### DIFF
--- a/angularjs-portal-home/src/main/webapp/js/override.js
+++ b/angularjs-portal-home/src/main/webapp/js/override.js
@@ -21,7 +21,7 @@ define(['angular'], function(angular) {
             'newstuffInfo': '/web/staticFeeds/new-stuff.json',
             'context': '/portal/',
             'base': '/portal/api/',
-            'layout': 'layout.json',
+            'layout': 'api/layoutDoc?tab=UW Bucky Home',
             'layoutTab': 'UW Bucky Home',
             'marketplace': {
                 'base': 'marketplace/',


### PR DESCRIPTION
layout.json is full of weird quirks, one of which makes testing locally not work at all. Reverting to layoutDoc for local builds.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
