### PR TITLE
fix(ci): Update Travis CI script so greenkeeper works with the lockfile

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,9 @@ addons:
 before_install:
   - nvm install node
   - npm install
+  - npm install -g greenkeeper-lockfile@1
+
+before_script: greenkeeper-lockfile-update
 
 script:
   - mvn package
@@ -27,6 +30,8 @@ script:
   - npm run lint-js
   - npm run lint-md
   - npm run lint-less
+
+after_script: greenkeeper-lockfile-upload
 
 cache:
   directories:


### PR DESCRIPTION
1. Detect whether the current CI build is caused by Greenkeeper
2. Update the lockfile with the latest version of the updated dependency using the package manager’s built in mechanism
3. Push a commit with the updated lockfile back to the Greenkeeper branch

reference: https://github.com/greenkeeperio/greenkeeper-lockfile#how-does-it-work

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
