### PR TITLE
Make widgets removable in maintenance mode

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/layout/partials/remove-button.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/layout/partials/remove-button.html
@@ -1,6 +1,6 @@
 <md-button ng-controller="LayoutController as layoutCtrl" class="widget-action widget-remove md-icon-button"
            aria-label="remove {{ portlet.fname }} widget from your home screen"
            ng-click="layoutCtrl.removePortlet(portlet.fname)"
-           ng-hide="GuestMode || portlet.lifecycleState === 'MAINTENANCE'">
+           ng-hide="GuestMode">
   <md-icon>close</md-icon>
 </md-button>


### PR DESCRIPTION
[MUMMNG-3581](https://jira.doit.wisc.edu/jira/browse/MUMMNG-3581): "Let user rm widgets in maintenance lifecycle state"

**In this PR**:
- Stop hiding the remove widget button in maintenance mode

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
