### PR TITLE
fix(package): Lock requirejs-text to npm released version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "integrity": "sha1-w8p0NJOGSMPg2cHjKN1otiLChMo=",
       "dev": true,
       "requires": {
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.16",
         "negotiator": "0.6.1"
       }
     },
@@ -224,7 +224,7 @@
       "dev": true,
       "requires": {
         "browserslist": "2.2.2",
-        "caniuse-lite": "1.0.30000704",
+        "caniuse-lite": "1.0.30000706",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "6.0.8",
@@ -237,7 +237,7 @@
           "integrity": "sha512-MejxGMNIeIqzgaMKVYfFTWHinrwZOnWMXteN9VlHinTd13/0aDmXY9uyRqNsCTnVxqRmrjQFcXI7cy0q9K1IYg==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000704",
+            "caniuse-lite": "1.0.30000706",
             "electron-to-chromium": "1.3.16"
           }
         }
@@ -267,9 +267,9 @@
       }
     },
     "babel-runtime": {
-      "version": "6.23.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.23.0.tgz",
-      "integrity": "sha1-CpSJ8UTecO+zzkMArM2zKeL8VDs=",
+      "version": "6.25.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.25.0.tgz",
+      "integrity": "sha1-M7mOql1IK7AajRqmtDetKwGuxBw=",
       "dev": true,
       "requires": {
         "core-js": "2.4.1",
@@ -326,9 +326,9 @@
       }
     },
     "binary-extensions": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.8.0.tgz",
-      "integrity": "sha1-SOyNFt9Dd+rl+liEaCSAr02Vx3Q=",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-1.9.0.tgz",
+      "integrity": "sha1-ZlBsFs5vTWkopbPNajPKQelB43s=",
       "dev": true
     },
     "blob": {
@@ -414,7 +414,7 @@
       "integrity": "sha1-zFJq9KExK30uBWU+VtDIq3DA4FM=",
       "dev": true,
       "requires": {
-        "caniuse-lite": "1.0.30000704",
+        "caniuse-lite": "1.0.30000706",
         "electron-to-chromium": "1.3.16"
       }
     },
@@ -482,9 +482,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000704",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000704.tgz",
-      "integrity": "sha1-rbbqARNFFWY2gtuTq6spHUwClGs=",
+      "version": "1.0.30000706",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000706.tgz",
+      "integrity": "sha1-vFmrxBun1KNjTdqVvv3tYRTh8k4=",
       "dev": true
     },
     "caseless": {
@@ -570,9 +570,9 @@
       "dev": true
     },
     "circular-json": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
-      "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.3.tgz",
+      "integrity": "sha512-UZK3NBx2Mca+b5LsG7bY183pHWt5Y1xts4P3Pz7ENTwGVnJOUWbRb3ocjvX7hx9tq/yTAdclXm9sZ38gNuem4A==",
       "dev": true
     },
     "cli": {
@@ -798,9 +798,9 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.1.tgz",
-      "integrity": "sha512-17m9pl5cD9jhPUHqaxSA4fyoiAQJUG7V3CQDxCF7gWzGYeUY0YEnLQdQyOEKjEPVv0yGbdCfdfJMq6SphRiRjw==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-2.2.2.tgz",
+      "integrity": "sha512-GiNXLwAFPYHy25XmTPpafYvn3CLAkJ8FLsscq78MQd1Kh0OU6Yzhn4eV2MVF4G9WEQZoWEGltatdR+ntGPMl5A==",
       "dev": true,
       "requires": {
         "is-directory": "0.3.1",
@@ -1272,7 +1272,7 @@
         "globals": "9.18.0",
         "ignore": "3.3.3",
         "imurmurhash": "0.1.4",
-        "inquirer": "3.2.0",
+        "inquirer": "3.2.1",
         "is-resolvable": "1.0.0",
         "js-yaml": "3.9.0",
         "json-stable-stringify": "1.0.1",
@@ -1286,7 +1286,7 @@
         "pluralize": "4.0.0",
         "progress": "2.0.0",
         "require-uncached": "1.0.3",
-        "semver": "5.3.0",
+        "semver": "5.4.1",
         "strip-json-comments": "2.0.1",
         "table": "4.0.1",
         "text-table": "0.2.0"
@@ -1325,16 +1325,16 @@
       "integrity": "sha512-16yjDdjrivRQT7/Kov+3O6DMvfg8WYC1JKPAsvf/UNtdLBeMXVYATohAM4nOak1ynGP69mKUlOjw7nroUqY9Sg==",
       "dev": true,
       "requires": {
-        "babel-runtime": "6.23.0",
+        "babel-runtime": "6.25.0",
         "browserslist": "2.1.4",
         "caniuse-db": "1.0.30000671",
         "requireindex": "1.1.0"
       }
     },
     "eslint-plugin-jasmine": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.7.1.tgz",
-      "integrity": "sha1-v6EPVGU67JvelrjXquO92UdDEts=",
+      "version": "2.8.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jasmine/-/eslint-plugin-jasmine-2.8.0.tgz",
+      "integrity": "sha1-nGndMR8CIMXUwOyDhK+l5G/Vp8w=",
       "dev": true
     },
     "eslint-plugin-json": {
@@ -1642,7 +1642,7 @@
       "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
       "dev": true,
       "requires": {
-        "circular-json": "0.3.1",
+        "circular-json": "0.3.3",
         "del": "2.2.2",
         "graceful-fs": "4.1.11",
         "write": "0.2.1"
@@ -1689,7 +1689,7 @@
       "requires": {
         "asynckit": "0.4.0",
         "combined-stream": "1.0.5",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.16"
       }
     },
     "format": {
@@ -2109,9 +2109,9 @@
       "dev": true
     },
     "inquirer": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.0.tgz",
-      "integrity": "sha512-4CyUYMP7lOBkiUU1rR24WGrfRX6SucwbY2Mqb1PdApU24wnTIk4TsnkQwV72dDdIKZ2ycLP+fWCV+tA7wwgoew==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.2.1.tgz",
+      "integrity": "sha512-QgW3eiPN8gpj/K5vVpHADJJgrrF0ho/dZGylikGX7iqAdRgC9FVKYKWFLx6hZDBFcOLEoSqINYrVPeFAeG/PdA==",
       "dev": true,
       "requires": {
         "ansi-escapes": "2.0.0",
@@ -2137,9 +2137,9 @@
           "dev": true
         },
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -2151,7 +2151,7 @@
           "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.1.0",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.2.1"
           }
@@ -2222,7 +2222,7 @@
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
       "dev": true,
       "requires": {
-        "binary-extensions": "1.8.0"
+        "binary-extensions": "1.9.0"
       }
     },
     "is-buffer": {
@@ -3159,18 +3159,18 @@
       "dev": true
     },
     "mime-db": {
-      "version": "1.27.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.27.0.tgz",
-      "integrity": "sha1-gg9XIpa70g7CXtVeW13oaeVDbrE=",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.29.0.tgz",
+      "integrity": "sha1-SNJtI1WJZRcErFkWygYAGRQmaHg=",
       "dev": true
     },
     "mime-types": {
-      "version": "2.1.15",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.15.tgz",
-      "integrity": "sha1-pOv1BkCUVpI3uM9wBGd20J/JKu0=",
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.16.tgz",
+      "integrity": "sha1-K4WKUuXs1RbbiXrCvodIeDBpjiM=",
       "dev": true,
       "requires": {
-        "mime-db": "1.27.0"
+        "mime-db": "1.29.0"
       }
     },
     "mimic-fn": {
@@ -3250,7 +3250,7 @@
       "requires": {
         "hosted-git-info": "2.5.0",
         "is-builtin-module": "1.0.0",
-        "semver": "5.3.0",
+        "semver": "5.4.1",
         "validate-npm-package-license": "3.0.1"
       }
     },
@@ -3563,9 +3563,9 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -3577,7 +3577,7 @@
           "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.1.0",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.2.1"
           }
@@ -4125,10 +4125,10 @@
         "unist-util-visit": "1.1.3"
       }
     },
-    "remark-lint-no-blockquote-without-caret": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-caret/-/remark-lint-no-blockquote-without-caret-1.0.0.tgz",
-      "integrity": "sha1-gd0i3V8EVOupwqU3u6Jgh0ShrW8=",
+    "remark-lint-no-blockquote-without-marker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/remark-lint-no-blockquote-without-marker/-/remark-lint-no-blockquote-without-marker-2.0.0.tgz",
+      "integrity": "sha512-3AT+0ivP/OcUgKGE/42NXTUOaypBVOSsA5LZhTJLGJXmjS2tSHSc2WSTT7rrJ+A8BymXfWH5eSsS2jfbCZ7EJw==",
       "dev": true,
       "requires": {
         "unified-lint-rule": "1.0.1",
@@ -4339,9 +4339,9 @@
       }
     },
     "remark-preset-lint-recommended": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-2.0.0.tgz",
-      "integrity": "sha1-G/7VuthqdOQjm5a6KEWaJnoFg18=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/remark-preset-lint-recommended/-/remark-preset-lint-recommended-3.0.0.tgz",
+      "integrity": "sha512-QuCWkzY2FINVaX8+u48qdp6+RakynZdd03hm5C5ZI12mpTymhahU5FpI/G28z+Nv/IaAIEcRj3d5me1vP2ULTQ==",
       "dev": true,
       "requires": {
         "remark-lint": "6.0.0",
@@ -4350,7 +4350,7 @@
         "remark-lint-list-item-bullet-indent": "1.0.0",
         "remark-lint-list-item-indent": "1.0.0",
         "remark-lint-no-auto-link-without-protocol": "1.0.0",
-        "remark-lint-no-blockquote-without-caret": "1.0.0",
+        "remark-lint-no-blockquote-without-marker": "2.0.0",
         "remark-lint-no-duplicate-definitions": "1.0.0",
         "remark-lint-no-heading-content-indent": "1.0.0",
         "remark-lint-no-inline-padding": "1.0.0",
@@ -4462,7 +4462,7 @@
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
         "json-stringify-safe": "5.0.1",
-        "mime-types": "2.1.15",
+        "mime-types": "2.1.16",
         "oauth-sign": "0.8.2",
         "qs": "6.3.2",
         "stringstream": "0.0.5",
@@ -4517,6 +4517,12 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/requirejs/-/requirejs-2.3.4.tgz",
       "integrity": "sha512-qPD5gRrj6kGQ0ZySAJgqbArkaDqPMbQIT0zSZDkIv1mfA17w/tR2Faq5l2qqRf2CdQx6FWln9nUrgd2UDzb19A==",
+      "dev": true
+    },
+    "requirejs-text": {
+      "version": "2.0.15",
+      "resolved": "https://registry.npmjs.org/requirejs-text/-/requirejs-text-2.0.15.tgz",
+      "integrity": "sha1-ExOHM2E/xEV7fhJH6Mt1HfeqVCk=",
       "dev": true
     },
     "requires-port": {
@@ -4597,9 +4603,9 @@
       "dev": true
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8=",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+      "integrity": "sha512-WfG/X9+oATh81XtllIo/I8gOiY9EXRdv1cQdyykeXK17YcUW3EXUAi2To4pcH6nZtJPr7ZOpM5OMyWJZm+8Rsg==",
       "dev": true
     },
     "set-blocking": {
@@ -4990,7 +4996,7 @@
         "autoprefixer": "7.1.2",
         "balanced-match": "1.0.0",
         "chalk": "2.0.1",
-        "cosmiconfig": "2.2.1",
+        "cosmiconfig": "2.2.2",
         "debug": "2.6.8",
         "execall": "1.0.0",
         "file-entry-cache": "2.0.0",
@@ -5026,9 +5032,9 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -5040,7 +5046,7 @@
           "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.1.0",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.2.1"
           }
@@ -5157,10 +5163,6 @@
         }
       }
     },
-    "text": {
-      "version": "github:requirejs/text#d04de4ffd7bf5ba6cb80cdca2d40d4f6f52a1b1f",
-      "dev": true
-    },
     "text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
@@ -5266,7 +5268,7 @@
       "dev": true,
       "requires": {
         "media-typer": "0.3.0",
-        "mime-types": "2.1.15"
+        "mime-types": "2.1.16"
       }
     },
     "typedarray": {
@@ -5388,9 +5390,9 @@
       },
       "dependencies": {
         "ansi-styles": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.1.0.tgz",
-          "integrity": "sha1-CcIC1ckX7CMYjKpcnLkXnNlUd1A=",
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
           "dev": true,
           "requires": {
             "color-convert": "1.9.0"
@@ -5408,7 +5410,7 @@
           "integrity": "sha512-Mp+FXEI+FrwY/XYV45b2YD3E8i3HwnEAoFcM0qlZzq/RZ9RwWitt2Y/c7cqRAz70U7hfekqx6qNYthuKFO6K0g==",
           "dev": true,
           "requires": {
-            "ansi-styles": "3.1.0",
+            "ansi-styles": "3.2.0",
             "escape-string-regexp": "1.0.5",
             "supports-color": "4.2.1"
           }

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
     "remark-cli": "^4.0.0",
     "remark-lint": "^6.0.0",
     "remark-preset-lint-consistent": "^2.0.0",
-    "remark-preset-lint-recommended": "^2.0.0",
+    "remark-preset-lint-recommended": "^3.0.0",
     "remark-validate-links": "^6.0.0",
     "requirejs": "^2.1.18",
+    "requirejs-text": "^2.0.15",
     "stylelint": "^8.0.0",
-    "stylelint-config-standard": "^17.0.0",
-    "text": "github:requirejs/text"
+    "stylelint-config-standard": "^17.0.0"
   },
   "stylelint": {
     "extends": "stylelint-config-standard",


### PR DESCRIPTION
Also updates `remark-preset-lint-recommended` which updated after the `greenkeeper/initial` branch was created but before it was merged.
Causing greenkeeper to miss it.

:warning: **NOTICE** :warning: 
When testing and after merge please run `rm -rf node_modules & npm install` to ensure dependencies are at latest version.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
