### PR TITLE
fix broken GitHub Pages build by rm whitespace

### DIFF
--- a/docs/presentations.md
+++ b/docs/presentations.md
@@ -10,5 +10,4 @@ Some of these are about MyUW's implementation of uPortal-home.
 
 
 [2017-08-16 intro to integration in MyUW]: https://docs.google.com/presentation/d/1_6NcXMV7b4ugWN1a0fDgXY9ALOPgZgMZjXPJAPnKryk/edit?usp=sharing
-[2017-06-22 MyUW widgets in 5 minutes]:
-https://docs.google.com/presentation/d/1j3hRRk4Cl4UxtsbBmrR_8UzlKivoHE8Fb-ZTOJitUt4/edit?usp=sharing
+[2017-06-22 MyUW widgets in 5 minutes]: https://docs.google.com/presentation/d/1j3hRRk4Cl4UxtsbBmrR_8UzlKivoHE8Fb-ZTOJitUt4/edit?usp=sharing


### PR DESCRIPTION
Use single space, alas not newline, in defining reference link.

Most pedantic pull request ever.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
