### PR TITLE
ci: Configure Dependency CI

### DIFF
--- a/dependencyci.yml
+++ b/dependencyci.yml
@@ -1,0 +1,5 @@
+platform:
+  Maven:
+    tests:
+      unlicensed: skip
+      removed: skip


### PR DESCRIPTION
Configures DependencyCI to ignore flaky maven checks.
This allows DependencyCI status to be re-enabled and to provide meaningful results.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
