### PR TITLE
fix(license): Acknowledge Jianyi Liu contributions via Apache 2 clause 5

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -200,3 +200,7 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+
+----
+
+This product may include Contributions intentionally submitted for inclusion in the Work, under the terms and conditions of the Apache License Version 2.0.


### PR DESCRIPTION
Apereo does not currently have an ICLA on file for @jiayinjx , an [already-acknowledged Contributor](https://github.com/UW-Madison-DoIT/angularjs-portal/blob/master/docs/contributors.md). Where included her contributions were intentionally Contributed, so at the least they can be licensed directly via [Apache2 clause 5](https://www.apache.org/licenses/LICENSE-2.0.html#contributions) regardless of ICLA status.

That is, in effect, bundle @jiayinjx 's Contributions as an Apache2-licensed bundled dependency. [Apache documentation suggests we don't actually have to do anything at all](http://www.apache.org/dev/licensing-howto.html#alv2-dep) in `LICENSE` to do this.

A closer audit might reveal that none of Liu's Contributions remain in the current product. While valued, the original Contributions were modest in scope and the codebase has enjoyed significant implementation churn over time. If Apache2 clause 5 ever turns out to be not good enough, someone can dig into that "there is no currently relevant Contribution needing licensing" hypothesis further. Doing this much in `LICENSE` to acknowledge this situation should leave enough breadcrumbs to allow that future digging if justified and may allow the project to defer worrying further about this wrinkle, possibly forever.

There's [precedent for this approach in Apereo software](https://bitbucket.org/opencast-community/opencast/src/11d8f0a31796b29bb0a31417ff389ae7c850c56f/NOTICES?at=develop&fileviewer=file-view-default#NOTICES-17), though on my reading [including this complexity in `NOTICE` and thereby emphasizing it to upstream software products is not necessary or justified](http://www.apache.org/dev/licensing-howto.html#mod-notice).

cf. https://github.com/UW-Madison-DoIT/uw-frame/pull/515 , which does this same licensing tweak for `uPortal-application-framework`.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
