### PR TITLE
build(maven): configure maven release plugin commit prefix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,7 @@
         <version>2.5.1</version>
         <configuration>
           <autoVersionSubmodules>true</autoVersionSubmodules>
+          <scmCommentPrefix>chore(release): </scmCommentPrefix>
           <useReleaseProfile>false</useReleaseProfile>
           <releaseProfiles>release</releaseProfiles>
           <goals>deploy</goals>


### PR DESCRIPTION
this avoids a conflict between the conventional commit message linter and the maven release plugin.

resolves #682

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
