### PR TITLE
add Apache2 NOTICE

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
- 
+
                                  Apache License
                            Version 2.0, January 2004
                         http://www.apache.org/licenses/

--- a/LICENSE
+++ b/LICENSE
@@ -204,3 +204,20 @@
 ----
 
 This product may include Contributions intentionally submitted for inclusion in the Work, under the terms and conditions of the Apache License Version 2.0.
+
+----
+
+In the binary (with-dependencies) distribution only:
+
+This product bundles Apereo uPortal Application Framework,
+which is available under the Apache License 2.0.
+
+This product bundles University of Wisconsin rest-proxy,
+which is available under the Apache License 2.0.
+
+This product bundles Apache Commons Codec and Commons Lang,
+which are available under the Apache License 2.0.
+
+This product bundles The Spring Framework,
+which is available under the Apache License 2.0.
+

--- a/LICENSE
+++ b/LICENSE
@@ -221,3 +221,33 @@ which are available under the Apache License 2.0.
 This product bundles The Spring Framework,
 which is available under the Apache License 2.0.
 
+----
+
+In the binary (with-dependencies) distribution only:
+
+This product bundles SLF4J,
+which is available under the MIT license.
+
+Copyright (c) 2004-2017 QOS.ch
+All rights reserved.
+
+Permission is hereby granted, free  of charge, to any person obtaining
+a  copy  of this  software  and  associated  documentation files  (the
+"Software"), to  deal in  the Software without  restriction, including
+without limitation  the rights to  use, copy, modify,  merge, publish,
+distribute,  sublicense, and/or sell  copies of  the Software,  and to
+permit persons to whom the Software  is furnished to do so, subject to
+the following conditions:
+
+The  above  copyright  notice  and  this permission  notice  shall  be
+included in all copies or substantial portions of the Software.
+
+THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+----

--- a/LICENSE
+++ b/LICENSE
@@ -251,3 +251,8 @@ OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 ----
+
+In the binary (with-dependencies) distribution only:
+
+This product bundles logback-classic,
+which is available under the Eclipse Public License 1.0.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,6 @@
+Apereo uPortal-home aka AngularJS-portal
+
+Copyright 2014-2017 the Apereo Foundation.
+
+This product includes software developed at
+the Apereo Foundation (http://www.apereo.org/).

--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ Drop angularjs-portal-home/target/web.war in the Tomcat instance that runs uPort
 
 This product is licensed to you under the Apache License 2.0.
 
+The binary distribution of this product includes binaries licensed under the Eclipse Public License - v 1.0.
+
+
 [MyUW Overview slide deck]: http://go.wisc.edu/qwg5r1
 [Tomcat docs re Maven plugin]: http://tomcat.apache.org/maven-plugin-2.0/tomcat7-maven-plugin/plugin-info.html
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ With this you can run `mvn tomcat7:deploy` or `mvn tomcat7:redeploy` if you have
 
 Drop angularjs-portal-home/target/web.war in the Tomcat instance that runs uPortal and fire it up. Should just work.
 
+## License
+
+This product is licensed to you under the Apache License 2.0.
+
 [MyUW Overview slide deck]: http://go.wisc.edu/qwg5r1
 [Tomcat docs re Maven plugin]: http://tomcat.apache.org/maven-plugin-2.0/tomcat7-maven-plugin/plugin-info.html
 

--- a/angularjs-portal-home/pom.xml
+++ b/angularjs-portal-home/pom.xml
@@ -68,10 +68,6 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
     </dependency>
-    <dependency>
-      <groupId>jstl</groupId>
-      <artifactId>jstl</artifactId>
-    </dependency>
 
     <dependency>
       <groupId>javax.servlet</groupId>

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -17,7 +17,7 @@ Items are checked where the project believes it now fulfills the exit criteria.
 
 - [ ] 4.1 Legal
   - [x] 4.1.1 Out-bound licensing
-  - [ ] 4.1.2 License marking
+  - [x] 4.1.2 License marking
   - [ ] 4.1.3 Contributor License Agreements
   - [ ] 4.1.4 Name trademark clarity
 - [ ] 4.2 Community
@@ -54,13 +54,11 @@ Next actions:
 
 #### 4.1.2 License marking
 
-+ Partial but not verified-complete license marking.
+All source files are marked with the Apereo Apache2 license header.
 
 Next actions:
 
-+ Clean up marking source code with license. (Intended for Q3 2017).
-+ Automate source code header checking
-+ Stop using Maven, stop delivering a `.war`, and thereby stop having Java dependencies and further simplify licensing posture.
++ Re-implement license header checking without relying upon Maven. Sooner or later this project will stop using Maven.
 
 #### 4.1.3 Contributor License Agreements
 

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -18,7 +18,7 @@ Items are checked where the project believes it now fulfills the exit criteria.
 - [ ] 4.1 Legal
   - [x] 4.1.1 Out-bound licensing
   - [x] 4.1.2 License marking
-  - [ ] 4.1.3 Contributor License Agreements
+  - [x] 4.1.3 Contributor License Agreements
   - [ ] 4.1.4 Name trademark clarity
 - [ ] 4.2 Community
   - [ ] 4.2.a Level of community involvement
@@ -62,11 +62,14 @@ Next actions:
 
 #### 4.1.3 Contributor License Agreements
 
-Most major contributors have ICLAs on file.
+All major contributors have ICLAs on file.
+
+Did not secure ICLA from one minor past Contributor. Deferred further worry about this by accepting the Contributor's Contributions (if any are still relevant) via Apache2 clause 5, as noted in `LICENSE`.
+
+If this ever becomes a problem a careful audit might reveal that no Contributions from this Contributor are still relevant, through the natural turnover of modules and code within the project. In practice this is unlikely to ever be a problem.
 
 Next actions:
 
-+ Follow up with 1 remaining past Contributor to secure ICLA. (Intended for Q3 2017).
 + Potentially implement cla-assistant.io with the wrinkle of it asking contributors to attest to their compliance with the external-to-CLA-assistant CLA agreement process. (Click-through assurance that demonstrated CLA agreement through more arduous process, not click-through agreement to CLA.)
 
 #### 4.1.4 Name trademark clarity

--- a/docs/apereo-incubation.md
+++ b/docs/apereo-incubation.md
@@ -16,7 +16,7 @@ uPortal-home [is presently][Apereo projects currently in incubation] in [Apereo 
 Items are checked where the project believes it now fulfills the exit criteria.
 
 - [ ] 4.1 Legal
-  - [ ] 4.1.1 Out-bound licensing
+  - [x] 4.1.1 Out-bound licensing
   - [ ] 4.1.2 License marking
   - [ ] 4.1.3 Contributor License Agreements
   - [ ] 4.1.4 Name trademark clarity
@@ -46,23 +46,21 @@ Items are checked where the project believes it now fulfills the exit criteria.
 
 #### 4.1.1 Out-bound licensing
 
-uPortal-home and uPortal-app-framework include the Apache 2 license (approved for Apereo outbound) as LICENSE, but do not include the NOTICE file intended for inclusion with Apache2-licensed products.
+uPortal-home and uPortal-app-framework include the Apache 2 license (approved for Apereo outbound) as LICENSE and accompanying NOTICE file acknowledging dependencies under Apache 2 and other permitted licenses.
 
 Next actions:
 
-+ Add `NOTICE` file. (Requires some auditing to get its contents correct). (Intended for Q3 2017).
++ Stop using Maven, stop delivering a `.war`, and thereby stop having Java dependencies and further simplify licensing posture.
 
 #### 4.1.2 License marking
 
 + Partial but not verified-complete license marking.
-+ Poor acknowledgement of dependency or inclusion licensing.
 
 Next actions:
 
 + Clean up marking source code with license. (Intended for Q3 2017).
 + Automate source code header checking
-+ Add NOTICE file. Audit inclusions and dependencies to get its contents right. (Intended for Q3 2017).
-+ Automate `NOTICE` file checking
++ Stop using Maven, stop delivering a `.war`, and thereby stop having Java dependencies and further simplify licensing posture.
 
 #### 4.1.3 Contributor License Agreements
 

--- a/pom.xml
+++ b/pom.xml
@@ -107,16 +107,6 @@
         <version>3.3.2</version>
       </dependency>
       <dependency>
-        <groupId>javax.servlet.jsp.jstl</groupId>
-        <artifactId>jstl-api</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
-        <groupId>jstl</groupId>
-        <artifactId>jstl</artifactId>
-        <version>1.2</version>
-      </dependency>
-      <dependency>
         <groupId>javax.servlet</groupId>
         <artifactId>servlet-api</artifactId>
         <version>2.5</version>


### PR DESCRIPTION
+ Add the [Apache2 boilerplate `NOTICE` file][]
+ Acknowledge included-in-war dependencies in `LICENSE`
+ Remove un-needed `JSTL` dependency so we don't have to untangle under what license we'd be redistributing it.
+ Update incubation status documentation to reflect this and other licensing progress since last incubation status update.

Attempts to apply [Apache guidance about composing NOTICE file and acknowledging dependencies in LICENSE file][Apache licensing howto].

As it turns out, the `NOTICE` file can be simple boilerplate, because the included dependencies don't rise to [ack-in-NOTICE technicality][Apache re modifications to NOTICE].

However, we do have an ECL 1.0 dependency: the Java logging implementation. [Apache's got a manageable amount of angst about this and emphasizes that we really need to emphasize to adopters that we've got this.][Apache Category B] So acknowledged in README.

Makes the pragmatic tradeoff of documenting war-file-distribution-only dependencies in the LICENSE file in the source and so in the source distribution. I don't think this is [what Apache Software Foundation would have us do][Apache re binary distributions]. However. Having the acknowledgements in source control is convenient. What's the alternative? Some shadow copy of LICENSE somewhere else? Incorporated into binary releases in some fancier release process we don't yet have? That seems like a not-currently-feasible amount of complexity, whereas this approach seems presently achievable as demonstrated by achieving it.

Someday this project will adjust to no longer build with Maven, no longer produce a `.war`, and so no longer have any Java dependencies, and so have fewer dependencies to acknowledge with less complexity. In the meantime, this should bring the project into licensing practice compliance.

The JavaScript dependencies don't seem to need acknowledgement because we don't redistribute them. Even the NPM distribution, it includes metadata referencing dependencies, but not the dependencies themselves. How civilized.

I am not a lawyer. This is not legal advice.

[Apache2 boilerplate `NOTICE` file]: http://www.apache.org/dev/licensing-howto.html#simple
[Apache licensing howto]: http://www.apache.org/dev/licensing-howto.html
[Apache re modifications to NOTICE]: http://www.apache.org/dev/licensing-howto.html#mod-notice
[Apache re bundled vs non-bundled dependencies]: http://www.apache.org/dev/licensing-howto.html#bundled-vs-non-bundled
[Apache re binary distributions]: http://www.apache.org/dev/licensing-howto.html#binary
[Apache Category B]: http://www.apache.org/legal/resolved.html#category-b