### PR TITLE
fix(license): remove scss auto-license in /docs

### DIFF
--- a/docs/assets/css/style.scss
+++ b/docs/assets/css/style.scss
@@ -1,4 +1,7 @@
-/**
+---
+---
+
+/*
  * Licensed to Apereo under one or more contributor license
  * agreements. See the NOTICE file distributed with this work
  * for additional information regarding copyright ownership.
@@ -16,8 +19,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
----
----
+
 
 @import "{{ site.theme }}";
 

--- a/pom.xml
+++ b/pom.xml
@@ -258,6 +258,7 @@
             <exclude>**/node_modules/**</exclude>
             <exclude>**/docs/_site/**</exclude>
             <exclude>**/docs/bower_components/**</exclude>
+            <exclude>**/docs/**/*.scss</exclude>
             <exclude>**/*.log*</exclude>
             <exclude>**/*.json</exclude>
             <exclude>**/*.lock</exclude>
@@ -265,7 +266,6 @@
           </excludes>
           <mapping>
             <less>JAVADOC_STYLE</less>
-            <scss>JAVADOC_STYLE</scss>
             <Gemfile>SCRIPT_STYLE</Gemfile>
             <example>SCRIPT_STYLE</example>
             <uP>XML_STYLE</uP>


### PR DESCRIPTION
Our github pages were looking funky:

![image](https://user-images.githubusercontent.com/5521429/30496009-c073a300-9a13-11e7-9198-5941b6bd6989.png)

 
vs, what it should look like
![image](https://user-images.githubusercontent.com/5521429/30496020-c74e2718-9a13-11e7-9a1e-ae26a05b21d1.png)



SCSS files used in jekyll have to start with a front matter comment and can't start with a header license.  This excludes scss files in the docs directory from having the license header added automatically and fixes the existing comment to move beneath the front matter comment.

Similar to https://github.com/UW-Madison-DoIT/uw-frame/pull/527



{Substantive content goes here. Summarize the changeset and *why* the changeset.}

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
