### PR TITLE
Remove "categories" from app dir UI

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -91,17 +91,6 @@
                             <li ng-repeat="related in portlet.relatedPortlets"><a href="apps/details/{{ ::related.fname }}">{{ ::related.title }}</a></li>
                         </ul>
                     </div>
-                    <div class="desc-item">
-                      <h3 tabindex="0" class="md-title">Categories</h3>
-                      <md-chips ng-if="portlet.categories.length > 0"
-                                ng-model="portlet.categories"
-                                readonly="true"
-                                md-removable="false">
-                        <md-chip-template>
-                          <a ng-href="apps" ng-click="specifyCategory($chip)" aria-label="see more apps in the {{ $chip }} category">{{ $chip }}</a>
-                        </md-chip-template>
-                      </md-chips>
-                    </div>
                     <div class="desc-item" ng-if="portlet.marketplaceScreenshots.length != 0">
                         <h3 tabindex="0" class="md-title">Screenshots</h3>
                         <ul class="enlarge">

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-entry.html
@@ -93,18 +93,6 @@
 		</md-button>
 	</div>
 
-	<!-- CATEGORIES ROW -->
-	<div layout="row" class="category-list" ng-if="portlet.categories.length > 0">
-    <md-chips ng-if="portlet.categories.length > 0"
-              ng-model="portlet.categories"
-              readonly="true"
-              md-removable="false">
-      <md-chip-template>
-        <a ng-click="selectFilter('category', $chip)" aria-label="see more apps in the {{ $chip }} category">{{ $chip }}</a>
-      </md-chip-template>
-    </md-chips>
-	</div>
-
   <!-- Action buttons for mobile -->
   <div hide-gt-xs layout="row">
     <div ng-show="GuestMode" layout="row" layout-align="end center" class="mp-mobile-buttons">

--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace.html
@@ -60,12 +60,6 @@
             <span aria-label="Sort by alphabetical order">A-Z</span>
             <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
           </li>
-          <li class="mp-tab md-ink-ripple" ng-click="selectFilter('category','')"
-              ng-class="{true: 'active'}[selectedFilter === 'category']"
-              ng-style="selectedFilter === 'category' && {color: primaryColorRgb}">
-            <span aria-label="Filter by categories">Categories</span>
-            <div class="mp-tabs-slide" ng-style="{background: primaryColorRgb}"></div>
-          </li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Categories are confusing. Stop bothering users with them.

**Removes navigation tab within app directory.**
![removes-the-categories-tab](https://user-images.githubusercontent.com/952283/30504690-da96828a-9a35-11e7-927f-c880924f1f84.png)

**Removes categories chips from app directory entries as rendered en masse.**
![removes-this-noise](https://user-images.githubusercontent.com/952283/30504733-127c7a92-9a36-11e7-8416-c52aea824682.png)

**Removes categories section from app directory details page.**
![removes-this-div](https://user-images.githubusercontent.com/952283/30504770-3d2f7b2c-9a36-11e7-9205-9ebd2eab9f2b.png)


Categories are unfit for purpose because they are tied up with permissions. Gotta have permission on the category to see the category qua category, but permission on the category inherits as permission on the portlets within the category. In practice this is confusing, yields to misconfigurations, accidental permission grants, a mess.

Maybe someday no-permission-complications "tags" could be re-introduced as a feature. Maybe we'll never need it.

But for near term it has become clear that we want to only grant permissions at the individual `portlet-definition` level and stop trying to get permissions on categories right.

This changeset just removes categories superficially from the UI. However, this will unblock removing categories whenever we can on the back-end with no weird UI consequences at that time.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
