### PR TITLE
fix(app_dir): Only show Related Apps div if there are related apps

### DIFF
--- a/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
+++ b/angularjs-portal-home/src/main/webapp/my-app/marketplace/partials/marketplace-details.html
@@ -85,7 +85,8 @@
                         <br>
                         <rating-button ng-hide="GuestMode" portlet='portlet' button-text="Rate" button-classes="md-raised"></rating-button>
                     </div>
-                    <div class="desc-item">
+                    <div class="desc-item"
+                      ng-if="portlet.relatedPortlets.length > 0">
                         <h3 tabindex="0" class="md-title">Related Apps</h3>
                         <ul>
                             <li ng-repeat="related in portlet.relatedPortlets"><a href="apps/details/{{ ::related.fname }}">{{ ::related.title }}</a></li>


### PR DESCRIPTION
Suppress the Related Apps section on the app directory entry details page in the case where there are no related apps.

![empty-related-apps](https://user-images.githubusercontent.com/952283/30615735-6f6bfee0-9d55-11e7-9c47-492d8dae5d12.png)


(MyUW recently locally hacked the back end so that there are never any related apps. Greatly improving performance. Turns out computing related apps is *really* expensive and since it's only ever shown on these infrequently-viewed details pages, removing the feature has good current tradeoffs).

----

Contributor License Agreement adherence:

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
