### PR TITLE
ci: remove greenkeeper lockfile upload step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ script:
   - npm run lint-md
   - npm run lint-less
 
-after_script: greenkeeper-lockfile-upload
-
 cache:
   directories:
     - $HOME/.m2


### PR DESCRIPTION
The GreenKeeper lockfile upload step, requires having a secure token injected into the public continuous integration environment.
With the current GitHub oauth API, this would mean the generating user would need to create a token, that gives write access to ALL of their public GitHub repositories.
This might be feasible with a build user scoped to a single repository, or if GitHub improves their API.
However at the moment this seems like a security risk.

Short term the best solution appears to be disabling the upload step, so CI doesn't waste time attempting a push that will not work.
Leaving humans to manually `rm -rf package-lock.json node_modules && npm install && git commit -a -m "chore(package): update package lock file" && git push upstream`

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
