### PR TITLE
build(maven): set Java 8 as target version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ matrix:
       env: BROWSERS=ChromeHeadless,FirefoxHeadless
     - os: linux
       dist: trusty
-      jdk: openjdk7
+      jdk: openjdk8
       env: BROWSERS=ChromeHeadless,FirefoxHeadless
     - os: osx
       osx_image: xcode8.3

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -18,9 +18,7 @@
 #
 
 environment:
-  matrix:
-    - JAVA_HOME: C:\Program Files\Java\jdk1.7.0
-    - JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+  JAVA_HOME: C:\Program Files\Java\jdk1.8.0
   nodejs_version: 8
 os: Visual Studio 2017 # Windows Server 2016
 install:

--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  
+
   <parent>
     <groupId>org.jasig.parent</groupId>
     <artifactId>jasig-parent</artifactId>
@@ -34,7 +34,7 @@
   <name>uPortal-home Parent Project</name>
   <description>An alternative homepage for uPortal</description>
   <url>https://github.com/uPortal-Project/uportal-home</url>
-  
+
   <developers>
     <developer>
         <email>uportal-dev@apereo.org</email>
@@ -60,8 +60,8 @@
 
   <properties>
     <spring.version>4.1.5.RELEASE</spring.version>
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <maven.license.plugin.ver>3.0</maven.license.plugin.ver>
   </properties>
 
@@ -259,7 +259,7 @@
             <uP>XML_STYLE</uP>
           </mapping>
         </configuration>
-      </plugin> 
+      </plugin>
     </plugins>
   </build>
 </project>


### PR DESCRIPTION
Java 7 has been [End Of Lifed (EOL)](http://www.oracle.com/technetwork/java/eol-135779.html).
Java 8 is going to be [EOL](http://www.oracle.com/technetwork/java/eol-135779.html).
This updates compiler target to Java 8.
Soon we should look into a Java 9 upgrade.

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
