### PR TITLE
fix(package): require npm version 5.6.0 or higher

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1148,6 +1148,16 @@
       "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
       "dev": true
     },
+    "decamelize-keys": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/decamelize-keys/-/decamelize-keys-1.1.0.tgz",
+      "integrity": "sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=",
+      "dev": true,
+      "requires": {
+        "decamelize": "1.2.0",
+        "map-obj": "1.0.1"
+      }
+    },
     "dedent": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
@@ -3180,6 +3190,23 @@
       "integrity": "sha1-L0SUrIkZ43Z8XLtpHp9GMyQoXUM=",
       "dev": true
     },
+    "gonzales-pe": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.3.tgz",
+      "integrity": "sha512-Kjhohco0esHQnOiqqdJeNz/5fyPkOMD/d6XVjwTAoPGUFh0mCollPUTUTa2OZy4dYNAqlPIQdTiNzJTWdd9Htw==",
+      "dev": true,
+      "requires": {
+        "minimist": "1.1.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
+          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
+          "dev": true
+        }
+      }
+    },
     "graceful-fs": {
       "version": "4.1.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
@@ -3997,6 +4024,12 @@
         }
       }
     },
+    "json-parse-better-errors": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.1.tgz",
+      "integrity": "sha512-xyQpxeWWMKyJps9CuGJYeng6ssI5bpqS9ltQpdVQ90t4ql6NdnxFKh95JcRt2cun/DjMVNrdjniLPuMA69xmCw==",
+      "dev": true
+    },
     "json-schema": {
       "version": "0.2.3",
       "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -4255,9 +4288,9 @@
       }
     },
     "known-css-properties": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.4.1.tgz",
-      "integrity": "sha512-n+ThoCKhyMFKkMfksdLMP5ndp+VzwDRzQdH6JlmZ2GTpUenYB2EeEKjOue2SErAAG/MmBSUISpwvawDhydWQdQ==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/known-css-properties/-/known-css-properties-0.5.0.tgz",
+      "integrity": "sha512-LOS0CoS8zcZnB1EjLw4LLqDXw8nvt3AGH5dXLQP3D9O1nLLA+9GC5GnPl5mmF+JiQAtSX4VyZC7KvEtcA4kUtA==",
       "dev": true
     },
     "lazy-cache": {
@@ -4851,6 +4884,16 @@
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
+    "minimist-options": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/minimist-options/-/minimist-options-3.0.2.tgz",
+      "integrity": "sha512-FyBrT/d0d4+uiZRbqznPXqw3IpZZG3gl3wKWiX784FycUKVwBt0uLBFkQrtE4tZOrgo78nZp2jnKz3L65T5LdQ==",
+      "dev": true,
+      "requires": {
+        "arrify": "1.0.1",
+        "is-plain-obj": "1.1.0"
+      }
+    },
     "mkdirp": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
@@ -5333,9 +5376,9 @@
       }
     },
     "postcss-html": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.11.0.tgz",
-      "integrity": "sha512-ruCTbRZWY+qOV4FNYNm6E0ucIbCkkuYHIqQ4W3iSVIc1aUVBTKMG0iUo2nPUAG2lhFaTmfBaZ17017osZ18ddA==",
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/postcss-html/-/postcss-html-0.12.0.tgz",
+      "integrity": "sha512-KxKUpj7AY7nlCbLcTOYxdfJnGE7QFAfU2n95ADj1Q90RM/pOLdz8k3n4avOyRFs7MDQHcRzJQWM1dehCwJxisQ==",
       "dev": true,
       "requires": {
         "htmlparser2": "3.9.2",
@@ -5463,6 +5506,16 @@
         "postcss": "6.0.14"
       }
     },
+    "postcss-sass": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-sass/-/postcss-sass-0.2.0.tgz",
+      "integrity": "sha512-cUmYzkP747fPCQE6d+CH2l1L4VSyIlAzZsok3HPjb5Gzsq3jE+VjpAdGlPsnQ310WKWI42sw+ar0UNN59/f3hg==",
+      "dev": true,
+      "requires": {
+        "gonzales-pe": "4.2.3",
+        "postcss": "6.0.14"
+      }
+    },
     "postcss-scss": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/postcss-scss/-/postcss-scss-1.0.2.tgz",
@@ -5579,6 +5632,12 @@
       "version": "6.5.1",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
       "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "dev": true
+    },
+    "quick-lru": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-1.1.0.tgz",
+      "integrity": "sha1-Q2CxfGETatOAeDl/8RQW4Ybc+7g=",
       "dev": true
     },
     "randomatic": {
@@ -6911,9 +6970,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.3.1.tgz",
-      "integrity": "sha512-v5K6tv+Ky3SoJfNqGOvgzRDLqZV133CZ7Wtu3y5aAGjQHVi+6dixFLgI82VrJZJdC4HwZplafJcRP+4r7EUt5g==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-8.4.0.tgz",
+      "integrity": "sha512-56hPH5mTFnk8LzlEuTWq0epa34fHuS54UFYQidBOFt563RJBNi1nz1F2HK2MoT1X1waq47milvRsRahFCCJs/Q==",
       "dev": true,
       "requires": {
         "autoprefixer": "7.2.3",
@@ -6929,21 +6988,22 @@
         "html-tags": "2.0.0",
         "ignore": "3.3.7",
         "imurmurhash": "0.1.4",
-        "known-css-properties": "0.4.1",
+        "known-css-properties": "0.5.0",
         "lodash": "4.17.4",
         "log-symbols": "2.1.0",
         "mathml-tag-names": "2.0.1",
-        "meow": "3.7.0",
+        "meow": "4.0.0",
         "micromatch": "2.3.11",
         "normalize-selector": "0.2.0",
         "pify": "3.0.0",
         "postcss": "6.0.14",
-        "postcss-html": "0.11.0",
+        "postcss-html": "0.12.0",
         "postcss-less": "1.1.3",
         "postcss-media-query-parser": "0.2.3",
         "postcss-reporter": "5.0.0",
         "postcss-resolve-nested-selector": "0.1.1",
         "postcss-safe-parser": "3.0.1",
+        "postcss-sass": "0.2.0",
         "postcss-scss": "1.0.2",
         "postcss-selector-parser": "3.1.1",
         "postcss-value-parser": "3.3.0",
@@ -6962,6 +7022,23 @@
           "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
           "dev": true
         },
+        "camelcase": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-4.1.0.tgz",
+          "integrity": "sha1-1UVjW+HjPFQmScaRc+Xeas+uNN0=",
+          "dev": true
+        },
+        "camelcase-keys": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-4.2.0.tgz",
+          "integrity": "sha1-oqpfsa9oh1glnDLBQUJteJI7m3c=",
+          "dev": true,
+          "requires": {
+            "camelcase": "4.1.0",
+            "map-obj": "2.0.0",
+            "quick-lru": "1.1.0"
+          }
+        },
         "globby": {
           "version": "7.1.1",
           "resolved": "https://registry.npmjs.org/globby/-/globby-7.1.1.tgz",
@@ -6976,17 +7053,114 @@
             "slash": "1.0.0"
           }
         },
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
           "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
           "dev": true
         },
+        "load-json-file": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
+          "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "4.1.11",
+            "parse-json": "4.0.0",
+            "pify": "3.0.0",
+            "strip-bom": "3.0.0"
+          }
+        },
+        "map-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-2.0.0.tgz",
+          "integrity": "sha1-plzSkIepJZi4eRJXpSPgISIqwfk=",
+          "dev": true
+        },
+        "meow": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/meow/-/meow-4.0.0.tgz",
+          "integrity": "sha512-Me/kel335m6vMKmEmA6c87Z6DUFW3JqkINRnxkbC+A/PUm0D5Fl2dEBQrPKnqCL9Te/CIa1MUt/0InMJhuC/sw==",
+          "dev": true,
+          "requires": {
+            "camelcase-keys": "4.2.0",
+            "decamelize-keys": "1.1.0",
+            "loud-rejection": "1.6.0",
+            "minimist": "1.2.0",
+            "minimist-options": "3.0.2",
+            "normalize-package-data": "2.4.0",
+            "read-pkg-up": "3.0.0",
+            "redent": "2.0.0",
+            "trim-newlines": "2.0.0"
+          }
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
+          "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1",
+            "json-parse-better-errors": "1.0.1"
+          }
+        },
+        "path-type": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+          "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+          "dev": true,
+          "requires": {
+            "pify": "3.0.0"
+          }
+        },
         "pify": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
           "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
           "dev": true
+        },
+        "read-pkg": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
+          "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "4.0.0",
+            "normalize-package-data": "2.4.0",
+            "path-type": "3.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-3.0.0.tgz",
+          "integrity": "sha1-PtSWaF26D4/hGNBpHcUfSh/5bwc=",
+          "dev": true,
+          "requires": {
+            "find-up": "2.1.0",
+            "read-pkg": "3.0.0"
+          }
+        },
+        "redent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/redent/-/redent-2.0.0.tgz",
+          "integrity": "sha1-wbIAe0LVfrE4kHmzyDM2OdXhzKo=",
+          "dev": true,
+          "requires": {
+            "indent-string": "3.2.0",
+            "strip-indent": "2.0.0"
+          }
         },
         "string-width": {
           "version": "2.1.1",
@@ -7006,6 +7180,24 @@
           "requires": {
             "ansi-regex": "3.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        },
+        "trim-newlines": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-2.0.0.tgz",
+          "integrity": "sha1-tAPQuRvlDDMd/EuC7s6yLD3hbSA=",
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -81,6 +81,9 @@
     "stylelint": "^8.0.0",
     "stylelint-config-standard": "^18.0.0"
   },
+  "engines": {
+    "npm": ">=5.6.0"
+  },
   "stylelint": {
     "extends": "stylelint-config-standard",
     "rules": {


### PR DESCRIPTION
npm <5.6.0 has issues with optional dependencies that are only installed for  particular operating system.
Causing dependencies such as `fsevents` to be added to the *package-lock.json* file on MacOS, but then be removed when a Linux system installs the project.
`npm >=5.6.0` includes a fix that normalizes handling of optional
dependencies to allow for any OS to produce that same *package-lock.json* file from a given *package.json*

reference: https://github.com/npm/npm/blob/latest/CHANGELOG.md#v560-2017-11-27

to update to the latest version of npm

```
npm install --global npm@latest
```

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
