### PR TITLE
ci(travis): allow Chrome to run in container environment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ matrix:
     - os: linux
       dist: trusty
       jdk: oraclejdk8
-      env: BROWSERS=ChromeHeadless,FirefoxHeadless
+      env: BROWSERS=ChromeHeadlessNoSandbox,FirefoxHeadless
     - os: linux
       dist: trusty
       jdk: openjdk8
-      env: BROWSERS=ChromeHeadless,FirefoxHeadless
+      env: BROWSERS=ChromeHeadlessNoSandbox,FirefoxHeadless
     - os: osx
       osx_image: xcode8.3
       env: BROWSERS=ChromeHeadless,Safari

--- a/web/src/main/webapp/karma.conf.js
+++ b/web/src/main/webapp/karma.conf.js
@@ -36,13 +36,13 @@ module.exports = function(config) {
         frameworks: ['jasmine', 'requirejs'],
 
         customLaunchers: {
-            FirefoxHeadless: {
-                base: 'Firefox',
-                flags: ['-headless'],
-            },
+          ChromeHeadlessNoSandbox: {
+            base: 'ChromeHeadless',
+            flags: ['--no-sandbox'],
+          },
         },
 
-        browsers: ['ChromeHeadless'], // or 'Chrome'
+        browsers: ['ChromeHeadless', 'FirefoxHeadless'], // or 'Chrome'
 
         plugins: [
             'karma-htmlfile-reporter',


### PR DESCRIPTION
Use no sandbox mode on travis container environment to prevent error:
```
The SUID sandbox helper binary was found, but is not configured correctly. Rather than run without sandboxing I'm aborting now. You need to make sure that /opt/google/chrome/chrome-sandbox is owned by root and has mode 4755
```

reference: https://docs.travis-ci.com/user/chrome

----

Contributor License Agreement adherence:

<!-- Place an x in the checkbox for YES. -->

- [x] This Contribution is under the terms of Individual [Contributor License Agreements][] (and also Corporate Contributor License Agreements to the extent applicable) appearing in the [Apereo CLA roster][].

[Apereo CLA roster]: http://licensing.apereo.org/completed-clas
[Contributor License Agreements]: https://www.apereo.org/licensing/agreements
