### PR TITLE
Make modes and switching modes more discoverable

### DIFF
--- a/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
+++ b/web/src/main/webapp/my-app/layout/list/partials/home-list-view.html
@@ -27,6 +27,15 @@
     <div ng-if="layout.length == 0" layout="row" layout-align="center center">
       <loading-gif data-object="layout" data-empty="layoutEmpty"></loading-gif>
     </div>
+    <div>
+      You're viewing MyUW in compact mode.
+      Compact mode is one of
+        <a
+          href="https://kb.wisconsin.edu/51574"
+          target="_blank" rel="noopener noreferrer"
+        >two MyUW modes</a>.
+      For a richer experience, try <a href="/expanded">expanded mode</a>.
+    </div>
     <!-- List View -->
     <ul dnd-list="layout"
         dnd-drop="moveWithDrag(item, index)"

--- a/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
+++ b/web/src/main/webapp/my-app/layout/widget/partials/home-widget-view.html
@@ -25,6 +25,15 @@
     <home-controls></home-controls>
     <!-- Loading -->
     <loading-gif data-object="layout" data-empty="layoutEmpty"></loading-gif>
+    <div>
+      You're viewing MyUW in expanded mode.
+      Expanded mode is one of
+      <a
+        href="https://kb.wisconsin.edu/51574"
+        target="_blank" rel="noopener noreferrer"
+      >two MyUW modes</a>.
+      For a simpler experience, try <a href="/compact">compact mode</a>.
+    </div>
     <!-- Widget View -->
     <ul dnd-list="layout"
         dnd-drop="moveWithDrag(item, index)"


### PR DESCRIPTION
Add text at the top of both compact and expanded home page modes, acknowledging that there are modes and inviting the user to switch between them.